### PR TITLE
Add rake task to support data migration

### DIFF
--- a/lib/tasks/repair_migrated_data.rake
+++ b/lib/tasks/repair_migrated_data.rake
@@ -1,0 +1,22 @@
+namespace :repair_migrated_data do
+  task add_missing_default_location_to_organisations: :environment do
+    missing_default_locations = Organisation.all.select do |org|
+      org.locations.empty?
+    end
+
+    missing_default_locations.each do |org|
+      org.locations.create!
+    end
+  end
+
+  task confirm_and_create_passwords_for_users: :environment do
+    User.all.each do |user|
+      random_password = Devise.friendly_token.first(16)
+      user.update!(
+        password: random_password,
+        password_confirmation: random_password,
+        confirmed_at: user.created_at
+      )
+    end
+  end
+end


### PR DESCRIPTION
We're migrating data from the 'other' GovWifi database so it can be used in the admin app - users, organisations, locations and IPs.

When we bring them across, there's a few bits to repair - we've done these in Rake tasks so they're louder about the way they break, easier to work with, etc.