### PR TITLE
Add ability to send emails with notifications of new users

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -51,7 +51,17 @@ protected
 
   def confirm_user
     @confirmable.confirm
+    notify_support_of_new_user(@confirmable)
     set_flash_message :notice, :confirmed
     sign_in_and_redirect(resource_name, @confirmable)
+  end
+
+  def notify_support_of_new_user(user)
+    NotifySupportOfNewUser.new(
+      notifications_gateway: EmailGateway.new
+    ).execute(
+      new_user_email: user.email,
+      template_id: GOV_NOTIFY_CONFIG['notify_support_of_new_user']['template_id']
+    )
   end
 end

--- a/config/gov_notify.yml
+++ b/config/gov_notify.yml
@@ -1,15 +1,27 @@
 staging:
+  support_email: 'govwifi-support@digital.cabinet-office.gov.uk'
   confirmation_email:
     template_id: '1af17502-9797-4e61-904e-999f6cf259a5'
+  notify_support_of_new_user:
+    template_id: '79af3335-ab32-4c4b-9075-b9d7138c7e61'
 
 development:
+  support_email: 'dev@localhost'
   confirmation_email:
     template_id: '1af17502-9797-4e61-904e-999f6cf259a5'
+  notify_support_of_new_user:
+    template_id: '79af3335-ab32-4c4b-9075-b9d7138c7e61'
 
 test:
+  support_email: 'test@localhost'
   confirmation_email:
     template_id: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+  notify_support_of_new_user:
+    template_id: 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy'
 
 production:
+  support_email: 'govwifi-support@digital.cabinet-office.gov.uk'
   confirmation_email:
     template_id: '5f42e490-ce5e-44e7-9104-805136961116'
+  notify_support_of_new_user:
+    template_id: 'fd79c7b9-48d7-4086-b62a-0fc6f56daa4b'

--- a/lib/use_cases/administrator/notify_support_of_new_user.rb
+++ b/lib/use_cases/administrator/notify_support_of_new_user.rb
@@ -1,0 +1,23 @@
+class NotifySupportOfNewUser
+  REFERENCE = 'notify_support_of_new_user'.freeze
+
+  def initialize(notifications_gateway:)
+    @notifications_gateway = notifications_gateway
+  end
+
+  def execute(new_user_email:, template_id:)
+    opts = {
+      email: GOV_NOTIFY_CONFIG['support_email'],
+      locals: { user_email: new_user_email },
+      template_id: template_id,
+      reference: REFERENCE,
+      email_reply_to_id: nil
+    }
+
+    notifications_gateway.send(opts)
+  end
+
+private
+
+  attr_reader :notifications_gateway
+end

--- a/spec/features/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/sign_up_as_an_organisation_spec.rb
@@ -80,6 +80,9 @@ describe 'Sign up as an organisation' do
 
   context 'when account is already confirmed' do
     before do
+      expect_any_instance_of(NotifySupportOfNewUser).to \
+        receive(:execute)
+
       sign_up_for_account
       create_password_for_account
       visit confirmation_email_link

--- a/spec/use_cases/administrator/notify_support_of_new_user_spec.rb
+++ b/spec/use_cases/administrator/notify_support_of_new_user_spec.rb
@@ -1,0 +1,31 @@
+describe NotifySupportOfNewUser do
+  class NotifySupportOfNewUserGatewayMock
+    def send(opts)
+      raise unless opts[:email] == 'test@localhost'
+      raise unless opts[:locals][:user_email] == 'user@example.com'
+      raise unless opts[:template_id] == 'yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy'
+      raise unless opts[:reference] == 'notify_support_of_new_user'
+
+      {}
+    end
+  end
+
+  let(:new_user_email) { 'user@example.com' }
+  let(:template_id) { GOV_NOTIFY_CONFIG['notify_support_of_new_user']['template_id'] }
+
+  subject do
+    described_class.new(
+      notifications_gateway: NotifySupportOfNewUserGatewayMock.new
+    )
+  end
+
+  it 'calls notifications gateway with valid data' do
+    expect {
+      subject
+        .execute(
+          new_user_email: new_user_email,
+          template_id: template_id
+        )
+    }.to_not raise_error
+  end
+end

--- a/spec/use_cases/administrator/send_confirmation_email_spec.rb
+++ b/spec/use_cases/administrator/send_confirmation_email_spec.rb
@@ -1,5 +1,5 @@
 describe SendConfirmationEmail do
-  class NotificationsGatewayMock
+  class SendConfirmationEmailGatewayMock
     def send(opts)
       raise unless opts[:email] == 'test@example.com'
       raise unless opts[:locals][:confirmation_url] == 'https://example.com'
@@ -16,7 +16,7 @@ describe SendConfirmationEmail do
 
   subject do
     described_class.new(
-      notifications_gateway: NotificationsGatewayMock.new
+      notifications_gateway: SendConfirmationEmailGatewayMock.new
     )
   end
 


### PR DESCRIPTION
Support (for today's date its Steve) wants to be CC'ed when
new user are registered so he can chase org admins to sign up
for MoU.