### PR TITLE
Handle unconfirmed users resetting passwords

### DIFF
--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -17,7 +17,9 @@ class AuthenticationMailer < ::Devise::Mailer
   end
 
   # Overrides https://github.com/plataformatec/devise/blob/master/app/mailers/devise/mailer.rb#L12
-  def reset_password_instructions(record, token, _opts = {})
+  def reset_password_instructions(record, token, opts = {})
+    confirmation_instructions(record, record.confirmation_token, opts) unless record.confirmed?
+
     reset_link = edit_password_url(record, reset_password_token: token)
     template_id = GOV_NOTIFY_CONFIG['reset_password_email']['template_id']
 

--- a/spec/features/reset_password_spec.rb
+++ b/spec/features/reset_password_spec.rb
@@ -1,6 +1,8 @@
 require 'support/notifications_service'
 require 'support/reset_password_use_case_spy'
 require 'support/reset_password_use_case'
+require 'support/confirmation_use_case_spy'
+require 'support/confirmation_use_case'
 require 'features/support/errors_in_form'
 
 describe "Resetting a password" do
@@ -26,6 +28,24 @@ describe "Resetting a password" do
 
     it "tells the user the email cannot be found" do
       expect(page).to have_content("Email not found")
+    end
+  end
+
+  context "when user is not yet confirmed" do
+    include_examples 'confirmation use case spy'
+    include_examples 'notifications service'
+
+    let(:user) { create(:user) }
+
+    it "sends the confirmation instructions instead of reset password" do
+      visit new_user_password_path
+      fill_in "user_email", with: user.email
+
+      expect {
+        click_on "Send me reset password instructions"
+      }.to change { ConfirmationUseCaseSpy.confirmations_count }.by(1)
+
+      expect(page).to have_content("You will receive an email with instructions")
     end
   end
 


### PR DESCRIPTION
Unconfirmed users don't have names set yet so
going through reset password flow will yield
errors about missing name.

To fix that, we re-send confirmation email if you
are unconfirmed user who wants to reset your password.