### PR TITLE
Reword healthy/unhealthy to operational/offline

### DIFF
--- a/lib/use_cases/administrator/health_checks/calculate_health.rb
+++ b/lib/use_cases/administrator/health_checks/calculate_health.rb
@@ -34,7 +34,7 @@ module UseCases
         end
 
         def status(health_check)
-          all_health_checkers_healthy?(health_check) ? :healthy : :unhealthy
+          all_health_checkers_healthy?(health_check) ? :operational : :offline
         end
 
         def all_health_checkers_healthy?(health_check)

--- a/spec/features/status/view_status_spec.rb
+++ b/spec/features/status/view_status_spec.rb
@@ -17,7 +17,7 @@ describe 'View GovWifi Status' do
       allow_any_instance_of(
         UseCases::Administrator::HealthChecks::CalculateHealth
       ).to receive(:execute).and_return(
-        [ip_address: '111.111.111.111', status: :healthy]
+        [ip_address: '111.111.111.111', status: :operational]
       )
 
       sign_in_user user

--- a/spec/use_cases/administrator/health_check/calculate_health_spec.rb
+++ b/spec/use_cases/administrator/health_check/calculate_health_spec.rb
@@ -115,10 +115,10 @@ describe UseCases::Administrator::HealthChecks::CalculateHealth do
   context 'Given health checkers are healthy' do
     let(:ips) { ['111.111.111.111', '222.222.222.222'] }
 
-    it 'returns healthy if all health checkers are healthy' do
+    it 'returns operational if all health checkers are healthy' do
       expected_result = [
-        { ip_address: '111.111.111.111', status: :healthy },
-        { ip_address: '222.222.222.222', status: :healthy }
+        { ip_address: '111.111.111.111', status: :operational },
+        { ip_address: '222.222.222.222', status: :operational }
       ]
 
       expect(result).to eq(expected_result)
@@ -129,8 +129,8 @@ describe UseCases::Administrator::HealthChecks::CalculateHealth do
     let(:aws_route53_gateway) { FakeUnHealthyRoute53Gateway.new }
     let(:ips) { ['123.123.123.123'] }
 
-    it 'returns an unhealthy status' do
-      expected_result = [{ ip_address: '123.123.123.123', status: :unhealthy }]
+    it 'returns an offline status' do
+      expected_result = [{ ip_address: '123.123.123.123', status: :offline }]
 
       expect(result).to eq(expected_result)
     end


### PR DESCRIPTION
Improve wording on the GovWifi status page.