### PR TITLE
Force SSL except for Healthcheck path

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,14 @@ module GovwifiAdmin
     config.autoload_paths += %W(#{config.root}/lib)
     config.autoload_paths += Dir["#{config.root}/lib/**/"]
 
+    # Force HTTPS for all requests except healthcheck endpoint
+    config.force_ssl = true
+    config.ssl_options = {
+      redirect: {
+        exclude: -> request { request.path =~ /healthcheck/ }
+      }
+    }
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/spec/features/resend_confirmation_instructions_spec.rb
+++ b/spec/features/resend_confirmation_instructions_spec.rb
@@ -20,6 +20,8 @@ describe 'Resending confirmation instructions' do
         fill_in 'user_email', with: entered_email
         click_on 'Resend confirmation instructions'
       }.to change { ConfirmationUseCaseSpy.confirmations_count }.by(2)
+
+      expect(URI(confirmation_email_link).scheme).to eq("https")
     end
   end
 

--- a/spec/features/reset_password_spec.rb
+++ b/spec/features/reset_password_spec.rb
@@ -45,6 +45,7 @@ describe "Resetting a password" do
     end
 
     context "when clicking on reset link" do
+      let(:reset_link) { ResetPasswordUseCaseSpy.last_reset_url }
       let(:reset_path) { ResetPasswordUseCaseSpy.last_reset_path_with_query }
 
       before do
@@ -52,6 +53,10 @@ describe "Resetting a password" do
         fill_in "user_email", with: user.email
         click_on "Send me reset password instructions"
         visit(reset_path)
+      end
+
+      it "sends an https link" do
+        expect(URI(reset_link).scheme).to eq("https")
       end
 
       it "redirects user to edit password page" do


### PR DESCRIPTION
Confirmation and reset password links were using "http" only, which meant users could not follow them in many browsers.

This forces "HTTPS" on the entire application, except for the healthcheck path.