### PR TITLE
Give users a way to escape invitations flow

### DIFF
--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -2,13 +2,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= link_to "Back to list", ips_path(anchor: :team), class: "govuk-back-link" %>
     <h2 class="govuk-heading-l">Invite a team member</h2>
-
     <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
       <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post } do |f| %>
 
         <div class="govuk-form-group <%= field_error(resource, :email) %>">
-          <%= f.label :email, "Email address", class: "govuk-label"  %>
+          <%= f.label :email, "Enter your email address", class: "govuk-label"  %>
           <div class="govuk-hint">Must be a valid government email address</div>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input", required: true %>
         </div>

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -2,13 +2,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= link_to "Back to list", ips_path(anchor: :team), class: "govuk-back-link" %>
+    <%= link_to "Back", ips_path(anchor: :team), class: "govuk-back-link" %>
     <h2 class="govuk-heading-l">Invite a team member</h2>
     <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
       <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post } do |f| %>
 
         <div class="govuk-form-group <%= field_error(resource, :email) %>">
-          <%= f.label :email, "Enter your email address", class: "govuk-label"  %>
+          <%= f.label :email, "Email address", class: "govuk-label"  %>
           <div class="govuk-hint">Must be a valid government email address</div>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input", required: true %>
         </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/429326/44992012-e8748500-af8d-11e8-87fc-005a66885b79.png)

Makes this consistent with our other form-style pages (and GOV in general)