### PR TITLE
Allow Jenkins to run migrations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,6 +71,9 @@ def deploy(deploy_environment) {
       sh('git fetch')
       sh('git checkout stable')
 
+      sh '''
+          aws ecs run-task --cluster ${deploy_environment}-api-cluster --task-definition admin-task-${deploy_environment} --count 1 --overrides "{ \\"containerOverrides\\": [{ \\"name\\": \\"admin\\", \\"command\\": [\\"bundle\\", \\"exec\\", \\"rake\\", \\"db:migrate\\"] }] }"
+      '''
       docker.withRegistry(env.AWS_ECS_API_REGISTRY) {
         sh("eval \$(aws ecr get-login --no-include-email)")
         def appImage = docker.build(


### PR DESCRIPTION
We call a scheduled task which will do the migrations for us in Jenkins.
Since we are running the migrations before making the task live, we will
need to keep the migrations non destructive.

We decided that this is ok, since we do this anyway for a blue green
setup.

We will look into making the new task live as soon as we have pushed a
new image into the ECR repository later on.