### PR TITLE
WIP: Add locations to db

### DIFF
--- a/app/controllers/ips_controller.rb
+++ b/app/controllers/ips_controller.rb
@@ -4,7 +4,7 @@ class IpsController < ApplicationController
   end
 
   def create
-    @ip = current_organisation.ips.new(ip_params)
+    @ip = current_organisation.locations.first.ips.new(ip_params)
     if @ip.save
       redirect_to(
         ips_path,

--- a/app/controllers/ips_controller.rb
+++ b/app/controllers/ips_controller.rb
@@ -4,7 +4,8 @@ class IpsController < ApplicationController
   end
 
   def create
-    @ip = current_organisation.locations.first.ips.new(ip_params)
+    default_location = current_organisation.locations.first
+    @ip = default_location.ips.new(ip_params)
     if @ip.save
       redirect_to(
         ips_path,

--- a/app/models/ip.rb
+++ b/app/models/ip.rb
@@ -1,5 +1,5 @@
 class Ip < ApplicationRecord
-  belongs_to :organisation
+  belongs_to :location
 
   validates :address, presence: true
   validate :address_must_be_valid_ip

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,0 +1,12 @@
+class Location < ApplicationRecord
+  belongs_to :organisation
+  has_many :ips
+
+  before_create :set_radius_secret_key
+
+private
+
+  def set_radius_secret_key
+    self.radius_secret_key = RadiusSecretKeyGenerator.new.execute
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -5,14 +5,9 @@ class Organisation < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
 
-  before_create :set_radius_secret_key
   after_create :create_location
 
 private
-
-  def set_radius_secret_key
-    self.radius_secret_key = RadiusSecretKeyGenerator.new.execute
-  end
 
   def create_location
     self.locations.create

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,14 +1,20 @@
 class Organisation < ApplicationRecord
   has_many :users, inverse_of: :organisation
-  has_many :ips
+  has_many :locations
+  has_many :ips, through: :locations
 
   validates :name, presence: true, uniqueness: true
 
   before_create :set_radius_secret_key
+  after_create :create_location
 
 private
 
   def set_radius_secret_key
     self.radius_secret_key = RadiusSecretKeyGenerator.new.execute
+  end
+
+  def create_location
+    self.locations.create
   end
 end

--- a/app/views/ips/_radius_details.html.erb
+++ b/app/views/ips/_radius_details.html.erb
@@ -5,7 +5,7 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    <p> Your RADIUS secret is <strong> <%= current_organisation.radius_secret_key %> </strong></p>
+    <p> Your RADIUS secret is <strong> <%= current_organisation.locations.first.radius_secret_key %> </strong></p>
 
     <p> We recommend connecting to one RADIUS server from each region: </p>
 

--- a/db/migrate/20180907133507_add_locations.rb
+++ b/db/migrate/20180907133507_add_locations.rb
@@ -1,0 +1,12 @@
+class AddLocations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :locations do |t|
+      t.string :radius_secret_key
+      t.string :address
+      t.string :postcode
+      t.references :organisation
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180907134753_add_location_id_to_ips.rb
+++ b/db/migrate/20180907134753_add_location_id_to_ips.rb
@@ -1,0 +1,6 @@
+class AddLocationIdToIps < ActiveRecord::Migration[5.2]
+  def change
+    remove_reference :ips, :organisation
+    add_reference :ips, :location
+  end
+end

--- a/db/migrate/20180907144200_remove_radius_secret_key_from_organisations.rb
+++ b/db/migrate/20180907144200_remove_radius_secret_key_from_organisations.rb
@@ -1,0 +1,5 @@
+class RemoveRadiusSecretKeyFromOrganisations < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :organisations, :radius_secret_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_06_130411) do
+ActiveRecord::Schema.define(version: 2018_09_07_134753) do
 
   create_table "ips", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "location_id"
+    t.index ["location_id"], name: "index_ips_on_location_id"
+  end
+
+  create_table "locations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "radius_secret_key"
+    t.string "address"
+    t.string "postcode"
     t.bigint "organisation_id"
-    t.index ["organisation_id"], name: "index_ips_on_organisation_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organisation_id"], name: "index_locations_on_organisation_id"
   end
 
   create_table "organisations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_07_134753) do
+ActiveRecord::Schema.define(version: 2018_09_07_144200) do
 
   create_table "ips", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "address"
@@ -34,7 +34,6 @@ ActiveRecord::Schema.define(version: 2018_09_07_134753) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "radius_secret_key"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -53,6 +52,7 @@ ActiveRecord::Schema.define(version: 2018_09_07_134753) do
     t.datetime "confirmation_sent_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "organisation_id"
     t.string "name"
     t.string "invitation_token"
     t.datetime "invitation_created_at"
@@ -62,7 +62,6 @@ ActiveRecord::Schema.define(version: 2018_09_07_134753) do
     t.string "invited_by_type"
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
-    t.bigint "organisation_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :location do
+    address { Faker::Address.street_address }
+    postcode { Faker::Address.zip_code }
+  end
+end

--- a/spec/features/view_ip_addresses_spec.rb
+++ b/spec/features/view_ip_addresses_spec.rb
@@ -48,7 +48,7 @@ describe 'View all my IP addresses' do
 
       it 'displays the radius secret key' do
         expect(page).to have_content(
-          "Your RADIUS secret is #{user.organisation.radius_secret_key}"
+          "Your RADIUS secret is #{user.organisation.locations.first.radius_secret_key}"
         )
       end
 

--- a/spec/features/view_ip_addresses_spec.rb
+++ b/spec/features/view_ip_addresses_spec.rb
@@ -31,8 +31,9 @@ describe 'View all my IP addresses' do
     end
 
     context 'when user has IPs' do
-      let!(:ip_1) { create(:ip, organisation: user.organisation) }
-      let!(:ip_2) { create(:ip, organisation: user.organisation) }
+      let(:location) { user.organisation.locations.first }
+      let!(:ip_1) { create(:ip, location: location) }
+      let!(:ip_2) { create(:ip, location: location) }
 
       before do
         sign_in_user user
@@ -77,7 +78,8 @@ describe 'View all my IP addresses' do
       end
 
       context 'Viewing someone elses IP Addresses' do
-        let(:other_ip) { create(:ip, organisation: create(:organisation)) }
+        let(:location) { create(:organisation).locations.first }
+        let(:other_ip) { create(:ip, location: location) }
 
         it 'Redirects to the root path' do
           visit ip_path(other_ip)

--- a/spec/models/ip_spec.rb
+++ b/spec/models/ip_spec.rb
@@ -1,14 +1,14 @@
 describe Ip do
-  it { should belong_to(:organisation) }
+  it { should belong_to(:location) }
 
   context "validations" do
     it { should validate_presence_of(:address) }
 
     context "address" do
-      let(:organisation) { create(:organisation) }
+      let(:location) { create(:organisation).locations.first }
 
       context "when invalid" do
-        let!(:ip) { Ip.create(address: "invalidIP", organisation: organisation) }
+        let!(:ip) { Ip.create(address: "invalidIP", location: location) }
 
         it "does not save when address is an invalid IP" do
           expect(Ip.count).to eq(0)
@@ -19,7 +19,7 @@ describe Ip do
       end
 
       context "when valid" do
-        let!(:ip) { Ip.create(address: "10.0.0.1", organisation: organisation) }
+        let!(:ip) { Ip.create(address: "10.0.0.1", location: location) }
 
         it "saves when address is a valid IP" do
           expect(Ip.count).to eq(1)

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,0 +1,18 @@
+describe Location do
+  context 'associations' do
+    it { should belong_to(:organisation) }
+    it { should have_many(:ips) }
+  end
+
+  describe "#save" do
+    let(:organisation) { create(:organisation) }
+    subject { build(:location, organisation: organisation) }
+    before do
+      subject.save
+    end
+
+    it 'sets the radius_secret_key' do
+      expect(subject.radius_secret_key).to be_present
+    end
+  end
+end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -5,15 +5,4 @@ describe Organisation do
     it { should validate_presence_of(:name) }
     it { should validate_uniqueness_of(:name) }
   end
-
-  describe "#save" do
-    subject { build(:organisation) }
-    before do
-      subject.save
-    end
-
-    it 'sets the radius_secret_key' do
-      expect(subject.radius_secret_key).to be_present
-    end
-  end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,7 +1,7 @@
 describe Organisation do
   context 'associations' do
     it { should have_many(:users) }
-    it { should have_many(:ips) }
+    it { should have_many(:locations) }
     it { should validate_presence_of(:name) }
     it { should validate_uniqueness_of(:name) }
   end


### PR DESCRIPTION
This is a spike to add locations to the admin portal. I have approached this from the angle of trying to get the schema ready to accept the old system data, without changing the frontend user flow. Its the smallest slice I could think of. 

Mainly this PR is about the schema and association changes.

But theres some obvious hacks that I will have to remove in the next iteration:
- For a new user, I'm creating a location when they create their organisation.
- Every IP they add is added to this location.
- I've done this so everything works until we modify the frontend flow.

OLD SYSTEM DATA: We need to import the existing data, which has locations, to this DB. So I've looked at the following schema to bring things over. Some names will need to be changed. I think its better to have nice names than follow the old conventions: https://github.com/alphagov/govwifi-allowed-sites-api/blob/master/mysql/schema.sql#L310

ALLOWED SITES: Will need changing as the radius secret key is now on location. Just realised I've gone with "locations" over "sites" as well.


WHAT TO DO WITH THE USER FLOW ON THE ADMIN PORTAL???

I think we are better off with locations than without. We've heard this from Steve, Milan and user testing. I think the following basic location => IP flow satisfies our needs...

State: New user, logged in, no IPs

Clicks on: "Add an IP"

Sees screen: "Where is this IP address located?"
Fills in: "address" and "postcode"
Clicks "next"

Sees screen "Add your IP"
Fills in: "123.12.123.11"
Clicks: "Add IP"

Sees IPs screen: "Location: XXXXX, IPs: "123.12.123.11""
Sees buttons "Add IP to location" - nested under the above IP
Sees button "Add IP in new location" further down page

Clicks "Add IP in new location" takes you to the above flow.
OR
Clicks "Add IP to location" and goes through the regular IP creation flow.