### PR TITLE
Ask user for name on password confirmation page

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -6,7 +6,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
 
   def update
     with_unconfirmed_confirmable do
-      if @confirmable.attempt_set_password(params[:user])
+      if @confirmable.update_details(params[:user])
         confirm_user
       else
         render_show_page

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,12 +8,14 @@ class User < ApplicationRecord
 
   validates_confirmation_of :password
   validate :email_on_whitelist
+  validates :name, presence: true, on: :update
 
-  def attempt_set_password(params)
+  def update_details(params)
     unless params[:password] == params[:password_confirmation]
       errors.add(:base, "Passwords must match") && return
     end
-    update(password: params[:password])
+
+    update(password: params[:password], name: params[:name])
   end
 
   def only_if_unconfirmed

--- a/app/views/users/confirmations/show.html.erb
+++ b/app/views/users/confirmations/show.html.erb
@@ -8,9 +8,15 @@
       <%= form_for(resource, as: resource_name, url: users_confirmations_path, html: { method: :put }) do |f| %>
         <%= f.hidden_field :confirmation_token, value: params[:confirmation_token] || params[:user][:confirmation_token] %>
 
+         <%= resource.errors.full_messages %>
+        <div class="govuk-form-group">
+          <%= f.label :name, "Name", class: "govuk-label" %>
+          <%= f.text_field :name, autofocus: true, class: "govuk-input", required: true %>
+        </div>
+
         <div class="govuk-form-group <%= "govuk-form-group--error" if resource&.errors&.any? %>">
           <%= f.label :password, "New password", class: "govuk-label" %>
-          <%= f.password_field :password, autofocus: true, class: "govuk-input", autocomplete: "off", required: true %>
+          <%= f.password_field :password, class: "govuk-input", autocomplete: "off", required: true %>
         </div>
 
         <div class="govuk-form-group">

--- a/app/views/users/confirmations/show.html.erb
+++ b/app/views/users/confirmations/show.html.erb
@@ -8,7 +8,6 @@
       <%= form_for(resource, as: resource_name, url: users_confirmations_path, html: { method: :put }) do |f| %>
         <%= f.hidden_field :confirmation_token, value: params[:confirmation_token] || params[:user][:confirmation_token] %>
 
-         <%= resource.errors.full_messages %>
         <div class="govuk-form-group">
           <%= f.label :name, "Name", class: "govuk-label" %>
           <%= f.text_field :name, autofocus: true, class: "govuk-input", required: true %>

--- a/db/migrate/20180822150340_add_name_to_users.rb
+++ b/db/migrate/20180822150340_add_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddNameToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_13_135333) do
+ActiveRecord::Schema.define(version: 2018_08_22_150340) do
 
   create_table "ips", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "address"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2018_08_13_135333) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "radius_secret_key"
+    t.string "name"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :user do
     email "test@gov.uk"
     password "123456"
+    name "bob"
 
     trait :confirmed do
       confirmed_at { Time.zone.now }

--- a/spec/features/asking_users_to_sign_in_spec.rb
+++ b/spec/features/asking_users_to_sign_in_spec.rb
@@ -18,7 +18,7 @@ describe 'asking users to sign in' do
   context 'with a pre-existing account, but signed out' do
     before do
       sign_up_for_account
-      create_password_for_account
+      update_user_details
 
       click_on 'Logout'
 

--- a/spec/features/logging_in_after_signing_up_spec.rb
+++ b/spec/features/logging_in_after_signing_up_spec.rb
@@ -11,7 +11,7 @@ describe 'logging in after signing up' do
 
   before do
     sign_up_for_account(email: 'tom@gov.uk')
-    create_password_for_account(
+    update_user_details(
       password: correct_password,
       confirmed_password: correct_password
     )

--- a/spec/features/resend_confirmation_instructions_spec.rb
+++ b/spec/features/resend_confirmation_instructions_spec.rb
@@ -47,7 +47,7 @@ describe 'Resending confirmation instructions' do
   context 'when user has been confirmed' do
     before do
       sign_up_for_account(email: correct_email)
-      create_password_for_account
+      update_user_details
       visit new_user_confirmation_path
       fill_in 'user_email', with: correct_email
       click_on 'Resend confirmation instructions'

--- a/spec/features/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/sign_up_as_an_organisation_spec.rb
@@ -7,10 +7,12 @@ describe 'Sign up as an organisation' do
   include_examples 'confirmation use case spy'
   include_examples 'notifications service'
 
+  let(:name) { 'Sally' }
+
   context 'with matching passwords' do
     before do
       sign_up_for_account(email: email)
-      create_password_for_account
+      update_user_details(name: name)
     end
 
     context 'with a gov.uk email' do
@@ -48,12 +50,21 @@ describe 'Sign up as an organisation' do
         )
       end
     end
+
+    context 'without a name' do
+      let(:name) { '' }
+      let(:email) { 'someone@other.gov.uk' }
+
+      it 'tells me my name is not valid' do
+        expect(page).to have_content("Name can't be blank")
+      end
+    end
   end
 
   context 'when password does not match password confirmation' do
     before do
       sign_up_for_account
-      create_password_for_account(password: 'password', confirmed_password: 'password1')
+      update_user_details(password: 'password', confirmed_password: 'password1')
       expect(page).to have_content 'Set your password'
     end
 
@@ -67,7 +78,7 @@ describe 'Sign up as an organisation' do
   context 'when password is too short' do
     before do
       sign_up_for_account
-      create_password_for_account(password: '1', confirmed_password: '1')
+      update_user_details(password: '1', confirmed_password: '1')
       expect(page).to have_content 'Set your password'
     end
 
@@ -84,7 +95,7 @@ describe 'Sign up as an organisation' do
         receive(:execute)
 
       sign_up_for_account
-      create_password_for_account
+      update_user_details
       visit confirmation_email_link
     end
 
@@ -98,7 +109,7 @@ describe 'Sign up as an organisation' do
   context 'when making two errors in a row' do
     before do
       sign_up_for_account
-      create_password_for_account(password: '1', confirmed_password: '1')
+      update_user_details(password: '1', confirmed_password: '1')
       expect(page).to have_content 'Password is too short (minimum is 6 characters)'
       expect(page).to have_content 'Set your password'
 

--- a/spec/features/support/sign_up_helpers.rb
+++ b/spec/features/support/sign_up_helpers.rb
@@ -6,9 +6,10 @@ def sign_up_for_account(email: 'default@gov.uk')
   click_on 'Sign up'
 end
 
-def create_password_for_account(password: 'supersecret', confirmed_password: 'supersecret')
+def update_user_details(password: 'supersecret', confirmed_password: 'supersecret', name: 'bob')
   return unless confirmation_email_received?
   visit confirmation_email_link
+  fill_in 'Name', with: name
   fill_in 'New password', with: password
   fill_in 'Confirm new password', with: confirmed_password
   click_on 'Save my password'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,21 +7,25 @@ describe User do
     it { should have_many(:ips) }
   end
 
-  describe '#attempt_set_password' do
+  describe '#update_details' do
     let(:user) { create(:user, password: 'password') }
     context 'when passwords match' do
-      let(:params) { { password: '123456', password_confirmation: '123456' } }
+      let(:params) { { password: '123456', password_confirmation: '123456', name: 'bob' } }
 
       it 'should set the users password' do
-        expect { user.attempt_set_password(params) }.to change(user, :password)
+        expect { user.update_details(params) }.to change(user, :password)
         expect(user.errors.empty?).to eq(true)
+      end
+
+      context 'Name validation' do
+        it { should validate_presence_of(:name).on(:update) }
       end
     end
 
     context 'when passwords do not match' do
       let(:params) { { password: '123456', password_confirmation: '1234567' } }
       it 'should not set the users password' do
-        expect { user.attempt_set_password(params) }.to_not change(user, :password)
+        expect { user.update_details(params) }.to_not change(user, :password)
         expect(user.errors.empty?).to eq(false)
         expect(user.errors.full_messages).to eq(['Passwords must match'])
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 RSpec.configure do |config|
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end


### PR DESCRIPTION
We want to store additional details for users once they follow the
confirmation link from their inbox.

Rename some of the set_password methods to be more general