### PR TITLE
Add basic feature spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,10 @@ gem 'rails', '~> 5.1.5'
 gem 'sass-rails', '~> 5.0'
 gem 'sqlite3'
 
+group :test do
+  gem 'capybara'
+end
+
 group :development, :test do
   gem 'byebug', '~> 10'
   gem 'govuk-lint', '~> 3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,10 +38,19 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     ast (2.4.0)
     builder (3.2.3)
     byebug (10.0.2)
+    capybara (3.5.1)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      xpath (~> 3.1)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
     diff-lcs (1.3)
@@ -75,6 +84,7 @@ GEM
     parser (2.5.1.2)
       ast (~> 2.4.0)
     powerpack (0.1.2)
+    public_suffix (3.0.2)
     puma (3.12.0)
     rack (2.0.5)
     rack-test (0.8.3)
@@ -166,12 +176,15 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    xpath (3.1.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   byebug (~> 10)
+  capybara
   govuk-lint (~> 3)
   listen (~> 3)
   puma (~> 3.12)

--- a/spec/features/basic_feature_spec.rb
+++ b/spec/features/basic_feature_spec.rb
@@ -1,0 +1,6 @@
+describe 'homepage', type: :feature do
+  it 'says govwifi' do
+    visit '/'
+    expect(page).to have_content('GovWifi')
+  end
+end


### PR DESCRIPTION
#17 is pretty heavy, so we're trying to slice stuff off.

This PR adds the most basic of feature specs, powered by Capybara to drive page interaction.