### PR TITLE
Verify email is in gov domain

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,41 +1,8 @@
 class Users::RegistrationsController < Devise::RegistrationsController
-  alias :rebuild_devise_user :build_resource
-
-  def create
-    if email_matches_whitelist
-      do_default_devise_behaviour
-    else
-      rebuild_devise_user
-      add_error_to_devise_user
-      render 'new'
-    end
-  end
-
 protected
 
   # The path used after sign up for inactive accounts.
   def after_inactive_sign_up_path_for(_resource)
     users_confirmations_pending_path
-  end
-
-  def do_default_devise_behaviour
-    Devise::RegistrationsController
-      .instance_method(:create).bind(self).call
-  end
-
-  def email_matches_whitelist
-    email = params.dig(:user, :email)
-    return false if email.blank?
-
-    domain = email.split('@').last
-    domain.starts_with?('gov.uk') || domain.include?('.gov.uk')
-  end
-
-  def add_error_to_devise_user
-    resource.errors.add(
-      :email,
-      :invalid,
-      message: 'only government/whitelisted emails can sign up'
-    )
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Users::RegistrationsController < Devise::RegistrationsController
 protected
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,10 +1,41 @@
-# frozen_string_literal: true
-
 class Users::RegistrationsController < Devise::RegistrationsController
+  alias :rebuild_devise_user :build_resource
+
+  def create
+    if email_matches_whitelist
+      do_default_devise_behaviour
+    else
+      rebuild_devise_user
+      add_error_to_devise_user
+      render 'new'
+    end
+  end
+
 protected
 
   # The path used after sign up for inactive accounts.
   def after_inactive_sign_up_path_for(_resource)
     users_confirmations_pending_path
+  end
+
+  def do_default_devise_behaviour
+    Devise::RegistrationsController
+      .instance_method(:create).bind(self).call
+  end
+
+  def email_matches_whitelist
+    email = params.dig(:user, :email)
+    return false if email.blank?
+
+    domain = email.split('@').last
+    domain.starts_with?('gov.uk') || domain.include?('.gov.uk')
+  end
+
+  def add_error_to_devise_user
+    resource.errors.add(
+      :email,
+      :invalid,
+      message: 'only government/whitelisted emails can sign up'
+    )
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
 
   after_create :reset_confirmation_token
 
+  validate :email_on_whitelist
+
   def attempt_set_password(params)
     unless params[:password] == params[:password_confirmation]
       errors.add(:base, "Passwords must match") && return
@@ -20,6 +22,12 @@ class User < ApplicationRecord
   # Must be defined to allow Devise to create users without passwords
   def password_required?
     false
+  end
+
+  def email_on_whitelist
+    checker = CheckIfWhitelistedEmail.new
+    whitelisted = checker.execute(self.email)[:success]
+    errors.add(:email, 'must be from a government domain') unless whitelisted
   end
 
 private

--- a/app/views/users/confirmations/pending.html.erb
+++ b/app/views/users/confirmations/pending.html.erb
@@ -6,7 +6,7 @@
       validate your e-mail address.
     </p>
     <p class="govuk-body">
-      Simply follow the isntructions in the email.
+      Simply follow the instructions in the email.
     </p>
   </div>
 </div>

--- a/lib/use_cases/administrator/check_if_whitelisted_email.rb
+++ b/lib/use_cases/administrator/check_if_whitelisted_email.rb
@@ -1,0 +1,11 @@
+class CheckIfWhitelistedEmail
+  def execute(email)
+    return { success: false } if email.blank?
+
+    domain = email.split('@').last
+    valid_domain = domain.starts_with?('gov.uk')
+    valid_subdomain = domain.include?('.gov.uk')
+
+    { success: valid_domain || valid_subdomain }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    email "test@test.com"
+    email "test@gov.uk"
     password "123456"
   end
 end

--- a/spec/features/logging_in_after_signing_up_spec.rb
+++ b/spec/features/logging_in_after_signing_up_spec.rb
@@ -5,21 +5,22 @@ describe 'logging in after signing up' do
   let(:correct_password) { 'f1uffy-bu44ies' }
 
   before do
-    sign_up_for_account
+    sign_up_for_account(email: 'tom@gov.uk')
     create_password_for_account(
-      password: correct_password, confirmed_password: correct_password
+      password: correct_password,
+      confirmed_password: correct_password
     )
 
     click_on 'Logout'
 
-    fill_in 'Email', with: 'tom@tom.com'
-    fill_in 'Password', with: entered_password
+    fill_in 'Email', with: 'tom@gov.uk'
+    fill_in 'Password', with: password
 
     click_on 'Continue'
   end
 
   context 'with correct password' do
-    let(:entered_password) { correct_password }
+    let(:password) { correct_password }
 
     it 'shows me congratulations' do
       expect(page).to have_content 'Congratulations!'
@@ -27,7 +28,7 @@ describe 'logging in after signing up' do
   end
 
   context 'with incorrect password' do
-    let(:entered_password) { 'coarse' }
+    let(:password) { 'coarse' }
 
     it_behaves_like 'not signed in'
   end

--- a/spec/features/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/sign_up_as_an_organisation_spec.rb
@@ -9,7 +9,7 @@ describe 'Sign up as an organisation' do
       create_password_for_account
     end
 
-    context 'with a .gov.uk email' do
+    context 'with a gov.uk email' do
       let(:email) { 'someone@gov.uk' }
 
       it 'congratulates me' do
@@ -17,7 +17,7 @@ describe 'Sign up as an organisation' do
       end
     end
 
-    context 'with a other.gov.uk email' do
+    context 'with a email from a subdomain of gov.uk' do
       let(:email) { 'someone@other.gov.uk' }
 
       it 'congratulates me' do
@@ -27,26 +27,6 @@ describe 'Sign up as an organisation' do
 
     context 'with a notgov.uk email' do
       let(:email) { 'someone@notgov.uk' }
-
-      it 'tells me my email is not valid' do
-        expect(page).to have_content(
-          'only government/whitelisted emails can sign up'
-        )
-      end
-    end
-
-    context 'with a other.notgov.uk email' do
-      let(:email) { 'someone@other.notgov.uk' }
-
-      it 'tells me my email is not valid' do
-        expect(page).to have_content(
-          'only government/whitelisted emails can sign up'
-        )
-      end
-    end
-
-    context 'with an email with gov in the local-part' do
-      let(:email) { 'fake.gov.uk@unrelateddomain.com' }
 
       it 'tells me my email is not valid' do
         expect(page).to have_content(

--- a/spec/features/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/sign_up_as_an_organisation_spec.rb
@@ -30,7 +30,7 @@ describe 'Sign up as an organisation' do
 
       it 'tells me my email is not valid' do
         expect(page).to have_content(
-          'only government/whitelisted emails can sign up'
+          'Email must be from a government domain'
         )
       end
     end
@@ -40,7 +40,7 @@ describe 'Sign up as an organisation' do
 
       it 'tells me my email is not valid' do
         expect(page).to have_content(
-          'only government/whitelisted emails can sign up'
+          "Email can't be blank"
         )
       end
     end

--- a/spec/features/support/sign_up_helpers.rb
+++ b/spec/features/support/sign_up_helpers.rb
@@ -1,10 +1,11 @@
-def sign_up_for_account
+def sign_up_for_account(email: 'default@gov.uk')
   visit new_user_registration_path
-  fill_in 'user_email', with: 'tom@tom.com'
+  fill_in 'user_email', with: email
   click_on 'Sign up'
 end
 
 def create_password_for_account(password: 'supersecret', confirmed_password: 'supersecret')
+  return unless confirmation_email_received?
   visit confirmation_email_link
   fill_in 'New password', with: password
   fill_in 'Confirm new password', with: confirmed_password
@@ -15,4 +16,8 @@ def confirmation_email_link
   confirmation_email = ActionMailer::Base.deliveries.first
   parsed_email = Nokogiri::HTML(confirmation_email.body.to_s)
   parsed_email.css('a').first['href']
+end
+
+def confirmation_email_received?
+  ActionMailer::Base.deliveries.any?
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,4 +23,34 @@ RSpec.describe User do
       end
     end
   end
+
+  describe '#save' do
+    subject { build(:user) }
+
+    context 'with the factory-built model' do
+      it { is_expected.to be_valid }
+    end
+
+    context 'with a gov.uk email' do
+      subject { build(:user, email: 'name@gov.uk') }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'with a non-gov.uk email' do
+      subject { build(:user, email: 'name@arbitrary-domain.com') }
+
+      it { is_expected.to_not be_valid }
+
+      context 'when saved' do
+        before { subject.save }
+
+        it 'explains the email must be from the correct domain' do
+          expect(subject.errors.full_messages).to eq(
+            ['Email must be from a government domain']
+          )
+        end
+      end
+    end
+  end
 end

--- a/spec/use_cases/administrator/check_if_whitelisted_email_spec.rb
+++ b/spec/use_cases/administrator/check_if_whitelisted_email_spec.rb
@@ -3,31 +3,31 @@ describe CheckIfWhitelistedEmail do
 
   it 'rejects an empty email address' do
     result = subject.execute('')
-    expect(result).to eq({ success: false })
+    expect(result).to eq(success: false)
   end
 
   it 'approves an address from the gov.uk domain' do
     result = subject.execute('someone@gov.uk')
-    expect(result).to eq({ success: true })
+    expect(result).to eq(success: true)
   end
 
   it 'approves an address from a gov.uk subdomain' do
     result = subject.execute('someone@other.gov.uk')
-    expect(result).to eq({ success: true })
+    expect(result).to eq(success: true)
   end
 
   it 'rejects an address not from a gov.uk domain' do
     result = subject.execute('someone@notgov.uk')
-    expect(result).to eq({ success: false })
+    expect(result).to eq(success: false)
   end
 
   it 'rejects an address not from a gov.uk subdomain' do
     result = subject.execute('someone@other.notgov.uk')
-    expect(result).to eq({ success: false })
+    expect(result).to eq(success: false)
   end
 
   it 'rejects an address with gov in the local-part' do
     result = subject.execute('fake.gov.uk@unrelateddomain.com')
-    expect(result).to eq({ success: false })
+    expect(result).to eq(success: false)
   end
 end

--- a/spec/use_cases/administrator/check_if_whitelisted_email_spec.rb
+++ b/spec/use_cases/administrator/check_if_whitelisted_email_spec.rb
@@ -1,0 +1,33 @@
+describe CheckIfWhitelistedEmail do
+  subject { described_class.new }
+
+  it 'rejects an empty email address' do
+    result = subject.execute('')
+    expect(result).to eq({ success: false })
+  end
+
+  it 'approves an address from the gov.uk domain' do
+    result = subject.execute('someone@gov.uk')
+    expect(result).to eq({ success: true })
+  end
+
+  it 'approves an address from a gov.uk subdomain' do
+    result = subject.execute('someone@other.gov.uk')
+    expect(result).to eq({ success: true })
+  end
+
+  it 'rejects an address not from a gov.uk domain' do
+    result = subject.execute('someone@notgov.uk')
+    expect(result).to eq({ success: false })
+  end
+
+  it 'rejects an address not from a gov.uk subdomain' do
+    result = subject.execute('someone@other.notgov.uk')
+    expect(result).to eq({ success: false })
+  end
+
+  it 'rejects an address with gov in the local-part' do
+    result = subject.execute('fake.gov.uk@unrelateddomain.com')
+    expect(result).to eq({ success: false })
+  end
+end

--- a/spec/use_cases/administrator/check_if_whitelisted_email_spec.rb
+++ b/spec/use_cases/administrator/check_if_whitelisted_email_spec.rb
@@ -6,6 +6,11 @@ describe CheckIfWhitelistedEmail do
     expect(result).to eq(success: false)
   end
 
+  it 'rejects a nil address' do
+    result = subject.execute(nil)
+    expect(result).to eq(success: false)
+  end
+
   it 'approves an address from the gov.uk domain' do
     result = subject.execute('someone@gov.uk')
     expect(result).to eq(success: true)


### PR DESCRIPTION
This is branched off #17, so won't be merged until after it.

This PR implements basic whitelisting on sign up emails - .gov.uk and subdomains are allowed, everyone else isn't.

This was the quickest implementation, there are patterns that beat the very simple string test - not sure how much time it's worth spending on a bulletproof regex (should we lift the one we have from PHP? seems horrible.)