### PR TITLE
Validate password_confirmation at the model

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -6,10 +6,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
 
   def update
     with_unconfirmed_confirmable do
-      if user_params[:password] != user_params[:password_confirmation]
-        @confirmable.errors.add(:password, "must match confirmation")
-        render_show_page
-      elsif @confirmable.update(user_params)
+      if @confirmable.update(user_params)
         confirm_user
       else
         render_show_page

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,14 +12,6 @@ class User < ApplicationRecord
   validate :email_on_whitelist
   validates :name, presence: true, on: :update
 
-  def update_details(params)
-    unless params[:password] == params[:password_confirmation]
-      errors.add(:password, "must match confirmation") && return
-    end
-
-    update(password: params[:password], name: params[:name])
-  end
-
   def only_if_unconfirmed
     pending_any_confirmation { yield }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,9 +8,12 @@ class User < ApplicationRecord
 
   before_create :reset_confirmation_token, :set_radius_secret_key
 
-  validates_confirmation_of :password
-  validate :email_on_whitelist
   validates :name, presence: true, on: :update
+
+  validates :password, confirmation: true, on: :update
+  validates :password_confirmation, presence: true, on: :update
+
+  validate :email_on_whitelist
 
   def only_if_unconfirmed
     pending_any_confirmation { yield }

--- a/app/views/users/confirmations/show.html.erb
+++ b/app/views/users/confirmations/show.html.erb
@@ -20,16 +20,14 @@
           <%= f.text_field :name, class: "govuk-input", required: true %>
         </div>
 
-        <div class="<%= field_error(resource, :password) %>">
-          <div class="govuk-form-group ">
-            <%= f.label :password, "Password", class: "govuk-label" %>
-            <%= f.password_field :password, class: "govuk-input", autocomplete: "off", required: true %>
-          </div>
+        <div class="govuk-form-group <%= field_error(resource, :password) %>">
+          <%= f.label :password, "Password", class: "govuk-label" %>
+          <%= f.password_field :password, class: "govuk-input", autocomplete: "off", required: true %>
+        </div>
 
-          <div class="govuk-form-group">
-            <%= f.label :password_confirmation, "Confirm password", class: "govuk-label" %>
-            <%= f.password_field :password_confirmation, class: "govuk-input", autocomplete: "off", required: true %>
-          </div>
+        <div class="govuk-form-group <%= field_error(resource, :password_confirmation) %>">
+          <%= f.label :password_confirmation, "Confirm password", class: "govuk-label" %>
+          <%= f.password_field :password_confirmation, class: "govuk-input", autocomplete: "off", required: true %>
         </div>
 
         <div class="actions">

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -8,16 +8,14 @@
       <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
         <%= f.hidden_field :reset_password_token %>
 
-        <div class="<%= field_error(resource, :password) %>">
-          <div class="govuk-form-group">
-            <%= f.label :password, "New password", class: "govuk-label" %>
-            <%= f.password_field :password, autofocus: true, class: "govuk-input", autocomplete: "off", required: true %>
-          </div>
+        <div class="govuk-form-group <%= field_error(resource, :password) %>">
+          <%= f.label :password, "New password", class: "govuk-label" %>
+          <%= f.password_field :password, autofocus: true, class: "govuk-input", autocomplete: "off", required: true %>
+        </div>
 
-          <div class="govuk-form-group">
-            <%= f.label :password_confirmation, "Confirm new password", class: "govuk-label" %>
-            <%= f.password_field :password_confirmation, class: "govuk-input", autocomplete: "off", required: true %>
-          </div>
+        <div class="govuk-form-group <%= field_error(resource, :password_confirmation) %>">
+          <%= f.label :password_confirmation, "Confirm new password", class: "govuk-label" %>
+          <%= f.password_field :password_confirmation, class: "govuk-input", autocomplete: "off", required: true %>
         </div>
 
         <div class="actions">

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,9 +3,8 @@ FactoryBot.define do
     sequence :email do |n|
       "test#{n}@gov.uk"
     end
-    sequence :password do |n|
-      "#{n}123456#{n}"
-    end
+    password { '123456' }
+    password_confirmation { '123456' }
     name { "bob" }
 
     trait :confirmed do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,9 @@ FactoryBot.define do
     sequence :email do |n|
       "test#{n}@gov.uk"
     end
-    password { "123456" }
+    sequence :password do |n|
+      "#{n}123456#{n}"
+    end
     name { "bob" }
 
     trait :confirmed do

--- a/spec/features/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/sign_up_as_an_organisation_spec.rb
@@ -75,7 +75,7 @@ describe 'Sign up as an organisation' do
     it_behaves_like 'errors in form'
 
     it 'tells the user that the passwords do not match' do
-      expect(page).to have_content 'Password must match confirmation'
+      expect(page).to have_content "Password confirmation doesn't match Password"
     end
   end
 
@@ -155,7 +155,7 @@ describe 'Sign up as an organisation' do
     it_behaves_like 'errors in form'
 
     it 'correctly sets the second error' do
-      expect(page).to have_content 'Password must match confirmation'
+      expect(page).to have_content "Password confirmation doesn't match Password"
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,7 +32,7 @@ describe User do
         end
       end
 
-      context 'when password confirmation is not present' do
+      context 'when password confirmation is missing' do
         let(:params) { { password: 'new_password', name: "New name" } }
 
         it 'should not set the users password' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,7 +8,7 @@ describe User do
     it { should validate_presence_of(:name).on(:update) }
 
     describe "password and password confirmation must match" do
-      let!(:user) { create(:user, :confirmed, name: "Old name") }
+      let(:user) { create(:user, :confirmed, name: "Old name") }
       before do
         user.update(params)
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,47 +1,44 @@
-require 'support/notifications_service'
-
 describe User do
-  include_examples 'notifications service'
-
   context 'associations' do
     it { should have_many(:ips) }
     it { should belong_to(:organisation) }
   end
 
-  describe '#update_details' do
-    let(:user) { create(:user, password: 'password') }
-    context 'when passwords match' do
-      let(:params) { { password: '123456', password_confirmation: '123456', name: 'bob' } }
+  context 'validations' do
+    it { should validate_presence_of(:name).on(:update) }
 
-      it 'should set the users password' do
-        expect { user.update_details(params) }.to change(user, :password)
-        expect(user.errors.empty?).to eq(true)
+    describe "password and password confirmation must match" do
+      let(:user) { create(:user, :confirmed) }
+
+      context 'when passwords match' do
+        let(:params) { { password: 'new_password', password_confirmation: 'new_password' } }
+
+        it 'should set the users password' do
+          expect { user.update(params) }.to change(user, :password)
+          expect(user.errors.empty?).to eq(true)
+        end
       end
 
-      context 'Name validation' do
-        it { should validate_presence_of(:name).on(:update) }
-      end
-    end
-
-    context 'when passwords do not match' do
-      let(:params) { { password: '123456', password_confirmation: '1234567' } }
-      it 'should not set the users password' do
-        expect { user.update_details(params) }.to_not change(user, :password)
-        expect(user.errors.empty?).to eq(false)
-        expect(user.errors.full_messages).to eq(['Password must match confirmation'])
+      context 'when passwords do not match' do
+        let(:params) { { password: 'new_password', password_confirmation: 'other_password' } }
+        it 'should not set the users password' do
+          expect { user.update(params) }.to_not change(user, :password)
+          expect(user.errors.empty?).to eq(false)
+          expect(user.errors.full_messages).to eq(["Password confirmation doesn't match Password"])
+        end
       end
     end
   end
 
   describe '#save' do
-    subject { build(:user) }
+    subject { build(:user, :confirmed) }
 
     context 'with the factory-built model' do
       it { is_expected.to be_valid }
     end
 
     context 'with valid data' do
-      subject { build(:user, email: 'name@gov.uk') }
+      subject { build(:user, :confirmed, email: 'name@gov.uk') }
 
       it { is_expected.to be_valid }
 
@@ -55,7 +52,7 @@ describe User do
     end
 
     context 'with a non-gov.uk email' do
-      subject { build(:user, email: 'name@arbitrary-domain.com') }
+      subject { build(:user, :confirmed, email: 'name@arbitrary-domain.com') }
 
       it { is_expected.to_not be_valid }
 


### PR DESCRIPTION
Validates the password confirmation correctly at the model. Wasn't working correctly before so we were forcing the controllers to check the two fields matched.