### PR TITLE
Update support and troubleshooting links

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,8 +1,5 @@
 class HelpController < ApplicationController
-  def index
-    @end_user_docs_link = SITE_CONFIG['end_user_docs_link']
-    @organisation_docs_link = SITE_CONFIG['organisation_docs_link']
-  end
+  def index; end
 
   def create
     template_id = GOV_NOTIFY_CONFIG['help_email']['template_id']

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -13,13 +13,18 @@
         </summary>
         <div class="govuk-details__text">
           <p class="govuk-body">
-            If an end user is having trouble with GovWifi, we recommend directing them to <%= link_to 'our guidance on common issues', @end_user_docs_link %>.
+            If an end user is having trouble with GovWifi, we recommend directing them to
+            <%= link_to 'our guidance on common issues', SITE_CONFIG['end_user_troubleshooting_link'] %>.
           </p>
           <p class="govuk-body">
-            If this doesn't resolve the issue, we recommend they contact their local support - we don't provide end user support directly
+            If this doesn't resolve the issue, we recommend they contact their
+            local support - we don't provide end user support directly
           </p>
           <p class="govuk-body">
-            If you're seeing systemic issues with GovWifi - lots of your end users are having trouble, but your access point is connecting to our RADIUS servers correctly - then check our <%= link_to 'guidance for resolving access point issues', @organisation_docs_link %>.
+            If you're seeing systemic issues with GovWifi - lots of your end
+            users are having trouble, but your access point is connecting to our
+            RADIUS servers correctly - then check our
+            <%= link_to 'guidance for resolving access point issues', SITE_CONFIG['organisation_troubleshooting_link'] %>.
           </p>
         </div>
       </details>
@@ -30,7 +35,7 @@
 
       <ul class="govuk-list govuk-list--bullet">
         <li><%= link_to 'Check servers status', status_index_path %></li>
-        <li><%= link_to 'Browse technical documentation', @organisation_docs_link %></li>
+        <li><%= link_to 'Browse technical documentation', SITE_CONFIG['organisation_docs_link'] %></li>
       </ul>
     <p>
   </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -66,7 +66,7 @@
       <p class="govuk-body"> You’ll receive your username and password in reply. </p>
 
       <p>
-        See our <%= link_to "full guidance", "https://www.gov.uk/government/collections/connect-to-govwifi" %> for individuals.
+        See our <%= link_to "full guidance", SITE_CONFIG['end_user_docs_link'] %> for individuals.
       </p>
     </div>
   </details>

--- a/app/views/team_members/index.html.erb
+++ b/app/views/team_members/index.html.erb
@@ -18,7 +18,7 @@
   </summary>
 
   <div class="govuk-details__text">
-    <p> Contact us via our <%= link_to "support form", "#" %> and use this format: </p>
+    <p> Contact us via our <%= link_to "support form", help_index_path %> and use this format: </p>
     <ul class="govuk-list">
     <li> Subject: Edit or remove team member </li>
     <li> Text: Name of organisation, user details to amend </li>

--- a/config/site.yml
+++ b/config/site.yml
@@ -1,7 +1,9 @@
 default: &default
   end_user_docs_link: 'https://wifi.service.gov.uk/connect.html'
+  end_user_troubleshooting_link: 'https://wifi.service.gov.uk/troubleshooting.html'
   organisation_docs_link: 'https://docs.wifi.service.gov.uk'
   product_page_link: 'https://wifi.service.gov.uk'
+  organisation_troubleshooting_link: 'https://docs.wifi.service.gov.uk/troubleshooting.html#troubleshooting'
 
 development:
   <<: *default


### PR DESCRIPTION
Broken links:
- help link on teams page

Incorrect Links:
- End user troubleshooting
- Admin troubleshooting

Also removed the links out of controllers. The `SITE_CONFIG` is already in memory, so I don't see the point in assigning an in memory string to an instance variable. I see controllers more for interacting with models. Happy with views accessing this in memory config directly.