### PR TITLE
Remove casting to JSON from the S3 Gateway

### DIFF
--- a/lib/gateways/s3.rb
+++ b/lib/gateways/s3.rb
@@ -8,7 +8,7 @@ module Gateways
     def upload(data:)
       client = Aws::S3::Client.new(config)
       client.put_object(
-        body: data.to_json,
+        body: data,
         bucket: bucket,
         key: key,
       )

--- a/lib/use_cases/performance_platform/publish_locations_ips.rb
+++ b/lib/use_cases/performance_platform/publish_locations_ips.rb
@@ -5,7 +5,7 @@ class PublishLocationsIps
   end
 
   def execute
-    payload = source_gateway.fetch_ips
+    payload = source_gateway.fetch_ips.to_json
     destination_gateway.upload(data: payload)
   end
 

--- a/spec/gateways/s3_spec.rb
+++ b/spec/gateways/s3_spec.rb
@@ -1,7 +1,7 @@
 describe Gateways::S3 do
   let(:bucket) { 'StubBucket' }
   let(:key) { 'StubKey' }
-  let(:data) { { blah: "foobar" } }
+  let(:data) { { blah: 'foobar' }.to_json }
 
   subject { described_class.new(bucket: bucket, key: key) }
 

--- a/spec/use_cases/performance_platform/publish_locations_ips_spec.rb
+++ b/spec/use_cases/performance_platform/publish_locations_ips_spec.rb
@@ -15,7 +15,7 @@ describe PublishLocationsIps do
 
   before do
     expect(s3_gateway).to receive(:upload)
-      .with(data: s3_payload)
+      .with(data: s3_payload.to_json)
       .and_return({})
   end
 


### PR DESCRIPTION
The content we will upload to S3 will not always be JSON.
Ensure data is prepared before handed over to this gateway.