### PR TITLE
Get Route53 Healthchecks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem 'aws-sdk-route53', '~> 1.0.0.rc13'
 gem 'devise', '~> 4.5.0'
 gem 'devise_invitable', '~> 1.7.0'
 gem 'mysql2', '~> 0.5.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,17 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
+    aws-eventstream (1.0.1)
+    aws-partitions (1.102.0)
+    aws-sdk-core (3.24.1)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-route53 (1.0.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.3)
     bcrypt (3.1.12)
     builder (3.2.3)
     byebug (10.0.2)
@@ -88,6 +99,7 @@ GEM
       scss_lint
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
+    jmespath (1.4.0)
     jwt (2.1.0)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -227,6 +239,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-route53 (~> 1.0.0.rc13)
   byebug (~> 10)
   capybara
   capybara-screenshot

--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -1,0 +1,12 @@
+class HealthChecksController < ApplicationController
+  def index
+    london_ips = ENV.fetch('LONDON_RADIUS_IPS').split(',')
+    dublin_ips = ENV.fetch('DUBLIN_RADIUS_IPS').split(',')
+
+    health_checks_fetcher_use_case = UseCases::Administrator::HealthChecks::Fetcher.new(ips: london_ips + dublin_ips)
+
+    @health_checks = UseCases::Administrator::HealthChecks::CalculateHealth.new(
+      health_checks_fetcher: health_checks_fetcher_use_case
+    ).execute
+  end
+end

--- a/app/views/health_checks/index.html.erb
+++ b/app/views/health_checks/index.html.erb
@@ -1,0 +1,5 @@
+Health Checks
+
+<% @health_checks.each do |health_check| %>
+   <%= health_check.fetch(:ip_address) %> <%= health_check.fetch(:status) %>
+<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,5 +54,6 @@ Rails.application.configure do
   config.action_mailer.default :charset => "utf-8"
 
   config.force_ssl = false
+  config.aws_config = { stub_responses: true }
 end
 ActionMailer::Base.perform_deliveries = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,6 +35,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.action_mailer.default_url_options = { host: "example.com" }
+  config.aws_config = { stub_responses: true }
 end
 
 ActionMailer::Base.delivery_method = :test

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,6 @@ Rails.application.routes.draw do
     get 'users/confirmations/pending', to: 'users/confirmations#pending'
   end
 
-  get '/healthcheck', to: 'monitoring#healthcheck'
-
+  resources :health_checks, only: [:index]
   resources :ips, only: [:index, :new, :create, :show]
 end

--- a/lib/gateways/route53.rb
+++ b/lib/gateways/route53.rb
@@ -1,0 +1,25 @@
+module Gateways
+  class Route53
+    def initialize
+      @client = Aws::Route53::Client.new(config)
+    end
+
+    def list_health_checks
+      client.list_health_checks
+    end
+
+    def get_health_check_status(id:)
+      client.get_health_check_status(health_check_id: id)
+    end
+
+  private
+
+    DEFAULT_REGION = 'eu-west-2'.freeze
+
+    attr_reader :client
+
+    def config
+      { region: DEFAULT_REGION }.merge(Rails.application.config.aws_config)
+    end
+  end
+end

--- a/lib/use_cases/administrator/health_checks/calculate_health.rb
+++ b/lib/use_cases/administrator/health_checks/calculate_health.rb
@@ -1,0 +1,40 @@
+module UseCases
+  module Administrator
+    module HealthChecks
+      class CalculateHealth
+        def initialize(route53_gateway: Gateways::Route53.new, health_checks_fetcher:)
+          @route53_gateway = route53_gateway
+          @health_checks_fetcher = health_checks_fetcher
+        end
+
+        def execute
+          health_checks_fetcher.execute.map do |health_check_ip_and_id|
+            ip = health_check_ip_and_id.fetch(:ip_address)
+            id = health_check_ip_and_id.fetch(:id)
+
+            {
+              ip: ip,
+              status: status(route53_gateway.get_health_check_status(health_check_id: id))
+            }
+          end
+        end
+
+      private
+
+        SUCCESS_STATUS = 'Success: HTTP Status Code 200, OK'.freeze
+
+        def status(health_check)
+          all_health_checkers_healthy?(health_check) ? :healthy : :unhealthy
+        end
+
+        def all_health_checkers_healthy?(health_check)
+          health_check.health_check_observations.all? do |a|
+            a.status_report.status == SUCCESS_STATUS
+          end
+        end
+
+        attr_reader :health_checks_fetcher, :route53_gateway
+      end
+    end
+  end
+end

--- a/lib/use_cases/administrator/health_checks/fetcher.rb
+++ b/lib/use_cases/administrator/health_checks/fetcher.rb
@@ -1,0 +1,39 @@
+module UseCases
+  module Administrator
+    module HealthChecks
+      class Fetcher
+        def initialize(route53_gateway: Gateways::Route53.new, ips:)
+          @route53_gateway = route53_gateway
+          @ips = ips
+        end
+
+        def execute
+          result = route53_gateway.list_health_checks.health_checks
+
+          with_ips(ips, without_latency_health_checks(result)).compact
+        end
+
+      private
+
+        attr_reader :route53_gateway, :ips
+
+        def with_ips(ips, health_checks)
+          health_checks.map do |health_check|
+            if ips.include?(health_check.health_check_config.ip_address)
+              {
+                ip_address: health_check.health_check_config.ip_address,
+                id: health_check.id
+              }
+            end
+          end
+        end
+
+        def without_latency_health_checks(health_checks)
+          health_checks.reject do |hc|
+            hc.health_check_config.measure_latency == true
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/health_checks/view_health_checks_spec.rb
+++ b/spec/features/health_checks/view_health_checks_spec.rb
@@ -1,0 +1,37 @@
+require 'features/support/not_signed_in'
+require 'features/support/sign_up_helpers'
+require 'support/notifications_service'
+require 'support/confirmation_use_case'
+
+describe 'View Health Checks' do
+  include_examples 'confirmation use case spy'
+  include_examples 'notifications service'
+
+  context 'when logged out' do
+    before do
+      visit health_checks_path
+    end
+
+    it_behaves_like 'not signed in'
+  end
+
+  context 'when logged in' do
+    let(:user) { create(:user) }
+
+    before do
+      allow_any_instance_of(
+        UseCases::Administrator::HealthChecks::CalculateHealth
+      ).to receive(:execute).and_return(
+        [ip_address: '111.111.111.111', status: :healthy]
+      )
+
+      sign_in_user user
+      visit health_checks_path
+    end
+
+    it 'allows viewing the health checks' do
+      expect(page).to have_content('Health Checks')
+      expect(page).to have_content('111.111.111.111')
+    end
+  end
+end

--- a/spec/gateways/route53_spec.rb
+++ b/spec/gateways/route53_spec.rb
@@ -1,0 +1,9 @@
+describe Gateways::Route53 do
+  it '.list_health_checks' do
+    expect(subject.list_health_checks.health_checks).to be_empty
+  end
+
+  it '.get_health_check_status' do
+    expect(subject.get_health_check_status(id: 'abc').health_check_observations).to be_empty
+  end
+end

--- a/spec/monitoring/healthcheck_spec.rb
+++ b/spec/monitoring/healthcheck_spec.rb
@@ -1,8 +1,0 @@
-require_relative '../rails_helper'
-
-describe 'healthcheck', type: :request do
-  it 'responds successfully' do
-    get '/healthcheck'
-    expect(response).to be_successful
-  end
-end

--- a/spec/use_cases/administrator/health_check/calculate_health_spec.rb
+++ b/spec/use_cases/administrator/health_check/calculate_health_spec.rb
@@ -1,0 +1,119 @@
+class FakeHealthyRoute53Gateway
+  def get_health_check_status(health_check_id:)
+    client = Aws::Route53::Client.new(stub_responses: true)
+
+    client.stub_responses(:get_health_check_status,
+      health_check_observations:
+        [
+          {
+            region: 'ap-southeast-2',
+            ip_address: '39.239.222.111',
+            status_report: {
+              status: 'Success: HTTP Status Code 200, OK'
+            }
+          }, {
+            region: 'ap-eu-west-1',
+            ip_address: '27.111.39.33',
+            status_report: {
+              status: 'Success: HTTP Status Code 200, OK'
+            }
+          }
+        ])
+
+    client.get_health_check_status(health_check_id: health_check_id)
+  end
+end
+
+class FakeUnHealthyRoute53Gateway
+  def get_health_check_status(health_check_id:)
+    client = Aws::Route53::Client.new(stub_responses: true)
+
+    client.stub_responses(:get_health_check_status,
+      health_check_observations:
+        [
+          {
+            region: 'ap-southeast-2',
+            ip_address: '39.239.222.111',
+            status_report: {
+              status: 'Failure: HTTP Status Code 500, Host Unreachable'
+            }
+          }, {
+            region: 'ap-eu-west-1',
+            ip_address: '27.111.39.33',
+            status_report: {
+              status: 'Success: HTTP Status Code 200, OK'
+            }
+          }
+        ])
+
+    client.get_health_check_status(health_check_id: health_check_id)
+  end
+end
+
+class FakeEmptyHealthCheckIdsUseCase
+  def execute
+    []
+  end
+end
+
+class FakeHealthCheckIdsUseCase
+  def execute
+    [
+      { ip_address: '123.123.123.123', id: 'abc123' }
+    ]
+  end
+end
+
+describe UseCases::Administrator::HealthChecks::CalculateHealth do
+  let(:aws_route53_gateway) { FakeHealthyRoute53Gateway.new }
+  let(:health_checks_fetcher) { FakeHealthCheckIdsUseCase.new }
+
+  let(:result) do
+    described_class.new(
+      route53_gateway: aws_route53_gateway,
+      health_checks_fetcher: health_checks_fetcher
+    ).execute
+  end
+
+  context 'Given checks are healthy' do
+    it 'returns healthy if all health checkers are healthy' do
+      expected_result = [{ ip: '123.123.123.123', status: :healthy }]
+
+      expect(result).to eq(expected_result)
+    end
+  end
+
+  context 'Given some checks have not passed' do
+    let(:aws_route53_gateway) { FakeUnHealthyRoute53Gateway.new }
+
+    it 'returns healthy if all health checkers are healthy' do
+      expected_result = [
+        { ip: '123.123.123.123', status: :unhealthy }
+      ]
+
+      expect(result).to eq(expected_result)
+    end
+  end
+
+  context 'No health checks found' do
+    let(:health_checks_fetcher) { FakeEmptyHealthCheckIdsUseCase.new }
+
+    it 'returns an empty list if no health check ids are supplied' do
+      expect(result).to be_empty
+    end
+  end
+
+
+  it 'calls .execute on the gateway' do
+    aws_route53_gateway = spy
+    health_checks_fetcher = FakeHealthCheckIdsUseCase.new
+    described_class.new(
+      route53_gateway: aws_route53_gateway,
+      health_checks_fetcher: health_checks_fetcher
+    ).execute
+
+    expect(aws_route53_gateway).to have_received(:get_health_check_status)
+      .with(health_check_id: 'abc123')
+      .once
+  end
+end

--- a/spec/use_cases/administrator/health_check/fetcher_spec.rb
+++ b/spec/use_cases/administrator/health_check/fetcher_spec.rb
@@ -1,0 +1,107 @@
+
+class FakeRoute53Gateway
+  def list_health_checks
+    client = Aws::Route53::Client.new(
+      stub_responses: {
+        list_health_checks: {
+          max_items: 10,
+          marker: 'PageMarker',
+          is_truncated: false,
+          health_checks: [
+            {
+              caller_reference: 'AdminMonitoring',
+              id: 'abc123',
+              health_check_version: 1,
+              health_check_config: {
+                ip_address: '52.91.79.12',
+                measure_latency: false,
+                type: 'HTTP',
+              }
+            }, {
+              caller_reference: 'AdminMonitoring',
+              id: 'xyz789',
+              health_check_version: 1,
+              health_check_config: {
+                ip_address: '53.54.89.98',
+                measure_latency: false,
+                type: 'HTTP',
+              }
+            }, {
+              caller_reference: 'AdminMonitoring',
+              id: 'zzzyyy',
+              health_check_version: 1,
+              health_check_config: {
+                ip_address: '111.111.111.111',
+                measure_latency: false,
+                type: 'HTTP',
+              }
+            }, {
+              caller_reference: 'AdminMonitoring',
+              id: 'latency123',
+              health_check_version: 1,
+              health_check_config: {
+                ip_address: '777.777.777.777',
+                measure_latency: true,
+                type: 'HTTP',
+              }
+            }
+          ]
+        }
+      }
+    )
+
+    client.list_health_checks
+  end
+end
+
+describe UseCases::Administrator::HealthChecks::Fetcher do
+  let(:result) { described_class.new(route53_gateway: aws_route53_gateway, ips: ips).execute }
+  let(:aws_route53_gateway) { FakeRoute53Gateway.new }
+
+  it 'calls .list_health_checks on the gateway' do
+    aws_route53_gateway = spy
+    described_class.new(route53_gateway: aws_route53_gateway, ips: []).execute
+    expect(aws_route53_gateway).to have_received(:list_health_checks)
+  end
+
+  context 'given a list of empty IP addresses' do
+    let(:ips) { [] }
+
+    it 'finds no results' do
+      expect(result).to be_empty
+    end
+  end
+
+  context 'Given IP addresses' do
+    context 'Given 1 IP address' do
+      let(:ips) { ['52.91.79.12'] }
+
+      it 'finds one health check id' do
+        expect(result).to eq(
+          [
+            { ip_address: '52.91.79.12', id: 'abc123' }
+          ]
+        )
+      end
+    end
+
+    context 'Given multiple IP addresses' do
+      let(:ips) { ['52.91.79.12', '53.54.89.98'] }
+
+      it 'finds multiple health check ids' do
+        expect(result).to eq([
+          { ip_address: '52.91.79.12', id: 'abc123' },
+          { ip_address: '53.54.89.98', id: 'xyz789' }
+        ])
+      end
+    end
+
+    context 'Given the IP of a latency health check' do
+      let(:ips) { ['777.777.777.777'] }
+
+      it 'returns no health check ids' do
+        expect(result).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
This introduces the Aws SDK for Route53.
The process of establishing whether an IP is healthy requires 2 steps:
  - Get healthcheck Id for that IP, excluding the latency health check
  - Do another API request to establish whether the health check is
  healthy based on the 6 health checkers associated with it

This doesn't display it on the view yet.
There is a failing feature spec for this that isn't a part of this PR.

This creates the use cases and wraps tests around them with fake AWS
gateways.