### PR TITLE
Remove Alpha banner

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -89,16 +89,6 @@
   </header>
 
   <div class="govuk-width-container">
-    <div class="govuk-phase-banner">
-      <p class="govuk-phase-banner__content">
-        <strong class="govuk-tag govuk-phase-banner__content__tag ">alpha</strong>
-        <span class="govuk-phase-banner__text">
-          This is a new service – your
-          <%= mail_to "support@govuk.zendesk.com", "feedback", class: "govuk-link" %> will help us to improve it.
-        </span>
-      </p>
-    </div>
-
     <main class="govuk-main-wrapper " id="main-content" role="main">
       <%= yield %>
     </main>


### PR DESCRIPTION
We are not actually "Alpha" or "Beta" as the GovWifi service is not new. We are simply creating a new interface and updating content. 