### PR TITLE
Add a configuration file for the staging environment

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,20 @@
+Rails.application.configure do
+  config.cache_classes = true
+  config.eager_load = true
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+  config.read_encrypted_secrets = true
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.assets.compile = false
+  config.log_level = :debug
+  config.log_tags = [:request_id]
+  config.i18n.fallbacks = true
+  config.active_support.deprecation = :notify
+  config.log_formatter = ::Logger::Formatter.new
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
+  config.active_record.dump_schema_after_migration = false
+end


### PR DESCRIPTION
We need logging enabled for staging.
Copy over the rest of the production configuration to staging so that we
have the same environment to test in