### PR TITLE
Lengthen timeout for Jenkins deploy step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,7 @@ def deploy(deploy_environment) {
 
   echo "${deploy_environment}"
   try {
-    timeout(time: 1, unit: 'MINUTES') {
+    timeout(time: 2, unit: 'MINUTES') {
       input "Do you want to deploy to ${deploy_environment}?"
       // Jenkins does a fetch without tags during setup this means
       // we need to run git fetch again here before we can checkout stable


### PR DESCRIPTION
Turns out this timeout is from the beginning of the build step,
so as this step takes about 40 seconds, you have to click 'proceed'
in a 20-second window.

Given the UI update speed, this is a little tight - 2 minutes should
do the trick.