### PR TITLE
Use partial for all flash notices

### DIFF
--- a/app/views/layouts/_flash_notices.html.erb
+++ b/app/views/layouts/_flash_notices.html.erb
@@ -1,7 +1,17 @@
 <% flash.each do |name, msg| -%>
-  <div class='flash-holder'>
-    <% if name == 'notice' %>
+  <% if name == 'notice' %>
+    <div class='flash-holder'>
       <%= content_tag :p, msg, class: "govuk-heading-m flash-message-notice" %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
+  <% if name == 'alert' %>
+    <div class="govuk-error-summary">
+      <h2 class="govuk-error-summary__title">
+        There is a problem
+      </h2>
+      <div class="govuk-error-summary__body">
+        <p><%= msg %></p>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,16 +1,4 @@
 <div class="govuk-grid-row">
-  <% if flash.present? %>
-    <div class="govuk-error-summary">
-      <div class="govuk-error-summary__body">
-        <ul class="govuk-list govuk-error-summary__list">
-          <% flash.each do |name, message| %>
-            <li><%= message %></li>
-          <% end %>
-        </ul>
-      </div>
-    </div>
-  <% end %>
-
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l">Sign in</h2>
 


### PR DESCRIPTION
Turns out the problem was with the `sessions#new` view managing its own flash messages, rather than using the partial.

There's still two types of error reporting in the app - one partial for validation errors on models, and one for flash messages - but I think this is a step in the right direction.