### PR TITLE
Improve navbar, show subnav bar on all pages

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,6 @@
 class HomeController < ApplicationController
   def index
     @ips = current_organisation.ips
-    @name = current_organisation.name
     @london_radius_ips = radius_ips[:london]
     @dublin_radius_ips = radius_ips[:dublin]
   end

--- a/app/views/application/_subnavigation.html.erb
+++ b/app/views/application/_subnavigation.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-grid-row subnav">
+  <div class="govuk-grid-column-one-third">
+    <h3 class="govuk-heading-m"><%= current_organisation.name %></h3>
+  </div>
+
+  <nav class="govuk-grid-column-two-thirds">
+    <%= link_to "Overview", '/', class: "govuk-link active" %>
+    <%= link_to "Team Members", team_members_path, class: "govuk-link" %>
+    <%= link_to "Settings", ips_path, class: "govuk-link" %>
+  </nav>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,15 +1,3 @@
-<div class="govuk-grid-row subnav">
-  <div class="govuk-grid-column-one-third">
-    <h3 class="govuk-heading-m"><%= @name %></h3>
-  </div>
-
-  <nav class="govuk-grid-column-two-thirds">
-    <%= link_to "Overview", '', class: "govuk-link active" %>
-    <%= link_to "Team Members", team_members_path, class: "govuk-link" %>
-    <%= link_to "Settings", ips_path, class: "govuk-link" %>
-  </nav>
-</div>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l">Get GovWifi in your building</h2>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,22 +70,22 @@
         <button role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
         <nav>
           <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-              <li class="govuk-header__navigation-item">
-                <%= link_to 'Status', status_index_path, class: "govuk-header__link" %>
-              </li>
+            <li class="govuk-header__navigation-item">
+              <%= link_to 'About', SITE_CONFIG['product_page_link'], class: "govuk-header__link" %>
+            </li>
+            <li class="govuk-header__navigation-item">
+              <%= link_to 'Documentation', SITE_CONFIG['organisation_docs_link'], class: "govuk-header__link" %>
+            </li>
             <% if user_signed_in? %>
               <li class="govuk-header__navigation-item">
-                <%= link_to 'Help', help_index_path, class: "govuk-header__link" %>
+                <%= link_to 'Support', help_index_path, class: "govuk-header__link" %>
               </li>
               <li class="govuk-header__navigation-item">
-                <%= link_to 'Logout', destroy_user_session_path, method: :delete, class: "govuk-header__link" %>
+                <%= link_to 'Sign out', destroy_user_session_path, method: :delete, class: "govuk-header__link" %>
               </li>
             <% else %>
               <li class="govuk-header__navigation-item">
-                <%= link_to 'Sign Up', new_user_registration_path, class: "govuk-header__link govuk-!-margin-right-3" %>
-              </li>
-              <li class="govuk-header__navigation-item">
-                <%= link_to 'Login', new_user_session_path, class: "govuk-header__link" %>
+                <%= link_to 'Sign in', new_user_session_path, class: "govuk-header__link" %>
               </li>
             <% end %>
           </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -96,6 +96,9 @@
 
   <div class="govuk-width-container">
     <main class="govuk-main-wrapper " id="main-content" role="main">
+      <% if user_signed_in? %>
+        <%= render "subnavigation" %>
+      <% end %>
       <%= render "layouts/flash_notices" %>
       <%= yield %>
     </main>

--- a/spec/features/asking_users_to_sign_in_spec.rb
+++ b/spec/features/asking_users_to_sign_in_spec.rb
@@ -20,7 +20,7 @@ describe 'asking users to sign in' do
       sign_up_for_account
       update_user_details
 
-      click_on 'Logout'
+      click_on 'Sign out'
 
       visit '/'
     end

--- a/spec/features/logging_in_after_signing_up_spec.rb
+++ b/spec/features/logging_in_after_signing_up_spec.rb
@@ -16,7 +16,7 @@ describe 'logging in after signing up' do
       confirmed_password: correct_password
     )
 
-    click_on 'Logout'
+    click_on 'Sign out'
 
     fill_in 'Email', with: 'tom@gov.uk'
     fill_in 'Password', with: password
@@ -28,7 +28,7 @@ describe 'logging in after signing up' do
     let(:password) { correct_password }
 
     it 'signs me in' do
-      expect(page).to have_content 'Logout'
+      expect(page).to have_content 'Sign out'
     end
   end
 

--- a/spec/features/reset_password_spec.rb
+++ b/spec/features/reset_password_spec.rb
@@ -91,7 +91,7 @@ describe "Resetting a password" do
         end
 
         it "changes to users password" do
-          expect(page).to have_content("Logout")
+          expect(page).to have_content("Sign out")
         end
       end
 

--- a/spec/features/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/sign_up_as_an_organisation_spec.rb
@@ -19,7 +19,7 @@ describe 'Sign up as an organisation' do
       let(:email) { 'someone@gov.uk' }
 
       it 'signs me in' do
-        expect(page).to have_content 'Logout'
+        expect(page).to have_content 'Sign out'
       end
 
       it 'creates an organisation for the user' do
@@ -31,7 +31,7 @@ describe 'Sign up as an organisation' do
       let(:email) { 'someone@other.gov.uk' }
 
       it 'signs me in' do
-        expect(page).to have_content 'Logout'
+        expect(page).to have_content 'Sign out'
       end
     end
 

--- a/spec/features/support/sign_up_helpers.rb
+++ b/spec/features/support/sign_up_helpers.rb
@@ -35,7 +35,7 @@ def sign_in_user(user)
 end
 
 def sign_out
-  click_on "Logout"
+  click_on "Sign out"
 end
 
 def invite_user(email)

--- a/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
+++ b/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
@@ -39,7 +39,7 @@ describe "Sign up from invitation" do
       it "confirms the user" do
         expect(invited_user.confirmed?).to eq(true)
         expect(invited_user.name).to eq("Ron Swanson")
-        expect(page).to have_content("Logout")
+        expect(page).to have_content("Sign out")
         expect(page).to have_content(user.organisation.name)
       end
     end

--- a/spec/features/team/resend_invitation_spec.rb
+++ b/spec/features/team/resend_invitation_spec.rb
@@ -49,7 +49,7 @@ describe 'Resend invitation to team member' do
         it 'confirms the user' do
           expect(invited_user.confirmed?).to eq(true)
           expect(invited_user.name).to eq('Ron Swanson')
-          expect(page).to have_content('Logout')
+          expect(page).to have_content('Sign out')
           expect(page).to have_content(user.organisation.name)
         end
       end


### PR DESCRIPTION
This PR moves the subnav into a partial and uses it from the application layout, so that it's available throughout the app when logged in.

It also changes the top-right nav to be closer to the other GDS services:

![image](https://user-images.githubusercontent.com/429326/45701921-590fca00-bb68-11e8-96a0-f7391f136462.png)

Formatting for the subnav is poor - this is being addressed in another change.
