### PR TITLE
Replace Alpine for Debian in our Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM ruby:2.5-alpine
+FROM ruby:2.5
 ARG BUNDLE_INSTALL_CMD
 ENV RACK_ENV=development
 
 WORKDIR /usr/src/app
 
 COPY Gemfile Gemfile.lock .ruby-version ./
-RUN apk --update --upgrade add build-base sqlite-dev tzdata nodejs && \
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+  apt-get update && apt-get install -y apt-transport-https && \
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+  apt-get update && apt-get install -y yarn && \
   bundle check || ${BUNDLE_INSTALL_CMD} && \
-  npm install -g yarn && \
-  apk del build-base && \
-  find / -type f -iname \*.apk-new -delete && \
-  rm -rf /var/cache/apk/*
+  rm -rf /var/lib/apt/lists/*
 
 COPY . .
 


### PR DESCRIPTION
The Alpine docker image has a smaller stack size which results in
SystemStackError from being raised in situations where you have a
deep call stack.

This error was being raised in this repository when running
Capybara tests involving rack-test and SASS compilation.

Switching to Debian should fix this as it doesn't have this stack
size problem.

See more information on this issue here:
https://github.com/docker-library/ruby/issues/196

When switching to Debian, we're pulling in the yarn binary via
their apt repository as default Debian doesn't provide an npm
from which we could use `npm install -g yarn`.

An additional problem is that the default Debian install doesn't
support apt repositories on HTTPS urls.  We first have to install
the `apt-transport-https` before being able to use the yarn repo.