### PR TITLE
Use email templates per environment

### DIFF
--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -5,9 +5,14 @@ class AuthenticationMailer < ::Devise::Mailer
 
   def confirmation_instructions(record, token, _opts = {})
     confirmation_link = confirmation_url(record, confirmation_token: token)
+    template_id = GOV_NOTIFY_CONFIG['confirmation_email']['template_id']
 
     SendConfirmationEmail.new(
       notifications_gateway: EmailGateway.new
-    ).execute(email: record.email, confirmation_url: confirmation_link)
+    ).execute(
+      email: record.email,
+      confirmation_url: confirmation_link,
+      template_id: template_id
+    )
   end
 end

--- a/config/gov_notify.yml
+++ b/config/gov_notify.yml
@@ -1,0 +1,15 @@
+staging:
+  confirmation_email:
+    template_id: '1af17502-9797-4e61-904e-999f6cf259a5'
+
+development:
+  confirmation_email:
+    template_id: '1af17502-9797-4e61-904e-999f6cf259a5'
+
+test:
+  confirmation_email:
+    template_id: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+
+production:
+  confirmation_email:
+    template_id: '5f42e490-ce5e-44e7-9104-805136961116'

--- a/config/initializers/gov_notify.rb
+++ b/config/initializers/gov_notify.rb
@@ -1,0 +1,3 @@
+GOV_NOTIFY_CONFIG = YAML.load_file(
+  Rails.root.join('config/gov_notify.yml')
+)[Rails.env]

--- a/lib/use_cases/administrator/send_confirmation_email.rb
+++ b/lib/use_cases/administrator/send_confirmation_email.rb
@@ -1,16 +1,15 @@
 class SendConfirmationEmail
-  TEMPLATE_ID = '5f42e490-ce5e-44e7-9104-805136961116'.freeze
   REFERENCE = 'confirmation_email'.freeze
 
   def initialize(notifications_gateway:)
     @notifications_gateway = notifications_gateway
   end
 
-  def execute(email:, confirmation_url:)
+  def execute(email:, confirmation_url:, template_id:)
     opts = {
       email: email,
       locals: { confirmation_url: confirmation_url },
-      template_id: TEMPLATE_ID,
+      template_id: template_id,
       reference: REFERENCE,
       email_reply_to_id: nil
     }

--- a/spec/support/confirmation_use_case_spy.rb
+++ b/spec/support/confirmation_use_case_spy.rb
@@ -19,7 +19,7 @@ class ConfirmationUseCaseSpy
   end
 
   # rubocop:disable Lint/UnusedMethodArgument
-  def execute(email:, confirmation_url:)
+  def execute(email:, confirmation_url:, template_id:)
     @@last_confirmation_url = confirmation_url
     @@confirmations_count += 1
 

--- a/spec/use_cases/send_confirmation_email_spec.rb
+++ b/spec/use_cases/send_confirmation_email_spec.rb
@@ -3,7 +3,7 @@ describe SendConfirmationEmail do
     def send(opts)
       raise unless opts[:email] == 'test@example.com'
       raise unless opts[:locals][:confirmation_url] == 'https://example.com'
-      raise unless opts[:template_id] == '5f42e490-ce5e-44e7-9104-805136961116'
+      raise unless opts[:template_id] == 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
       raise unless opts[:reference] == 'confirmation_email'
 
       {}
@@ -12,6 +12,7 @@ describe SendConfirmationEmail do
 
   let(:email) { 'test@example.com' }
   let(:confirmation_url) { 'https://example.com' }
+  let(:template_id) { GOV_NOTIFY_CONFIG['confirmation_email']['template_id'] }
 
   subject do
     described_class.new(
@@ -20,7 +21,13 @@ describe SendConfirmationEmail do
   end
 
   it 'calls notifications gateway with valid data' do
-    expect { subject.execute(email: email, confirmation_url: confirmation_url) }
-      .to_not raise_error
+    expect {
+      subject
+        .execute(
+          email: email,
+          confirmation_url: confirmation_url,
+          template_id: template_id
+        )
+    }.to_not raise_error
   end
 end


### PR DESCRIPTION
GovNotify has two versions: production (live) and staging. They both
define different sets of templates and API keys. We must use a correct
app for specific env.