### PR TITLE
Make notify valid (if fake) email address

### DIFF
--- a/config/gov_notify.yml
+++ b/config/gov_notify.yml
@@ -1,5 +1,5 @@
 staging:
-  support_email: 'dev@localhost'
+  support_email: 'dev@localhost.com'
   confirmation_email:
     template_id: '1af17502-9797-4e61-904e-999f6cf259a5'
   notify_support_of_new_user:


### PR DESCRIPTION
Notify (the GOV service) needs a "real" email address, or it blows up.