### PR TITLE
Lock yarn and nodejs versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,6 @@ RUN ${BUNDLE_INSTALL_CMD}
 
 COPY . .
 
-RUN bash -c "RAILS_ENV=production bundle exec rails assets:precompile"
+RUN RAILS_ENV=production bundle exec rails assets:precompile
 
 CMD ["bundle", "exec", "rails", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,16 +16,17 @@ ENV S3_WHITELIST_OBJECT_KEY 'WhitelistStubKey'
 
 WORKDIR /usr/src/app
 
-COPY Gemfile Gemfile.lock .ruby-version ./
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  apt-get update && apt-get install -y apt-transport-https && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update && apt-get install -y yarn && \
-  bundle check || ${BUNDLE_INSTALL_CMD} && \
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+  apt-get update && apt-get install -y apt-transport-https nodejs libuv1 && \
+  curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.9.4 && \
   rm -rf /var/lib/apt/lists/*
+ENV PATH "$PATH:/root/.yarn/bin:/root/.config/yarn/global/node_modules/.bin"
+
+COPY Gemfile Gemfile.lock .ruby-version ./
+RUN ${BUNDLE_INSTALL_CMD}
 
 COPY . .
 
-RUN RAILS_ENV=production rails assets:precompile
+RUN bash -c "RAILS_ENV=production bundle exec rails assets:precompile"
 
 CMD ["bundle", "exec", "rails", "server"]

--- a/bin/yarn
+++ b/bin/yarn
@@ -2,7 +2,7 @@
 VENDOR_PATH = File.expand_path('..', __dir__)
 Dir.chdir(VENDOR_PATH) do
   begin
-    exec "yarnpkg #{ARGV.join(' ')}"
+    exec "yarn #{ARGV.join(' ')}"
   rescue Errno::ENOENT
     warn "Yarn executable was not detected in the system."
     warn "Download Yarn at https://yarnpkg.com/en/docs/install"


### PR DESCRIPTION
**Why:** We were seeing a flaky bug introduced by a new version of yarn released

* Yarn 1.9.4
* Nodejs 8~