### PR TITLE
Add mobile column to Users table

### DIFF
--- a/db/migrate/20180912135253_add_phone_number_to_users.rb
+++ b/db/migrate/20180912135253_add_phone_number_to_users.rb
@@ -1,0 +1,5 @@
+class AddPhoneNumberToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :mobile, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_12_133317) do
+ActiveRecord::Schema.define(version: 2018_09_12_135253) do
 
   create_table "ips", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "address"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 2018_09_12_133317) do
     t.string "invited_by_type"
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
+    t.string "mobile"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"


### PR DESCRIPTION
The `mobile` column on the old database needs to exist in the new admin DB. 

Is there a better name than `user.mobile`?

I don't believe this change will ripple anywhere else, eg: allowed-sites-api.

https://trello.com/c/rOskvxcm/33-1-add-mobile-to-new-users-table