### PR TITLE
Mount the repository directory in development

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,0 +1,6 @@
+version: '3.4'
+
+services:
+  app:
+    volumes:
+    - ".:/usr/src/app"


### PR DESCRIPTION
Mounting the repository as a volume allows any changes to
manifest themselves inside of docker immediately, which
creates faster feedback loops when running `make serve`.

Now that we are mounting the app as a volume we may have
a stray pid file left over from a previous `make serve`
execution.  `rm -f` before performing `make serve` will
prevent this from being an issue.

We are unable to do this on Jenkins because the Jenkins
image is already running inside of Docker.  To the
Jenkins node the parent directory is already a virtual
filesystem path.  Therefore if this was done on Jenkins,
the docker deamon would fail to find the parent path
(as it is passed in as a virtual path which the daemon
wouldn't be able to see).

If/when Jenkins moves to not being run inside of docker
we can remove the distinction between local development
and Jenkins builds.