### PR TITLE
Use regex from env-var to validate emails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV DB_USER root
 ENV DB_PASS root
 ENV DB_HOST db
 ENV DEVISE_SECRET_KEY fake-secret-key
+ENV AUTHORISED_EMAIL_DOMAINS_REGEX '.*'
 
 WORKDIR /usr/src/app
 

--- a/lib/use_cases/administrator/check_if_whitelisted_email.rb
+++ b/lib/use_cases/administrator/check_if_whitelisted_email.rb
@@ -1,11 +1,8 @@
 class CheckIfWhitelistedEmail
   def execute(email)
-    return { success: false } if email.blank?
+    pattern = ENV.fetch('AUTHORISED_EMAIL_DOMAINS_REGEX')
+    checker = Regexp.new(pattern, Regexp::IGNORECASE)
 
-    domain = email.split('@').last
-    valid_domain = domain.starts_with?('gov.uk')
-    valid_subdomain = domain.include?('.gov.uk')
-
-    { success: valid_domain || valid_subdomain }
+    { success: email.to_s.match?(checker) }
   end
 end

--- a/spec/features/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/sign_up_as_an_organisation_spec.rb
@@ -24,8 +24,8 @@ describe 'Sign up as an organisation' do
       end
     end
 
-    context 'with a notgov.uk email' do
-      let(:email) { 'someone@notgov.uk' }
+    context 'with a non-gov email' do
+      let(:email) { 'someone@google.com' }
 
       it 'tells me my email is not valid' do
         expect(page).to have_content(

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe User do
+describe User do
   context 'associations' do
     it { should have_many(:ips) }
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,4 +10,6 @@ RSpec.configure do |config|
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
   config.before { ActionMailer::Base.deliveries.clear }
+
+  ENV['AUTHORISED_EMAIL_DOMAINS_REGEX'] = '.*gov\.uk'
 end

--- a/spec/use_cases/administrator/check_if_whitelisted_email_spec.rb
+++ b/spec/use_cases/administrator/check_if_whitelisted_email_spec.rb
@@ -1,38 +1,45 @@
 describe CheckIfWhitelistedEmail do
   subject { described_class.new }
 
-  it 'rejects an empty email address' do
-    result = subject.execute('')
-    expect(result).to eq(success: false)
+  context 'with a regex in the environment variable' do
+    before do
+      ENV['AUTHORISED_EMAIL_DOMAINS_REGEX'] = 'someone@a+\.uk'
+    end
+
+    it 'rejects an empty email address' do
+      result = subject.execute('')
+      expect(result).to eq(success: false)
+    end
+
+    it 'rejects a nil address' do
+      result = subject.execute(nil)
+      expect(result).to eq(success: false)
+    end
+
+    it 'accepts an address matching the regex' do
+      result = subject.execute('someone@aaa.uk')
+      expect(result).to eq(success: true)
+    end
+
+    it 'rejects an address not matching the regex' do
+      result = subject.execute('someone@bbb.uk')
+      expect(result).to eq(success: false)
+    end
+
+    it 'accepts an address matching the regex regardless of case' do
+      result = subject.execute('SOMEONE@AAA.UK')
+      expect(result).to eq(success: true)
+    end
   end
 
-  it 'rejects a nil address' do
-    result = subject.execute(nil)
-    expect(result).to eq(success: false)
-  end
+  context 'with no regex in the environment variable' do
+    before do
+      ENV.delete('AUTHORISED_EMAIL_DOMAINS_REGEX')
+    end
 
-  it 'approves an address from the gov.uk domain' do
-    result = subject.execute('someone@gov.uk')
-    expect(result).to eq(success: true)
-  end
-
-  it 'approves an address from a gov.uk subdomain' do
-    result = subject.execute('someone@other.gov.uk')
-    expect(result).to eq(success: true)
-  end
-
-  it 'rejects an address not from a gov.uk domain' do
-    result = subject.execute('someone@notgov.uk')
-    expect(result).to eq(success: false)
-  end
-
-  it 'rejects an address not from a gov.uk subdomain' do
-    result = subject.execute('someone@other.notgov.uk')
-    expect(result).to eq(success: false)
-  end
-
-  it 'rejects an address with gov in the local-part' do
-    result = subject.execute('fake.gov.uk@unrelateddomain.com')
-    expect(result).to eq(success: false)
+    it 'blows up' do
+      expect { subject.execute('any string') }
+        .to raise_error(IndexError)
+    end
   end
 end


### PR DESCRIPTION
We've got a regex that the `build` repo pushes as an env-var to all environments - this uses that regex to validate emails (as the other systems do).

Long-term I'd like to see the approved domains expressed in a way that is less... buried. 

Since there's a lot of cases covered, it's a little tricky to reproduce with just a few rows in a table somewhere, but we could at least do approved domains _from now on_ a little more nicely to start.