### PR TITLE
Link new user to add IP's and locations

### DIFF
--- a/app/views/application/_radius_details.html.erb
+++ b/app/views/application/_radius_details.html.erb
@@ -7,8 +7,12 @@
   <div class="govuk-details__text">
     <p> Your RADIUS secrets are:</p>
     <ul class="govuk-list">
+    <% if (current_organisation.locations).empty? %>
+        <p>Your Radius secret keys will be generated when you <%=link_to('add your first IP address', new_ip_path, class: "govuk-link")%></p>
+    <% else %>
       <% current_organisation.locations.each do |loc| %>
-        <li><%= "#{loc.address}, #{loc.postcode}" %> - <strong><%= loc.radius_secret_key %></strong></li>
+          <li><%= "#{loc.address}, #{loc.postcode}" %> - <strong><%= loc.radius_secret_key %></strong></li>
+        <% end %>
       <% end %>
     </ul>
 

--- a/spec/features/guidance_after_sign_in_spec.rb
+++ b/spec/features/guidance_after_sign_in_spec.rb
@@ -3,14 +3,20 @@ require 'support/notifications_service'
 
 describe 'guidance after sign in' do
   let(:user) { create(:user, :confirmed, :with_organisation) }
-  let!(:location) { create(:location, organisation: user.organisation) }
+  before { sign_in_user user }
 
-  before do
-    sign_in_user user
-    visit root_path
+  context 'without locations' do
+    before { visit root_path }
+
+    it 'displays message to inform user to add IPs and locations' do
+      expect(page).to have_content 'Your Radius secret keys will be generated when you add your first IP address'
+    end
   end
 
   context 'with locations' do
+    let!(:location) { create(:location, organisation: user.organisation) }
+    before { visit root_path }
+
     it 'shows me the landing guidance' do
       expect(page).to have_content 'Get GovWifi'
       expect(page).to have_content 'Getting help'
@@ -44,9 +50,5 @@ describe 'guidance after sign in' do
         expect(page).to have_content(radius_ip_4)
       end
     end
-  end
-
-  context 'without locations' do 
-
   end
 end

--- a/spec/features/guidance_after_sign_in_spec.rb
+++ b/spec/features/guidance_after_sign_in_spec.rb
@@ -7,40 +7,46 @@ describe 'guidance after sign in' do
 
   before do
     sign_in_user user
-    visit '/'
+    visit root_path
   end
 
-  it 'shows me the landing guidance' do
-    expect(page).to have_content 'Get GovWifi'
-    expect(page).to have_content 'Getting help'
+  context 'with locations' do
+    it 'shows me the landing guidance' do
+      expect(page).to have_content 'Get GovWifi'
+      expect(page).to have_content 'Getting help'
+    end
+
+    it 'displays radius connection details' do
+      expect(page).to have_content(location.radius_secret_key)
+    end
+
+    context 'with radius IPs in env-vars' do
+      let(:radius_ip_1) { '111.111.111.111' }
+      let(:radius_ip_2) { '121.121.121.121' }
+      let(:radius_ip_3) { '131.131.131.131' }
+      let(:radius_ip_4) { '141.141.141.141' }
+
+      before do
+        ENV['LONDON_RADIUS_IPS'] = "#{radius_ip_1},#{radius_ip_2}"
+        ENV['DUBLIN_RADIUS_IPS'] = "#{radius_ip_3},#{radius_ip_4}"
+      end
+
+      it 'displays RADIUS settings' do
+        expect(page).to have_content('RADIUS')
+        expect(page).to have_content('London')
+        expect(page).to have_content('Dublin')
+      end
+
+      it 'displays the correct IPs' do
+        expect(page).to have_content(radius_ip_1)
+        expect(page).to have_content(radius_ip_2)
+        expect(page).to have_content(radius_ip_3)
+        expect(page).to have_content(radius_ip_4)
+      end
+    end
   end
 
-  it 'displays radius connection details' do
-    expect(page).to have_content(location.radius_secret_key)
-  end
+  context 'without locations' do 
 
-  context 'with radius IPs in env-vars' do
-    let(:radius_ip_1) { '111.111.111.111' }
-    let(:radius_ip_2) { '121.121.121.121' }
-    let(:radius_ip_3) { '131.131.131.131' }
-    let(:radius_ip_4) { '141.141.141.141' }
-
-    before do
-      ENV['LONDON_RADIUS_IPS'] = "#{radius_ip_1},#{radius_ip_2}"
-      ENV['DUBLIN_RADIUS_IPS'] = "#{radius_ip_3},#{radius_ip_4}"
-    end
-
-    it 'displays RADIUS settings' do
-      expect(page).to have_content('RADIUS')
-      expect(page).to have_content('London')
-      expect(page).to have_content('Dublin')
-    end
-
-    it 'displays the correct IPs' do
-      expect(page).to have_content(radius_ip_1)
-      expect(page).to have_content(radius_ip_2)
-      expect(page).to have_content(radius_ip_3)
-      expect(page).to have_content(radius_ip_4)
-    end
   end
 end


### PR DESCRIPTION
Add test to inform new users to add IP's and locations.
Add conditional to display guidance message to guide the user to add IP's and locations.

Before: 
![no-radius-secret-key](https://user-images.githubusercontent.com/40758489/46020474-66800380-c0d6-11e8-8b1c-9087cea9779d.png)

After: 
![screen shot 2018-09-25 at 15 18 11](https://user-images.githubusercontent.com/40758489/46020445-5536f700-c0d6-11e8-8e25-902788b6e2e9.png)