### PR TITLE
Only validate emails for new users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
   validates :password, confirmation: true, on: :update
   validates :password_confirmation, presence: true, on: :update
 
-  validate :email_on_whitelist
+  validate :email_on_whitelist, on: :create
 
   def only_if_unconfirmed
     pending_any_confirmation { yield }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -65,18 +65,30 @@ describe User do
     end
 
     context 'with a non-gov.uk email' do
-      subject { build(:user, :confirmed, email: 'name@arbitrary-domain.com') }
+      context 'for a new record' do
+        subject { build(:user, :confirmed, email: 'name@arbitrary-domain.com') }
 
-      it { is_expected.to_not be_valid }
+        it { is_expected.to_not be_valid }
 
-      context 'when saved' do
-        before { subject.save }
+        context 'when saved' do
+          before { subject.save }
 
-        it 'explains the email must be from the correct domain' do
-          expect(subject.errors.full_messages).to eq(
-            ['Email must be from a government domain']
-          )
+          it 'explains the email must be from the correct domain' do
+            expect(subject.errors.full_messages).to eq(
+              ['Email must be from a government domain']
+            )
+          end
         end
+      end
+
+      context 'for an existing record' do
+        subject do
+          user = create(:user, :confirmed)
+          user.email = 'name@arbitrary-domain.com'
+          user
+        end
+
+        it { is_expected.to be_valid }
       end
     end
   end


### PR DESCRIPTION
We want to make sure users have an email that's from .gov (or other 
whitelisted) domains, so that not anyone can sign up for GovWifi.

After the fact, however, users might hand over control to an external 
provider (e.g. BT), but those organisations aren't on the whitelist 
(and can't be in some cases - we can't let everyone from BT sign up!)

We have data covering our existing organisations that defies our 
whitelist already, so this is necessary if we want to bring it across 
and get all organisations using admin.

This PR changes the validation on Users to be only on creation.