### PR TITLE
Add guidance to new IP form

### DIFF
--- a/app/controllers/ips_controller.rb
+++ b/app/controllers/ips_controller.rb
@@ -4,8 +4,12 @@ class IpsController < ApplicationController
   end
 
   def create
-    ip = current_user.ips.create!(ip_params)
-    redirect_to ip
+    @ip = current_user.ips.new(ip_params)
+    if @ip.save
+      redirect_to @ip
+    else
+      render :new
+    end
   end
 
   def index

--- a/app/views/ips/new.html.erb
+++ b/app/views/ips/new.html.erb
@@ -1,13 +1,21 @@
-<%= render "layouts/form_errors" %>
+<%= render "layouts/form_errors", resource: @ip %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l">Add an IP</h2>
 
+    <div class="govuk-body">
+      <p>Only IPv4 addresses can be accepted</p>
+      <ul>
+        <li>Must not be an IPv6 Address</li>
+        <li>Must not include a "/" (subnet IPv4)</li>
+      </ul>
+    </div>
+
     <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
       <%= form_with model: @ip do |form| %>
         <div class="govuk-form-group <%= "govuk-form-group--error" if @ip&.errors&.any? %>">
-          <%= form.label :ip, "Enter a valid IP address", class: "govuk-label"  %><br />
+          <%= form.label :ip, "IP Address", class: "govuk-label"  %><br />
           <%= form.text_field :address, id: :address, autofocus: true, class: "govuk-input", required: true %>
         </div>
 

--- a/spec/features/add_an_ip_address_spec.rb
+++ b/spec/features/add_an_ip_address_spec.rb
@@ -1,5 +1,6 @@
 require 'features/support/not_signed_in'
 require 'features/support/sign_up_helpers'
+require 'features/support/errors_in_form'
 require 'features/support/activation_notice'
 require 'support/notifications_service'
 require 'support/confirmation_use_case'
@@ -30,6 +31,20 @@ describe 'Add an IP to my account' do
 
       it 'displays the form' do
         expect(page).to have_content('Add an IP')
+      end
+    end
+
+    context 'with an invalid IP address' do
+      before do
+        fill_in 'address', with: 'InvalidIP'
+        expect { click_on 'save' }.to change { Ip.count }.by(0)
+      end
+
+      it_behaves_like 'errors in form'
+
+      it 'displays the form with error message' do
+        expect(page).to have_content('Add an IP')
+        expect(page).to have_content('Address must be valid IP address format')
       end
     end
 


### PR DESCRIPTION
Improve IP form to be safer for users:

- Add Errors:
<img width="993" alt="screen shot 2018-08-16 at 11 41 08" src="https://user-images.githubusercontent.com/2160769/44204250-c5eb0b00-a149-11e8-83ef-d2efb8a75acb.png">

- Add Guidance
<img width="724" alt="screen shot 2018-08-16 at 11 40 56" src="https://user-images.githubusercontent.com/2160769/44204261-cedbdc80-a149-11e8-8532-fcf695806afb.png">
