### PR TITLE
Empty AWS configuration overrides for staging and production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,5 +79,6 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
   config.action_mailer.default_url_options = { host: "admin-platform.wifi.service.gov.uk" }
-  config.aws_config = {}
+  config.s3_aws_config = {}
+  config.route53_aws_config = {}
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -18,5 +18,6 @@ Rails.application.configure do
   end
   config.active_record.dump_schema_after_migration = false
   config.action_mailer.default_url_options = { host: "admin-platform.staging.wifi.service.gov.uk" }
-  config.aws_config = {}
+  config.s3_aws_config = {}
+  config.route53_aws_config = {}
 end


### PR DESCRIPTION
In test and development we stub AWS responses.
We recently changed this configuration to be S3 and Route53 specific.
This was missed for staging and production