### PR TITLE
Add post build cleanup step to the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,12 @@ pipeline {
       }
     }
   }
+
+  post {
+    always {
+      sh 'make stop'
+    }
+  }
 }
 
 


### PR DESCRIPTION
This should remove any running docker images which helps keep Jenkins
in a healthy state.  This will run even if the build fails for whatever
reason.