### PR TITLE
Fix bug in development with sending emails

### DIFF
--- a/config/gov_notify.yml
+++ b/config/gov_notify.yml
@@ -8,7 +8,7 @@ staging:
     template_id: '1672af2e-2acb-463a-95ee-2adad2aaceee'
 
 development:
-  support_email: 'dev@localhost'
+  support_email: 'dev@localhost.com'
   confirmation_email:
     template_id: '1af17502-9797-4e61-904e-999f6cf259a5'
   notify_support_of_new_user:


### PR DESCRIPTION
When someone signs up we want to know about it on production.
This was breaking in development with an invalid email error, since we
stubbed out Notify