### PR TITLE
Improve UX of add IP page

### DIFF
--- a/app/models/ip.rb
+++ b/app/models/ip.rb
@@ -9,6 +9,7 @@ private
   def address_must_be_valid_ip
     checker = CheckIfValidIp.new
     valid_ip = checker.execute(self.address)[:success]
-    errors.add(:address, 'must be valid IP address format') unless valid_ip
+    message = 'must be a valid IPv4 address (without subnet)'
+    errors.add(:address, message) unless valid_ip
   end
 end

--- a/app/views/ips/_activation_notice.html.erb
+++ b/app/views/ips/_activation_notice.html.erb
@@ -1,9 +1,6 @@
-<div class="govuk-grid-column-two-thirds">
-  <div class="govuk-inset-text">
-    <h4 class="govuk-heading-s">24 Hours to Activate</h4>
-    <p class="govuk-body">
-      You can configure your access points immedately but it will take 24 hours
-      for your new IP to be activated.
-    </p>
-  </div>
+<div class="govuk-inset-text">
+  <h4 class="govuk-heading-s">New locations are not immediately available</h4>
+  <p class="govuk-body">
+    You can configure your access points now, but new IPs will not be activated until the next working day.
+  </p>
 </div>

--- a/app/views/ips/_activation_notice.html.erb
+++ b/app/views/ips/_activation_notice.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-inset-text">
-  <h4 class="govuk-heading-s">New locations are not immediately available</h4>
+  <h4 class="govuk-heading-s">New IPs are not immediately available</h4>
   <p class="govuk-body">
     You can configure your access points now, but new IPs will not be activated until the next working day.
   </p>

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -78,12 +78,12 @@
       <p class="govuk-body">
         You currently have no IPs configured for use with GovWifi. Find out <%= link_to "more", "#", class: "govuk-link" %>
       </p>
-      <%= link_to "Add IP", new_ip_path, class: "govuk-button" %>
+      <%= link_to "Add Location", new_ip_path, class: "govuk-button" %>
     <% else %>
       <%= render "radius_details",
         london_ips: @london_radius_ips,
         dublin_ips: @dublin_radius_ips  %>
-      <%= link_to "Add IP", new_ip_path, class: "govuk-button govuk-!-margin-bottom-0" %>
+      <%= link_to "Add Location", new_ip_path, class: "govuk-button govuk-!-margin-bottom-0" %>
       <%= render "ips/table", ips: @ips %>
 
       <details class="govuk-details">

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -6,8 +6,8 @@
       </a>
     </li>
     <li class="govuk-tabs__list-item">
-      <a class="govuk-tabs__tab" href="#locations">
-        Locations
+      <a class="govuk-tabs__tab" href="#ips">
+        IP Addresses
       </a>
     </li>
     <li class="govuk-tabs__list-item">
@@ -33,7 +33,7 @@
     <div>
       <h3> 1. Add IP </h3>
       <ul class="govuk-list govuk-list--bullet">
-        <li> Go to "Locations" </li>
+        <li> Go to "IP Addresses" </li>
         <li> Enter the IPs of your access points </li>
       </ul>
     </div>
@@ -72,18 +72,18 @@
     <a href="#support"> Getting help </a>
   </section>
 
-  <section class="govuk-tabs__panel" id="locations">
-    <h2 class="govuk-heading-l">Locations</h2>
+  <section class="govuk-tabs__panel" id="ips">
+    <h2 class="govuk-heading-l">IP Addresses</h2>
     <% if @ips.empty? %>
       <p class="govuk-body">
         You currently have no IPs configured for use with GovWifi. Find out <%= link_to "more", "#", class: "govuk-link" %>
       </p>
-      <%= link_to "Add Location", new_ip_path, class: "govuk-button" %>
+      <%= link_to "Add IP Address", new_ip_path, class: "govuk-button" %>
     <% else %>
       <%= render "radius_details",
         london_ips: @london_radius_ips,
         dublin_ips: @dublin_radius_ips  %>
-      <%= link_to "Add Location", new_ip_path, class: "govuk-button govuk-!-margin-bottom-0" %>
+      <%= link_to "Add IP Address", new_ip_path, class: "govuk-button govuk-!-margin-bottom-0" %>
       <%= render "ips/table", ips: @ips %>
 
       <details class="govuk-details">

--- a/app/views/ips/new.html.erb
+++ b/app/views/ips/new.html.erb
@@ -2,29 +2,23 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Add an IP</h2>
+    <%= link_to "Back to list", ips_path(anchor: :locations), class: "govuk-back-link" %>
 
-    <div class="govuk-body">
-      <p>Only IPv4 addresses can be accepted</p>
-      <ul>
-        <li>Must not be an IPv6 Address</li>
-        <li>Must not include a "/" (subnet IPv4)</li>
-      </ul>
-    </div>
+    <h2 class="govuk-heading-l">Add a new location</h2>
+
+    <%= render "activation_notice" %>
 
     <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
       <%= form_with model: @ip do |form| %>
         <div class="govuk-form-group <%= "govuk-form-group--error" if @ip&.errors&.any? %>">
-          <%= form.label :ip, "IP Address", class: "govuk-label"  %><br />
-          <%= form.text_field :address, id: :address, autofocus: true, class: "govuk-input", required: true %>
+          <%= form.label :ip, "Enter IP Address (IPv4 only)", class: "govuk-label"  %><br />
+          <%= form.text_field :address, id: :address, autofocus: true, autocomplete: "off", class: "govuk-input", required: true %>
         </div>
 
         <div class="actions">
-          <%= form.submit "save", class: "govuk-button govuk-!-margin-top-4" %>
+          <%= form.submit "Save", class: "govuk-button govuk-!-margin-top-4" %>
         </div>
       <% end %>
     </div>
   </div>
-
-  <%= render "activation_notice" %>
 </div>

--- a/app/views/ips/new.html.erb
+++ b/app/views/ips/new.html.erb
@@ -2,9 +2,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= link_to "Back to list", ips_path(anchor: :locations), class: "govuk-back-link" %>
+    <%= link_to "Back to list", ips_path(anchor: :ips), class: "govuk-back-link" %>
 
-    <h2 class="govuk-heading-l">Add a new location</h2>
+    <h2 class="govuk-heading-l">Add a new IP Address</h2>
 
     <%= render "activation_notice" %>
 

--- a/spec/features/add_an_ip_address_spec.rb
+++ b/spec/features/add_an_ip_address_spec.rb
@@ -23,7 +23,7 @@ describe 'Add an IP to my account' do
       sign_in_user user
       visit ips_path
       expect(page).to have_content "Add IP"
-      click_on "Add Location"
+      click_on "Add IP Address"
     end
 
     context 'before saving the IP' do

--- a/spec/features/add_an_ip_address_spec.rb
+++ b/spec/features/add_an_ip_address_spec.rb
@@ -23,35 +23,37 @@ describe 'Add an IP to my account' do
       sign_in_user user
       visit ips_path
       expect(page).to have_content "Add IP"
-      click_on "Add IP"
+      click_on "Add Location"
     end
 
     context 'before saving the IP' do
       it_behaves_like 'shows activation notice'
 
       it 'displays the form' do
-        expect(page).to have_content('Add an IP')
+        expect(page).to have_content('Enter IP Address (IPv4 only)')
       end
     end
 
     context 'with an invalid IP address' do
       before do
         fill_in 'address', with: 'InvalidIP'
-        expect { click_on 'save' }.to change { Ip.count }.by(0)
+        expect { click_on 'Save' }.to change { Ip.count }.by(0)
       end
 
       it_behaves_like 'errors in form'
 
       it 'displays the form with error message' do
-        expect(page).to have_content('Add an IP')
-        expect(page).to have_content('Address must be valid IP address format')
+        expect(page).to have_content('Enter IP Address')
+        expect(page).to have_content(
+          'Address must be a valid IPv4 address (without subnet)'
+        )
       end
     end
 
     context 'after successfully saving an IP' do
       before do
         fill_in 'address', with: '10.0.0.1'
-        expect { click_on 'save' }.to change { Ip.count }.by 1
+        expect { click_on 'Save' }.to change { Ip.count }.by 1
       end
 
       it_behaves_like 'shows activation notice'

--- a/spec/features/support/activation_notice.rb
+++ b/spec/features/support/activation_notice.rb
@@ -1,5 +1,5 @@
 shared_examples 'shows activation notice' do
-  it 'tells the user locations are not immediately available' do
-    expect(page).to have_content 'New locations are not immediately available'
+  it 'tells the user IPs are not immediately available' do
+    expect(page).to have_content 'New IPs are not immediately available'
   end
 end

--- a/spec/features/support/activation_notice.rb
+++ b/spec/features/support/activation_notice.rb
@@ -1,5 +1,5 @@
 shared_examples 'shows activation notice' do
-  it 'tells the user it takes 24 hours to activate' do
-    expect(page).to have_content '24 Hours to Activate'
+  it 'tells the user locations are not immediately available' do
+    expect(page).to have_content 'New locations are not immediately available'
   end
 end

--- a/spec/models/ip_spec.rb
+++ b/spec/models/ip_spec.rb
@@ -12,7 +12,9 @@ describe Ip do
 
         it "does not save when address is an invalid IP" do
           expect(Ip.count).to eq(0)
-          expect(ip.errors.full_messages).to eq(["Address must be valid IP address format"])
+          expect(ip.errors.full_messages).to eq([
+            "Address must be a valid IPv4 address (without subnet)"
+          ])
         end
       end
 


### PR DESCRIPTION
## Summary 
This commit changes various markup and messages to better illustrate to users the purpose and functionality of the now "Add Locations" page. it also adds a functioning 'back' link.

It also modifies the feature specs that were checking against these pages.

Notably this changes the language from "adding IPs" to "adding locations", which I'm not sure if correct. Feels like we have divergent language around this concept.

## New

![image](https://user-images.githubusercontent.com/429326/44719841-7ba84900-aabc-11e8-922a-85042b100446.png)

## Old (for reference)

![image](https://user-images.githubusercontent.com/429326/44719847-82cf5700-aabc-11e8-8914-e47c6d72e087.png)
