### PR TITLE
Don't filter out latency health checks

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -89,15 +89,6 @@ Rails.application.configure do
                 measure_latency: false,
                 type: 'HTTP',
               }
-            }, {
-              caller_reference: 'AdminMonitoring',
-              id: 'latency123',
-              health_check_version: 1,
-              health_check_config: {
-                ip_address: '777.777.777.777',
-                measure_latency: true,
-                type: 'HTTP',
-              }
             }
           ]
         }

--- a/lib/use_cases/administrator/health_checks/calculate_health.rb
+++ b/lib/use_cases/administrator/health_checks/calculate_health.rb
@@ -28,7 +28,7 @@ module UseCases
         end
 
         def health_check_for_ip(ip)
-          non_latency_health_checks.find do |health_check|
+          health_checks.find do |health_check|
             health_check.health_check_config.ip_address == ip
           end
         end
@@ -43,13 +43,7 @@ module UseCases
           end
         end
 
-        def non_latency_health_checks
-          all_health_checks.reject do |hc|
-            hc.health_check_config.measure_latency == true
-          end
-        end
-
-        def all_health_checks
+        def health_checks
           @health_checks ||= route53_gateway.list_health_checks.health_checks
         end
       end

--- a/spec/use_cases/administrator/health_check/calculate_health_spec.rb
+++ b/spec/use_cases/administrator/health_check/calculate_health_spec.rb
@@ -49,15 +49,6 @@ class FakeHealthyRoute53Gateway
                 measure_latency: false,
                 type: 'HTTP',
               }
-            }, {
-              caller_reference: 'AdminMonitoring',
-              id: 'latency123',
-              health_check_version: 1,
-              health_check_config: {
-                ip_address: '777.777.777.777',
-                measure_latency: true,
-                type: 'HTTP',
-              }
             }
           ]
         }
@@ -129,16 +120,6 @@ describe UseCases::Administrator::HealthChecks::CalculateHealth do
         { ip_address: '111.111.111.111', status: :healthy },
         { ip_address: '222.222.222.222', status: :healthy }
       ]
-
-      expect(result).to eq(expected_result)
-    end
-  end
-
-  context 'Given a latency health check' do
-    let(:ips) { ['777.777.777.777', '111.111.111.111'] }
-
-    it 'returns healthy if all health checkers are healthy' do
-      expected_result = [{ ip_address: '111.111.111.111', status: :healthy }]
 
       expect(result).to eq(expected_result)
     end


### PR DESCRIPTION
There is no need to filter out latency health checks as they are
actually just an attribute on a regular health check.

This was missed due to changes between staging and production route53
health checks setup.