### PR TITLE
Remove the call to setBuildStatus

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,6 @@ pipeline {
 
 def deploy(deploy_environment) {
   if(deployCancelled()) {
-    setBuildStatus("Build successful", "SUCCESS");
     return
   }
 


### PR DESCRIPTION
This was hangover when copying from the other Jenkinsfiles,
but isn't actually needed as Jenkins multibranch pipeline will
do this automatically for us.