### PR TITLE
Reduce 'deploy to X?' wait time on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,7 @@ def deploy(deploy_environment) {
 
   echo "${deploy_environment}"
   try {
-    timeout(time: 5, unit: 'MINUTES') {
+    timeout(time: 1, unit: 'MINUTES') {
       input "Do you want to deploy to ${deploy_environment}?"
       // Jenkins does a fetch without tags during setup this means
       // we need to run git fetch again here before we can checkout stable


### PR DESCRIPTION
Right now Jenkins waits for 5 minutes before failing the build - this keeps gumming up the build pipeline when there's lots of builds going on. 

If I want to push something to staging or production I'm there waiting already, or I can just re-trigger a build (which only takes about a minute anyway).

As a quick fix, reduce the time before timing out to 1 minute instead.