### PR TITLE
Tabify logged-in landing, add placeholder content

### DIFF
--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -1,14 +1,80 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-heading-l">Locations</h2>
-      </div>
-      <div class="govuk-grid-column-one-third">
-        <%= link_to "Add IP", new_ip_path, class: "govuk-button",  style: "float:right;" %>
-      </div>
+<div class="govuk-tabs" data-module="tabs">
+  <ul class="govuk-tabs__list">
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#home">
+        Home
+      </a>
+    </li>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#locations">
+        Locations
+      </a>
+    </li>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#team">
+        Team
+      </a>
+    </li>
+  </ul>
+
+  <section class="govuk-tabs__panel" id="home">
+    <div>
+      <h2 class="govuk-heading-l">Home</h2>
+      <p class="govuk-body">Use this service to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li> add IPs </li>
+        <li> add team members to your organisation </li>
+        <li> understand how your users are using GovWifi </li>
+        <li> get support </li>
+      </ul>
     </div>
 
+    <h2> Steps to get GovWifi in your building</h2>
+    <div>
+      <h3> 1. Add IP </h3>
+      <ul class="govuk-list govuk-list--bullet">
+        <li> Go to "Locations" </li>
+        <li> Enter the IPs of your access points </li>
+      </ul>
+    </div>
+
+    <div>
+      <h3> 2. Configure your access point </h3>
+      <ul class="govuk-list govuk-list--bullet">
+        <li> Use the secret key provided </li>
+        <li> Use your GovWifi IP </li>
+        <li> Install the access point </li>
+      </ul>
+    </div>
+
+    <div>
+      <h3> 3. Wait until the next working day </h3>
+      <p class="govuk-body"> Once you've set IPs in this tool, they won't be available for use until tomorrow. </p>
+    </div>
+
+    <div>
+      <h3> 4. Add team members </h3>
+      <ul class="govuk-list govuk-list--bullet">
+        <li> They must have government/whitelisted emails </li>
+        <li> They will need to confirm their email address and enter an account password </li>
+      </ul>
+    </div>
+
+    <div>
+      <h3> 5. Confirm your setup is working </h3>
+      <ul class="govuk-list govuk-list--bullet">
+        <li> Check you have login attempts for your users </li>
+        <li> Check activity from your access points </li>
+        <li> Check the GovWifi service status </li>
+      </ul>
+    </div>
+
+    <a href="#support"> Getting help </a>
+  </section>
+
+  <section class="govuk-tabs__panel" id="locations">
+    <h2 class="govuk-heading-l">Locations</h2>
+      <%= link_to "Add IP", new_ip_path, class: "govuk-button" %>
     <% if @ips.empty? %>
       <p class="govuk-body">
         You have not added any of your IPs, <%= link_to "add one now", new_ip_path, class: "govuk-link" %>
@@ -24,5 +90,15 @@
         london_ips: @london_radius_ips,
         dublin_ips: @dublin_radius_ips  %>
     <% end %>
-  </div>
+  </section>
+
+   <section class="govuk-tabs__panel" id="team">
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        Managing team isn't available yet.
+      </strong>
+    </div>
+  </section>
 </div>


### PR DESCRIPTION
This PR introduces three tabs - home, locations and team - that
will hopefully help to make it clearer to a user what's happening once
they've logged in.

I think this version of the content is too dense to guide a user, and
I'm not happy with a lot of the language, we can refine it from here.

"Home" part of this: 

![image](https://user-images.githubusercontent.com/429326/44529794-d7518b80-a6e4-11e8-998d-787b839b1776.png)

"Locations" takes what the page used to look like (which will soon get updated as well):

![image](https://user-images.githubusercontent.com/429326/44529815-e3d5e400-a6e4-11e8-8089-9cbceb2e3d6e.png)

Team isn't available yet:

![image](https://user-images.githubusercontent.com/429326/44529834-f05a3c80-a6e4-11e8-8631-d4ff1ce20b5f.png)

Notably tabbed view isn't something GOV.UK are confident in yet, but things can be moved around pretty easily.