### PR TITLE
Fix resend confirmation bug

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -29,8 +29,7 @@ protected
 
   def set_resources
     @original_token = params[:confirmation_token] || params[:user][:confirmation_token]
-    confirmation_token = Devise.token_generator.digest(User, :confirmation_token, @original_token)
-    @confirmable = User.find_or_initialize_with_error_by(:confirmation_token, confirmation_token)
+    @confirmable = User.find_or_initialize_with_error_by(:confirmation_token, @original_token)
   end
 
   def with_unconfirmed_confirmable

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -2,7 +2,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   # This controller overrides the Devise:ConfirmationsController (part of Devise gem)
   # in order to set user passwords after they have confirmed their email. This is
   # based largely on recommendations here: 'https://github.com/plataformatec/devise/wiki/How-To:-Override-confirmations-so-users-can-pick-their-own-passwords-as-part-of-confirmation-activation'
-  before_action :set_resources, only: %i[update show]
+  before_action :set_resource, only: %i[update show]
 
   def update
     with_unconfirmed_confirmable do
@@ -27,9 +27,10 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
 
 protected
 
-  def set_resources
-    @original_token = params[:confirmation_token] || params[:user][:confirmation_token]
-    @confirmable = User.find_or_initialize_with_error_by(:confirmation_token, @original_token)
+  def set_resource
+    token = params[:confirmation_token] || params[:user][:confirmation_token]
+    @confirmable = User.find_or_initialize_with_error_by(:confirmation_token, token)
+    self.resource = @confirmable
   end
 
   def with_unconfirmed_confirmable
@@ -39,12 +40,10 @@ protected
   end
 
   def render_show_page
-    self.resource = @confirmable
     render 'users/confirmations/show', confirmation_token: @original_token
   end
 
   def render_new_page
-    self.resource = @confirmable
     render 'users/confirmations/new'
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,8 +5,6 @@ class User < ApplicationRecord
   devise :invitable, :confirmable, :database_authenticatable, :registerable, :recoverable,
     :rememberable, :trackable, :validatable
 
-  before_create :reset_confirmation_token
-
   validates :name, presence: true, on: :update
 
   validates :password, confirmation: true, on: :update
@@ -33,14 +31,5 @@ private
     checker = CheckIfWhitelistedEmail.new
     whitelisted = checker.execute(self.email)[:success]
     errors.add(:email, 'must be from a government domain') unless whitelisted
-  end
-
-  # Required as Devise fails to encrypt/digest the user confirmation token when
-  # creating the user.  See: https://github.com/plataformatec/devise/issues/2615
-  def reset_confirmation_token
-    encrypted_token = Devise.token_generator.digest(
-      User, :confirmation_token, self.confirmation_token
-    )
-    self.confirmation_token = encrypted_token
   end
 end

--- a/spec/features/resend_confirmation_instructions_spec.rb
+++ b/spec/features/resend_confirmation_instructions_spec.rb
@@ -23,6 +23,17 @@ describe 'Resending confirmation instructions' do
 
       expect(URI(confirmation_email_link).scheme).to eq("https")
     end
+
+    it 'does not change the link' do
+      sign_up_for_account(email: correct_email)
+      previous_link = confirmation_email_link
+
+      visit new_user_confirmation_path
+      fill_in 'user_email', with: entered_email
+      click_on 'Resend confirmation instructions'
+
+      expect(confirmation_email_link).to eq(previous_link)
+    end
   end
 
   context 'when user has not been confirmed' do


### PR DESCRIPTION
Resetting the token doesn't seem to be necessary - looks like we were digesting the token before comparing, which might have confused things.

Still not super-clear on how this Devise functionality is working, but we removed some code and got the test passing, so it's a step in the right direction.