### PR TITLE
Allow to run single tests

### DIFF
--- a/spec/support/notifications_service.rb
+++ b/spec/support/notifications_service.rb
@@ -1,3 +1,5 @@
+require 'notifications/client'
+
 shared_examples 'notifications service' do
   let(:notifications_payload) { double }
 


### PR DESCRIPTION
Without this require the spec_helper would not load a spec
that actually has it and thus fail. Requiring it explicitly here
fixes the issue.