### PR TITLE
Display health checks to the user

### DIFF
--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -1,0 +1,8 @@
+class HealthChecksController < ApplicationController
+  def index
+    london_ips = ENV.fetch('LONDON_RADIUS_IPS').split(',')
+    dublin_ips = ENV.fetch('DUBLIN_RADIUS_IPS').split(',')
+
+    @health_checks = UseCases::Administrator::HealthChecks::CalculateHealth.new.execute(ips: london_ips + dublin_ips)
+  end
+end

--- a/app/views/health_checks/index.html.erb
+++ b/app/views/health_checks/index.html.erb
@@ -1,0 +1,5 @@
+Health Checks
+
+<% @health_checks.each do |health_check| %>
+   <%= health_check.fetch(:ip_address) %> <%= health_check.fetch(:status) %>
+<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,5 +54,55 @@ Rails.application.configure do
   config.action_mailer.default :charset => "utf-8"
 
   config.force_ssl = false
+  config.aws_config = {
+    stub_responses: {
+      get_health_check_status: {
+        health_check_observations: [
+          {
+            region: 'ap-southeast-2',
+            ip_address: '39.239.222.111',
+            status_report: {
+              status: 'Success: HTTP Status Code 200, OK'
+            }
+          }
+        ]
+      }, list_health_checks: {
+          max_items: 10,
+          marker: 'PageMarker',
+          is_truncated: false,
+          health_checks: [
+            {
+              caller_reference: 'AdminMonitoring',
+              id: 'abc123',
+              health_check_version: 1,
+              health_check_config: {
+                ip_address: '111.111.111.111',
+                measure_latency: false,
+                type: 'HTTP',
+              }
+            }, {
+              caller_reference: 'AdminMonitoring',
+              id: 'xyz789',
+              health_check_version: 1,
+              health_check_config: {
+                ip_address: '222.222.222.222',
+                measure_latency: false,
+                type: 'HTTP',
+              }
+            }, {
+              caller_reference: 'AdminMonitoring',
+              id: 'latency123',
+              health_check_version: 1,
+              health_check_config: {
+                ip_address: '777.777.777.777',
+                measure_latency: true,
+                type: 'HTTP',
+              }
+            }
+          ]
+        }
+    }
+  }
+
 end
 ActionMailer::Base.perform_deliveries = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,6 +35,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.action_mailer.default_url_options = { host: "example.com" }
+  config.aws_config = { stub_responses: true }
 end
 
 ActionMailer::Base.delivery_method = :test

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,6 @@ Rails.application.routes.draw do
   end
 
   get '/healthcheck', to: 'monitoring#healthcheck'
-
+  resources :health_checks, only: [:index]
   resources :ips, only: [:index, :new, :create, :show]
 end

--- a/lib/gateways/route53.rb
+++ b/lib/gateways/route53.rb
@@ -1,0 +1,25 @@
+module Gateways
+  class Route53
+    def initialize
+      @client = Aws::Route53::Client.new(config)
+    end
+
+    def list_health_checks
+      client.list_health_checks
+    end
+
+    def get_health_check_status(health_check_id:)
+      client.get_health_check_status(health_check_id: health_check_id)
+    end
+
+  private
+
+    DEFAULT_REGION = 'eu-west-2'.freeze
+
+    attr_reader :client
+
+    def config
+      { region: DEFAULT_REGION }.merge(Rails.application.config.aws_config)
+    end
+  end
+end

--- a/lib/use_cases/administrator/health_checks/calculate_health.rb
+++ b/lib/use_cases/administrator/health_checks/calculate_health.rb
@@ -2,7 +2,7 @@ module UseCases
   module Administrator
     module HealthChecks
       class CalculateHealth
-        def initialize(route53_gateway:)
+        def initialize(route53_gateway: Gateways::Route53.new)
           @route53_gateway = route53_gateway
         end
 
@@ -22,7 +22,7 @@ module UseCases
           return if health_check.nil?
 
           {
-            ip: health_check.health_check_config.ip_address,
+            ip_address: health_check.health_check_config.ip_address,
             status: status(route53_gateway.get_health_check_status(health_check_id: health_check.id))
           }
         end

--- a/spec/features/health_checks/view_health_checks_spec.rb
+++ b/spec/features/health_checks/view_health_checks_spec.rb
@@ -1,0 +1,32 @@
+require 'features/support/not_signed_in'
+require 'features/support/sign_up_helpers'
+
+describe 'View Health Checks' do
+  context 'when logged out' do
+    before do
+      visit health_checks_path
+    end
+
+    it_behaves_like 'not signed in'
+  end
+
+  context 'when logged in' do
+    let(:user) { create(:user, :confirmed, :with_organisation) }
+
+    before do
+      allow_any_instance_of(
+        UseCases::Administrator::HealthChecks::CalculateHealth
+      ).to receive(:execute).and_return(
+        [ip_address: '111.111.111.111', status: :healthy]
+      )
+
+      sign_in_user user
+      visit health_checks_path
+    end
+
+    it 'allows viewing the health checks' do
+      expect(page).to have_content('Health Checks')
+      expect(page).to have_content('111.111.111.111')
+    end
+  end
+end

--- a/spec/gateways/route53_spec.rb
+++ b/spec/gateways/route53_spec.rb
@@ -1,0 +1,9 @@
+describe Gateways::Route53 do
+  it '.list_health_checks' do
+    expect(subject.list_health_checks.health_checks).to be_empty
+  end
+
+  it '.get_health_check_status' do
+    expect(subject.get_health_check_status(health_check_id: 'abc').health_check_observations).to be_empty
+  end
+end

--- a/spec/use_cases/administrator/health_check/calculate_health_spec.rb
+++ b/spec/use_cases/administrator/health_check/calculate_health_spec.rb
@@ -126,8 +126,8 @@ describe UseCases::Administrator::HealthChecks::CalculateHealth do
 
     it 'returns healthy if all health checkers are healthy' do
       expected_result = [
-        { ip: '111.111.111.111', status: :healthy },
-        { ip: '222.222.222.222', status: :healthy }
+        { ip_address: '111.111.111.111', status: :healthy },
+        { ip_address: '222.222.222.222', status: :healthy }
       ]
 
       expect(result).to eq(expected_result)
@@ -138,7 +138,7 @@ describe UseCases::Administrator::HealthChecks::CalculateHealth do
     let(:ips) { ['777.777.777.777', '111.111.111.111'] }
 
     it 'returns healthy if all health checkers are healthy' do
-      expected_result = [{ ip: '111.111.111.111', status: :healthy }]
+      expected_result = [{ ip_address: '111.111.111.111', status: :healthy }]
 
       expect(result).to eq(expected_result)
     end
@@ -149,7 +149,7 @@ describe UseCases::Administrator::HealthChecks::CalculateHealth do
     let(:ips) { ['123.123.123.123'] }
 
     it 'returns an unhealthy status' do
-      expected_result = [{ ip: '123.123.123.123', status: :unhealthy }]
+      expected_result = [{ ip_address: '123.123.123.123', status: :unhealthy }]
 
       expect(result).to eq(expected_result)
     end


### PR DESCRIPTION
This is unstyled, but uses the use cases created in the previous pr.
We won't be displaying actual health checks in development, so this is
stubbed out in config/environments/development.rb