### PR TITLE
Improve UX of "confirmation email sent" page

### DIFF
--- a/app/views/users/confirmations/pending.html.erb
+++ b/app/views/users/confirmations/pending.html.erb
@@ -1,12 +1,17 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <h1 class="govuk-heading-xl">Super</h1>
-    <p class="govuk-body">
-      You have submitted a sign up request. Please check your email inbox to
-      validate your e-mail address.
-    </p>
-    <p class="govuk-body">
-      Simply follow the instructions in the email.
-    </p>
-  </div>
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        Confirmation email sent
+      </h1>
+      <p class="govuk-panel__body">We've sent confirmation instructions to <strong>your email address.</strong></p>
+    </div>
+
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        Once you have confirmed your email address, you can continue to creating an account.
+      </strong>
+    </div>
 </div>

--- a/app/views/users/confirmations/pending.html.erb
+++ b/app/views/users/confirmations/pending.html.erb
@@ -7,11 +7,7 @@
       <p class="govuk-panel__body">We've sent confirmation instructions to <strong>your email address.</strong></p>
     </div>
 
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning</span>
-        Once you have confirmed your email address, you can continue to creating an account.
-      </strong>
-    </div>
+    <p class="govuk-inset-text">
+      Once you have confirmed your email address, you can continue to creating an account.
+    </p>
 </div>


### PR DESCRIPTION
Some improvements to copy, large clear layout.

Notably, this PR doesn't include the "actual" email address, or the "resend confirmation email", as the Devise resource is not in context at this path. Time is short, so that comes later.

![image](https://user-images.githubusercontent.com/429326/44521708-e24bf200-a6cb-11e8-9655-5ed072d0ac26.png)
