### PR TITLE
Don't email support for staging signups

### DIFF
--- a/config/gov_notify.yml
+++ b/config/gov_notify.yml
@@ -1,5 +1,5 @@
 staging:
-  support_email: 'govwifi-support@digital.cabinet-office.gov.uk'
+  support_email: 'dev@localhost'
   confirmation_email:
     template_id: '1af17502-9797-4e61-904e-999f6cf259a5'
   notify_support_of_new_user:


### PR DESCRIPTION
Since we are doing a lot of testing here, it will get pretty noisy in
Zendesk