### PR TITLE
Route53 Healthchecks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem 'aws-sdk-route53', '~> 1.0.0.rc13'
 gem 'devise', '~> 4.5.0'
 gem 'devise_invitable', '~> 1.7.0'
 gem 'mysql2', '~> 0.5.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,17 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
+    aws-eventstream (1.0.1)
+    aws-partitions (1.102.0)
+    aws-sdk-core (3.24.1)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-route53 (1.0.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.3)
     bcrypt (3.1.12)
     builder (3.2.3)
     byebug (10.0.2)
@@ -88,6 +99,7 @@ GEM
       scss_lint
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
+    jmespath (1.4.0)
     jwt (2.1.0)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -227,6 +239,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-route53 (~> 1.0.0.rc13)
   byebug (~> 10)
   capybara
   capybara-screenshot

--- a/lib/use_cases/administrator/health_checks/calculate_health.rb
+++ b/lib/use_cases/administrator/health_checks/calculate_health.rb
@@ -1,0 +1,58 @@
+module UseCases
+  module Administrator
+    module HealthChecks
+      class CalculateHealth
+        def initialize(route53_gateway:)
+          @route53_gateway = route53_gateway
+        end
+
+        def execute(ips:)
+          ips.map { |ip| status_for_ip(ip) }.compact
+        end
+
+      private
+
+        attr_reader :fetch_health_checks_use_case, :route53_gateway
+
+        SUCCESS_STATUS = 'Success: HTTP Status Code 200, OK'.freeze
+
+        def status_for_ip(ip)
+          health_check = health_check_for_ip(ip)
+
+          return if health_check.nil?
+
+          {
+            ip: health_check.health_check_config.ip_address,
+            status: status(route53_gateway.get_health_check_status(health_check_id: health_check.id))
+          }
+        end
+
+        def health_check_for_ip(ip)
+          non_latency_health_checks.find do |health_check|
+            health_check.health_check_config.ip_address == ip
+          end
+        end
+
+        def status(health_check)
+          all_health_checkers_healthy?(health_check) ? :healthy : :unhealthy
+        end
+
+        def all_health_checkers_healthy?(health_check)
+          health_check.health_check_observations.all? do |a|
+            a.status_report.status == SUCCESS_STATUS
+          end
+        end
+
+        def non_latency_health_checks
+          all_health_checks.reject do |hc|
+            hc.health_check_config.measure_latency == true
+          end
+        end
+
+        def all_health_checks
+          @health_checks ||= route53_gateway.list_health_checks.health_checks
+        end
+      end
+    end
+  end
+end

--- a/spec/use_cases/administrator/health_check/calculate_health_spec.rb
+++ b/spec/use_cases/administrator/health_check/calculate_health_spec.rb
@@ -1,0 +1,171 @@
+class FakeHealthyRoute53Gateway
+  def get_health_check_status(health_check_id:)
+    client = Aws::Route53::Client.new(stub_responses: true)
+
+    client.stub_responses(:get_health_check_status,
+      health_check_observations:
+        [
+          {
+            region: 'ap-southeast-2',
+            ip_address: '39.239.222.111',
+            status_report: {
+              status: 'Success: HTTP Status Code 200, OK'
+            }
+          }, {
+            region: 'ap-eu-west-1',
+            ip_address: '27.111.39.33',
+            status_report: {
+              status: 'Success: HTTP Status Code 200, OK'
+            }
+          }
+        ])
+
+    client.get_health_check_status(health_check_id: health_check_id)
+  end
+
+  def list_health_checks
+    client = Aws::Route53::Client.new(
+      stub_responses: {
+        list_health_checks: {
+          max_items: 10,
+          marker: 'PageMarker',
+          is_truncated: false,
+          health_checks: [
+            {
+              caller_reference: 'AdminMonitoring',
+              id: 'abc123',
+              health_check_version: 1,
+              health_check_config: {
+                ip_address: '111.111.111.111',
+                measure_latency: false,
+                type: 'HTTP',
+              }
+            }, {
+              caller_reference: 'AdminMonitoring',
+              id: 'xyz789',
+              health_check_version: 1,
+              health_check_config: {
+                ip_address: '222.222.222.222',
+                measure_latency: false,
+                type: 'HTTP',
+              }
+            }, {
+              caller_reference: 'AdminMonitoring',
+              id: 'latency123',
+              health_check_version: 1,
+              health_check_config: {
+                ip_address: '777.777.777.777',
+                measure_latency: true,
+                type: 'HTTP',
+              }
+            }
+          ]
+        }
+      }
+    )
+
+    client.list_health_checks
+  end
+end
+
+class FakeUnHealthyRoute53Gateway
+  def get_health_check_status(health_check_id:)
+    client = Aws::Route53::Client.new(stub_responses: true)
+
+    client.stub_responses(:get_health_check_status,
+      health_check_observations:
+        [
+          {
+            region: 'ap-southeast-2',
+            ip_address: '39.239.222.111',
+            status_report: {
+              status: 'Failure: HTTP Status Code 500, Host Unreachable'
+            }
+          }
+        ])
+
+    client.get_health_check_status(health_check_id: health_check_id)
+  end
+
+  def list_health_checks
+    client = Aws::Route53::Client.new(
+      stub_responses: {
+        list_health_checks: {
+          max_items: 10,
+          marker: 'PageMarker',
+          is_truncated: false,
+          health_checks: [
+            {
+              caller_reference: 'AdminMonitoring',
+              id: 'latency123',
+              health_check_version: 1,
+              health_check_config: {
+                ip_address: '123.123.123.123',
+                measure_latency: false,
+                type: 'HTTP',
+              }
+            }
+          ]
+        }
+      }
+    )
+
+    client.list_health_checks
+  end
+end
+
+describe UseCases::Administrator::HealthChecks::CalculateHealth do
+  let(:aws_route53_gateway) { FakeHealthyRoute53Gateway.new }
+
+  let(:result) do
+    described_class.new(route53_gateway: aws_route53_gateway).execute(ips: ips)
+  end
+
+  context 'Given health checkers are healthy' do
+    let(:ips) { ['111.111.111.111', '222.222.222.222'] }
+
+    it 'returns healthy if all health checkers are healthy' do
+      expected_result = [
+        { ip: '111.111.111.111', status: :healthy },
+        { ip: '222.222.222.222', status: :healthy }
+      ]
+
+      expect(result).to eq(expected_result)
+    end
+  end
+
+  context 'Given a latency health check' do
+    let(:ips) { ['777.777.777.777', '111.111.111.111'] }
+
+    it 'returns healthy if all health checkers are healthy' do
+      expected_result = [{ ip: '111.111.111.111', status: :healthy }]
+
+      expect(result).to eq(expected_result)
+    end
+  end
+
+  context 'Given some checkers are unhealthy' do
+    let(:aws_route53_gateway) { FakeUnHealthyRoute53Gateway.new }
+    let(:ips) { ['123.123.123.123'] }
+
+    it 'returns an unhealthy status' do
+      expected_result = [{ ip: '123.123.123.123', status: :unhealthy }]
+
+      expect(result).to eq(expected_result)
+    end
+  end
+
+  context 'No health checks found' do
+    let(:ips) { [] }
+    it 'finds no health checks' do
+      expect(result).to be_empty
+    end
+  end
+
+  it 'calls .get_health_check_status on the gateway' do
+    aws_route53_gateway = spy
+    described_class.new(route53_gateway: aws_route53_gateway).execute(ips: ['111.111.111.111'])
+
+    expect(aws_route53_gateway).to have_received(:get_health_check_status).once
+  end
+end


### PR DESCRIPTION
This introduces the Aws SDK for Route53.
The process of establishing whether an IP is healthy requires 2 steps:
  - Get healthcheck Id for that IP, excluding the latency health check
  - Do another API request to establish whether the health check is
  healthy based on the 6 health checkers associated with it

This doesn't display it on the view yet.
There is a failing feature spec for this that isn't a part of this PR.

This creates the use cases and wraps tests around them with fake AWS
gateways.