### PR TITLE
Add healthchecking route for ECS autoscaling

### DIFF
--- a/app/controllers/monitoring_controller.rb
+++ b/app/controllers/monitoring_controller.rb
@@ -1,0 +1,5 @@
+class MonitoringController < ApplicationController
+  def healthcheck
+    render body: "Healthy"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  get '/healthcheck', to: 'monitoring#healthcheck'
 end

--- a/spec/monitoring/healthcheck_spec.rb
+++ b/spec/monitoring/healthcheck_spec.rb
@@ -1,0 +1,8 @@
+require_relative '../rails_helper'
+
+describe MonitoringController, type: :controller do
+  it "Should return a 200 to a healthchecker request" do
+    get :healthcheck
+    assert_response :success
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path('../../config/environment', __FILE__)
+
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require 'rspec/rails'
+
+ActiveRecord::Migration.maintain_test_schema!
+
+RSpec.configure do |config|
+  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+
+  config.use_transactional_fixtures = true
+
+  config.infer_spec_type_from_file_location!
+
+  config.filter_rails_from_backtrace!
+end


### PR DESCRIPTION
AWS target groups use the healthchecking route to determine whether the app is ready for accepting incoming requests or not.  Once the app is ready, it will be registered with the load balancer to start receiving requests.

At the moment this healthcheck is very simple, as our app doesn't have any complex behaviour.