### PR TITLE
Disallow viewing other IP Adresses

### DIFF
--- a/app/controllers/ips_controller.rb
+++ b/app/controllers/ips_controller.rb
@@ -19,7 +19,9 @@ class IpsController < ApplicationController
   end
 
   def show
-    @ip = Ip.find(params[:id])
+    @ip = current_user.ips.find_by(id: params[:id])
+
+    redirect_to root_path unless @ip.present?
   end
 
 private

--- a/spec/features/view_ip_addresses_spec.rb
+++ b/spec/features/view_ip_addresses_spec.rb
@@ -81,6 +81,15 @@ describe 'View all my IP addresses' do
         end
       end
 
+      context 'Viewing someone elses IP Addresses' do
+        let(:other_ip) { create(:ip, user: create(:user, email: 'someone-else@gov.uk')) }
+
+        it 'Redirects to the root path' do
+          visit ip_path(other_ip)
+          expect(page.current_path).to eq(root_path)
+        end
+      end
+
       context 'with no radius IPs in config' do
         before do
           ENV.delete('LONDON_RADIUS_IPS')


### PR DESCRIPTION
Ensure that you cannot navigate to other IP addresses by modifying the
id in the URL