### PR TITLE
Assign Invited User to Organisation

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,0 +1,14 @@
+class Users::InvitationsController < Devise::InvitationsController
+  # Overrides https://github.com/scambra/devise_invitable/blob/master/app/controllers/devise/invitations_controller.rb#L12
+  def new
+    self.resource = User.new(organisation_id: current_user.organisation_id)
+    render :new
+  end
+
+private
+
+  # Overrides https://github.com/scambra/devise_invitable/blob/master/app/controllers/devise/invitations_controller.rb#L105
+  def invite_params
+    params.require(:user).permit(:email, :organisation_id)
+  end
+end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,11 +1,11 @@
 class Users::InvitationsController < Devise::InvitationsController
-  # Overrides https://github.com/scambra/devise_invitable/blob/master/app/controllers/devise/invitations_controller.rb#L12
-  def new
-    self.resource = User.new(organisation_id: current_user.organisation_id)
-    render :new
-  end
+  before_action :add_organisation_to_params, only: :create
 
 private
+
+  def add_organisation_to_params
+    params[:user][:organisation_id] = current_user.organisation_id
+  end
 
   # Overrides https://github.com/scambra/devise_invitable/blob/master/app/controllers/devise/invitations_controller.rb#L105
   def invite_params

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -3,6 +3,8 @@
 <%= form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => {:method => :post} do |f| %>
   <%= devise_error_messages! %>
 
+  <%= f.hidden_field :organisation_id %>
+
 <% resource.class.invite_key_fields.each do |field| -%>
   <p><%= f.label field %><br />
   <%= f.text_field field %></p>

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -3,8 +3,6 @@
 <%= form_for resource, :as => resource_name, :url => invitation_path(resource_name), :html => {:method => :post} do |f| %>
   <%= devise_error_messages! %>
 
-  <%= f.hidden_field :organisation_id %>
-
 <% resource.class.invite_key_fields.each do |field| -%>
   <p><%= f.label field %><br />
   <%= f.text_field field %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,8 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: {
     confirmations: 'users/confirmations',
-    registrations: 'users/registrations'
+    registrations: 'users/registrations',
+    invitations: 'users/invitations'
   }
   devise_scope :user do
     put 'users/confirmations', to: 'users/confirmations#update'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,6 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
 
-user = User.create(email: "test@gov.uk", password: "password", name: "Steve")
+organisation = Organisation.create(name: "Parks & Recreation Dept")
+user = organisation.users.create(email: "test@gov.uk", password: "password", name: "Steve")
 user.confirm

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     trait :confirmed do
       confirmed_at { Time.zone.now }
     end
+
+    trait :with_organisation do
+      association :organisation
+    end
   end
 end

--- a/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
+++ b/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
@@ -7,7 +7,7 @@ describe "Sign up from invitation" do
   include_examples 'invite use case spy'
   include_examples 'notifications service'
 
-  let(:user) { create(:user, :confirmed) }
+  let(:user) { create(:user, :confirmed, :with_organisation) }
   let(:invited_user_email) { "invited@gov.uk" }
 
   before do
@@ -39,6 +39,7 @@ describe "Sign up from invitation" do
       it "confirms the user" do
         expect(invited_user.confirmed?).to eq(true)
         expect(invited_user.name).to eq("Ron Swanson")
+        expect(invited_user.organisation).to eq(user.organisation)
         expect(page).to have_content("Home")
         expect(page).to have_content("Logout")
       end

--- a/spec/features/team/invite_a_team_member_spec.rb
+++ b/spec/features/team/invite_a_team_member_spec.rb
@@ -14,7 +14,7 @@ describe "Invite a team member" do
   end
 
   context "when logged in" do
-    let(:user) { create(:user, :confirmed) }
+    let(:user) { create(:user, :confirmed, :with_organisation) }
     before do
       sign_in_user user
       visit new_user_invitation_path
@@ -40,6 +40,7 @@ describe "Invite a team member" do
         }.to change { User.count }.by(1)
         expect(InviteUseCaseSpy.invite_count).to eq(1)
         expect(invited_user.confirmed?).to eq(false)
+        expect(invited_user.organisation).to eq(user.organisation)
         expect(page).to have_content("Home")
       end
     end


### PR DESCRIPTION
Assigns the current user's organisation to the invited user.

I realise I am testing model attributes from a feature spec, however we currently have no indication of the user's organisation in the view, so it kind of has to be here for now. (Unless we want to make some controller specs that is 🤢 )