### PR TITLE
Improve layout/messaging of IP Addresses page (+ other minor copy/layout tweaks across app)

### DIFF
--- a/app/controllers/ips_controller.rb
+++ b/app/controllers/ips_controller.rb
@@ -6,7 +6,7 @@ class IpsController < ApplicationController
   def create
     @ip = current_organisation.ips.new(ip_params)
     if @ip.save
-      flash[:notice] = 'IP Added: ' + @ip.address
+      flash[:notice] = "#{@ip.address} added, it will be active starting tomorrow"
       redirect_to ips_path(anchor: 'ips')
     else
       render :new

--- a/app/controllers/ips_controller.rb
+++ b/app/controllers/ips_controller.rb
@@ -6,8 +6,11 @@ class IpsController < ApplicationController
   def create
     @ip = current_organisation.ips.new(ip_params)
     if @ip.save
-      flash[:notice] = "#{@ip.address} added, it will be active starting tomorrow"
-      redirect_to ips_path(anchor: 'ips')
+      redirect_to(
+        ips_path,
+        anchor: 'ips',
+        notice: "#{@ip.address} added, it will be active starting tomorrow"
+      )
     else
       render :new
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,10 @@ class User < ApplicationRecord
     false
   end
 
+  def invitation_pending?
+    invitation_sent_at && !invitation_accepted?
+  end
+
 private
 
   def email_on_whitelist

--- a/app/views/ips/_activation_notice.html.erb
+++ b/app/views/ips/_activation_notice.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-inset-text">
   <h4 class="govuk-heading-s">New IPs are not immediately available</h4>
   <p class="govuk-body">
-    You can configure your access points now, but new IPs will not be activated until the next working day.
+    You can configure your access points now, but new IPs will not be activated until the next day.
   </p>
 </div>

--- a/app/views/ips/_radius_details.html.erb
+++ b/app/views/ips/_radius_details.html.erb
@@ -1,5 +1,5 @@
 <h3 class="govuk-heading-m"> Connecting to us </h3>
-<p class="govuk-body"> You'll need to configure your access point to contact our RADIUS servers, to authenticate your users. </p>
+<p class="govuk-body"> You need to configure your access point to contact our RADIUS servers. </p>
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -1,4 +1,4 @@
-<table class="govuk-table govuk-!-margin-top-7">
+<table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col">IP Address</th>

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -80,15 +80,12 @@
     <h2 class="govuk-heading-l">IP Addresses</h2>
     <% if @ips.empty? %>
       <p class="govuk-body">
-        You currently have no IPs configured for use with GovWifi. Find out <%= link_to "more", "#", class: "govuk-link" %>
+        You need to add the IPs of your access point(s)
       </p>
       <%= link_to "Add IP Address", new_ip_path, class: "govuk-button" %>
     <% else %>
-      <%= render "radius_details",
-        london_ips: @london_radius_ips,
-        dublin_ips: @dublin_radius_ips  %>
-      <%= link_to "Add IP Address", new_ip_path, class: "govuk-button govuk-!-margin-bottom-0" %>
       <%= render "ips/table", ips: @ips %>
+      <%= link_to "Add IP Address", new_ip_path, class: "govuk-button" %>
 
       <details class="govuk-details">
         <summary class="govuk-details__summary">
@@ -105,6 +102,10 @@
         </div>
       </details>
     <% end %>
+    <hr class="govuk-section-break--m govuk-section-break--visible">
+    <%= render "radius_details",
+      london_ips: @london_radius_ips,
+      dublin_ips: @dublin_radius_ips  %>
   </section>
 
    <section class="govuk-tabs__panel" id="team">

--- a/app/views/ips/new.html.erb
+++ b/app/views/ips/new.html.erb
@@ -16,7 +16,7 @@
         </div>
 
         <div class="actions">
-          <%= form.submit "Save", class: "govuk-button govuk-!-margin-top-4" %>
+          <%= form.submit "Add new IP Address", class: "govuk-button" %>
         </div>
       <% end %>
     </div>

--- a/app/views/team_members/_table.html.erb
+++ b/app/views/team_members/_table.html.erb
@@ -3,20 +3,21 @@
     <% team_members.each do |member| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell "><%= member.email %></td>
-        <td class="govuk-table__cell ">
-          <% if !member.invitation_sent_at.nil? && !member.invitation_accepted? %>
+        <% if member.invitation_pending? %>
+          <td class="govuk-table__cell ">
             Invitation pending
-          <% end %>
-        </td>
-        <td class="govuk-table__cell ">
-          <% if !member.invitation_sent_at.nil? && !member.invitation_accepted? %>
+          </td>
+          <td class="govuk-table__cell ">
             <%= button_to("Resend invite",
               user_invitation_path({ user: { email: member.email }}),
               method: :post,
               class: "govuk-button small-table-button")
             %>
-          <% end %>
-        </td>
+          </td>
+        <% else %>
+          <td class="govuk-table__cell " />
+          <td class="govuk-table__cell " />
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/team_members/_table.html.erb
+++ b/app/views/team_members/_table.html.erb
@@ -4,20 +4,19 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell "><%= member.email %></td>
         <td class="govuk-table__cell ">
-	  <% if !member.invitation_sent_at.nil? && !member.invitation_accepted? %>
-            invitation pending
-	  <% end %>
-	</td>
+          <% if !member.invitation_sent_at.nil? && !member.invitation_accepted? %>
+            Invitation pending
+          <% end %>
+        </td>
         <td class="govuk-table__cell ">
-	  <% if !member.invitation_sent_at.nil? && !member.invitation_accepted? %>
-	    <%= button_to(
-	      "resend invite",
+          <% if !member.invitation_sent_at.nil? && !member.invitation_accepted? %>
+            <%= button_to("Resend invite",
               user_invitation_path({ user: { email: member.email }}),
               method: :post,
-	      class: "govuk-button small-table-button")
-	    %>
-	  <% end %>
-	</td>
+              class: "govuk-button small-table-button")
+            %>
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -3,14 +3,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l">Resend confirmation instructions</h2>
-    <p class="govuk-body">
-      We are glad you would like to sign up your organisation for GovWifi.
-    </p>
 
     <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
       <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
         <div class="govuk-form-group <%= field_error(resource, :email) %>">
-          <%= f.label :email, "Provide your email address", class: "govuk-label" %><br />
+          <%= f.label :email, "Enter your email address", class: "govuk-label" %><br />
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input",
             value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), required: true %>
         </div>

--- a/spec/features/add_an_ip_address_spec.rb
+++ b/spec/features/add_an_ip_address_spec.rb
@@ -25,22 +25,18 @@ describe 'Add an IP to my account' do
     context 'and that IP is valid' do
       before do
         fill_in 'address', with: '10.0.0.1'
-        click_on 'Save'
+        click_on 'Add new IP Address'
       end
 
-      it 'shows a success message' do
-        expect(page).to have_content('IP Added')
-      end
-
-      it 'shows me the new IP' do
-        expect(page).to have_content('10.0.0.1')
+      it 'shows me the IP was added' do
+        expect(page).to have_content('10.0.0.1 added')
       end
 
       context 'when I add a second IP' do
         before do
           visit new_ip_path
           fill_in 'address', with: '10.0.0.2'
-          click_on 'Save'
+          click_on 'Add new IP Address'
         end
 
         it 'shows both new IPs' do
@@ -53,7 +49,7 @@ describe 'Add an IP to my account' do
     context 'and that IP is invalid' do
       before do
         fill_in 'address', with: '10.wrong.0.1'
-        click_on 'Save'
+        click_on 'Add new IP Address'
       end
 
       it_behaves_like 'errors in form'

--- a/spec/features/team/resend_invitation_spec.rb
+++ b/spec/features/team/resend_invitation_spec.rb
@@ -3,29 +3,29 @@ require 'support/invite_use_case_spy'
 require 'support/invite_use_case'
 require 'support/notifications_service'
 
-describe "Resend invitation to team member" do
-  context "resend invitation" do
+describe 'Resend invitation to team member' do
+  context 'resend invitation' do
     include_examples 'invite use case spy'
     include_examples 'notifications service'
 
     let(:user) { create(:user, :confirmed, :with_organisation) }
-    let(:invited_user_email) { "invited@gov.uk" }
+    let(:invited_user_email) { 'invited@gov.uk' }
 
     before do
       sign_in_user user
       invite_user(invited_user_email)
     end
 
-    it 'will have "invitation sent" text on team members page' do
-      expect(page).to have_content('invitation pending')
+    it 'shows that the invitation is pending' do
+      expect(page).to have_content('Invitation pending')
     end
 
-    it 'will send an invitation' do
-      expect { click_button("resend invite") }.to \
+    it 'sends an invitation' do
+      expect { click_button('Resend invite') }.to \
         change { InviteUseCaseSpy.invite_count }.by(1)
     end
 
-    context "signup from resent invitation" do
+    context 'signup from resent invitation' do
       let(:invite_link) { InviteUseCaseSpy.last_invite_url }
       let(:invited_user) { User.find_by(email: invited_user_email) }
 
@@ -33,22 +33,22 @@ describe "Resend invitation to team member" do
         visit invite_link
       end
 
-      it "displays the sign up page" do
-        expect(page).to have_content("Create your account")
+      it 'displays the sign up page' do
+        expect(page).to have_content('Create your account')
       end
 
-      context "signing up as an invited user" do
+      context 'signing up as an invited user' do
         before do
-          fill_in "Your name", with: "Ron Swanson"
-          fill_in "Password", with: "password"
-          fill_in "Confirm password", with: "password"
-          click_on "Create my account"
+          fill_in 'Your name', with: 'Ron Swanson'
+          fill_in 'Password', with: 'password'
+          fill_in 'Confirm password', with: 'password'
+          click_on 'Create my account'
         end
 
-        it "confirms the user" do
+        it 'confirms the user' do
           expect(invited_user.confirmed?).to eq(true)
-          expect(invited_user.name).to eq("Ron Swanson")
-          expect(page).to have_content("Logout")
+          expect(invited_user.name).to eq('Ron Swanson')
+          expect(page).to have_content('Logout')
           expect(page).to have_content(user.organisation.name)
         end
       end

--- a/spec/features/view_ip_addresses_spec.rb
+++ b/spec/features/view_ip_addresses_spec.rb
@@ -26,13 +26,7 @@ describe 'View all my IP addresses' do
 
       it 'shows there are no IPs' do
         expect(page).to have_content 'Add IP'
-        expect(page).to have_content 'You currently have no IPs configured for use with GovWifi'
-      end
-
-      it 'does not show RADIUS settings' do
-        expect(page).to_not have_content('RADIUS')
-        expect(page).to_not have_content('London')
-        expect(page).to_not have_content('Dublin')
+        expect(page).to have_content 'You need to add the IPs of your access point'
       end
     end
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/429326/44985453-59a93d80-af78-11e8-9982-c3c853ba9452.png)

![image](https://user-images.githubusercontent.com/429326/44986413-8a3ea680-af7b-11e8-9064-3e1d41b8e47d.png)


This PR separates out the "add an IP" and "configure your access points" tasks a little better. Planning to move them to separate screens in the near-future, based on Anna/Constance's feedback.

Adds a warning about IPs not being immediately available to the messaging feedback and some other scattered bits of copy.