### PR TITLE
Add the secret key base to the staging environment

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -28,5 +28,8 @@ test:
 # Or, use `bin/rails secrets:setup` to configure encrypted secrets
 # and move the `production:` environment over there.
 
+staging:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
Currently getting this error from the staging environment:

```
DEPRECATION WARNING: You didn't set `secret_key_base`.
Read the upgrade documentation to learn more about this new config option.
```