### PR TITLE
Add service_email column to Organisations table

### DIFF
--- a/db/migrate/20180912133317_add_service_email_to_organisations.rb
+++ b/db/migrate/20180912133317_add_service_email_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddServiceEmailToOrganisations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :organisations, :service_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_07_144200) do
+ActiveRecord::Schema.define(version: 2018_09_12_133317) do
 
   create_table "ips", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "address"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2018_09_07_144200) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "service_email"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
T "notifications" column on the old database needs to be transferred to the new admin db. This column holds the email for service for the organisation. 

I've gone with `service_email` because I thought `organisation.service_email` made a lot of sense.

This doesn't exist as a feature in the front end.

I don't think this will require any changes to the other apps / APIs.

https://trello.com/c/8xyIhzal/32-1-add-notifications-to-new-organisations-table