### PR TITLE
Display "healthy" or "unhealthy" along with the icon

### DIFF
--- a/app/views/status/_result.html.erb
+++ b/app/views/status/_result.html.erb
@@ -2,7 +2,7 @@
   <h2 class="govuk-heading-m"><%= region %></h2>
   <ul class="govuk-list">
     <% health_checks.each do |health_check| %>
-      <li><div class="health-check-status health-check-<%= health_check.fetch(:status) %>">&nbsp;</div> <%= health_check.fetch(:ip_address) %></li>
+      <li><div class="health-check-status health-check-<%= health_check.fetch(:status) %>">&nbsp;</div><%= health_check.fetch(:status).capitalize %> - <strong><%= health_check.fetch(:ip_address) %></strong></li>
     <% end %>
   </ul>
 </div>


### PR DESCRIPTION
For accessibility we can't rely on just the colour of the status icon.
Print the status next to the icon as well.

<img width="1041" alt="screen shot 2018-08-30 at 12 16 55" src="https://user-images.githubusercontent.com/1215147/44848431-a1655780-ac4e-11e8-9a97-39bfe496c0fa.png">
