### PR TITLE
Order radius IPs based on organisation ID

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,6 +8,7 @@ class HomeController < ApplicationController
 private
 
   def radius_ips
-    ViewRadiusIPAddresses.new.execute
+    view_radius = ViewRadiusIPAddresses.new(organisation_id: current_organisation.id)
+    view_radius.execute
   end
 end

--- a/lib/use_cases/organisation/view_radius_ip_addresses.rb
+++ b/lib/use_cases/organisation/view_radius_ip_addresses.rb
@@ -1,4 +1,8 @@
 class ViewRadiusIPAddresses
+  def initialize(organisation_id:)
+    @organisation_id = organisation_id
+  end
+
   def execute
     validate_as_ip_addresses!(london_ips)
     validate_as_ip_addresses!(dublin_ips)
@@ -8,12 +12,19 @@ class ViewRadiusIPAddresses
 
 private
 
+  def order_by_organisation(ip_array)
+    srand @organisation_id
+    ip_array.shuffle
+  end
+
   def london_ips
-    ENV.fetch('LONDON_RADIUS_IPS').split(',')
+    ips = ENV.fetch('LONDON_RADIUS_IPS').split(',')
+    order_by_organisation(ips)
   end
 
   def dublin_ips
-    ENV.fetch('DUBLIN_RADIUS_IPS').split(',')
+    ips = ENV.fetch('DUBLIN_RADIUS_IPS').split(',')
+    order_by_organisation(ips)
   end
 
   def validate_as_ip_addresses!(addresses)

--- a/spec/use_cases/organisation/view_radius_ip_addresses_spec.rb
+++ b/spec/use_cases/organisation/view_radius_ip_addresses_spec.rb
@@ -1,5 +1,5 @@
 describe ViewRadiusIPAddresses do
-  subject { described_class.new }
+  subject { described_class.new(organisation_id: org_id) }
 
   context 'with RADIUS environment variables' do
     before do
@@ -7,7 +7,63 @@ describe ViewRadiusIPAddresses do
       ENV['DUBLIN_RADIUS_IPS'] = "#{radius_ip_3},#{radius_ip_4}"
     end
 
-    context 'example one' do
+    context 'as organisation 1' do
+      let(:org_id) { 1 }
+
+      context 'example one' do
+        let(:radius_ip_1) { '111.111.111.111' }
+        let(:radius_ip_2) { '121.121.121.121' }
+        let(:radius_ip_3) { '131.131.131.131' }
+        let(:radius_ip_4) { '141.141.141.141' }
+
+        it 'returns those IPs in a hash' do
+          expect(subject.execute).to eq(
+            london: [radius_ip_1, radius_ip_2],
+            dublin: [radius_ip_3, radius_ip_4]
+          )
+        end
+      end
+
+      context 'example two' do
+        let(:radius_ip_1) { '151.151.151.151' }
+        let(:radius_ip_2) { '161.161.161.161' }
+        let(:radius_ip_3) { '171.171.171.171' }
+        let(:radius_ip_4) { '181.181.181.181' }
+
+        it 'returns those IPs in a hash' do
+          expect(subject.execute).to eq(
+            london: [radius_ip_1, radius_ip_2],
+            dublin: [radius_ip_3, radius_ip_4]
+          )
+        end
+      end
+
+      context 'including invalid Dublin IPs' do
+        let(:radius_ip_1) { '111.111.111.111' }
+        let(:radius_ip_2) { '121.121.121.121' }
+        let(:radius_ip_3) { '131.131.131.131' }
+        let(:radius_ip_4) { 'cat.dog.bear.pig' }
+
+        it 'blows up' do
+          expect { subject.execute }.to raise_error(IPAddr::InvalidAddressError)
+        end
+      end
+
+      context 'including invalid London IPs' do
+        let(:radius_ip_1) { '111.111.111.111' }
+        let(:radius_ip_2) { 'cat.dog.bear.pig' }
+        let(:radius_ip_3) { '131.131.131.131' }
+        let(:radius_ip_4) { '141.141.141.141' }
+
+        it 'blows up' do
+          expect { subject.execute }.to raise_error(IPAddr::InvalidAddressError)
+        end
+      end
+    end
+
+    context 'as organisation 2' do
+      let(:org_id) { 2 }
+
       let(:radius_ip_1) { '111.111.111.111' }
       let(:radius_ip_2) { '121.121.121.121' }
       let(:radius_ip_3) { '131.131.131.131' }
@@ -15,50 +71,16 @@ describe ViewRadiusIPAddresses do
 
       it 'returns those IPs in a hash' do
         expect(subject.execute).to eq(
-          london: [radius_ip_1, radius_ip_2],
-          dublin: [radius_ip_3, radius_ip_4]
+          london: [radius_ip_2, radius_ip_1],
+          dublin: [radius_ip_4, radius_ip_3]
         )
-      end
-    end
-
-    context 'example two' do
-      let(:radius_ip_1) { '151.151.151.151' }
-      let(:radius_ip_2) { '161.161.161.161' }
-      let(:radius_ip_3) { '171.171.171.171' }
-      let(:radius_ip_4) { '181.181.181.181' }
-
-      it 'returns those IPs in a hash' do
-        expect(subject.execute).to eq(
-          london: [radius_ip_1, radius_ip_2],
-          dublin: [radius_ip_3, radius_ip_4]
-        )
-      end
-    end
-
-    context 'including invalid Dublin IPs' do
-      let(:radius_ip_1) { '111.111.111.111' }
-      let(:radius_ip_2) { '121.121.121.121' }
-      let(:radius_ip_3) { '131.131.131.131' }
-      let(:radius_ip_4) { 'cat.dog.bear.pig' }
-
-      it 'blows up' do
-        expect { subject.execute }.to raise_error(IPAddr::InvalidAddressError)
-      end
-    end
-
-    context 'including invalid London IPs' do
-      let(:radius_ip_1) { '111.111.111.111' }
-      let(:radius_ip_2) { 'cat.dog.bear.pig' }
-      let(:radius_ip_3) { '131.131.131.131' }
-      let(:radius_ip_4) { '141.141.141.141' }
-
-      it 'blows up' do
-        expect { subject.execute }.to raise_error(IPAddr::InvalidAddressError)
       end
     end
   end
 
-  context 'with no RADIUS env-vars' do
+  context 'with an organisation, but no RADIUS env-vars' do
+    let(:org_id) { 1 }
+
     before do
       ENV.delete('LONDON_RADIUS_IPS')
       ENV.delete('DUBLIN_RADIUS_IPS')

--- a/spec/use_cases/organisation/view_radius_ip_addresses_spec.rb
+++ b/spec/use_cases/organisation/view_radius_ip_addresses_spec.rb
@@ -69,7 +69,7 @@ describe ViewRadiusIPAddresses do
       let(:radius_ip_3) { '131.131.131.131' }
       let(:radius_ip_4) { '141.141.141.141' }
 
-      it 'returns those IPs in a hash' do
+      it 'returns those IPs in a differently ordered hash' do
         expect(subject.execute).to eq(
           london: [radius_ip_2, radius_ip_1],
           dublin: [radius_ip_4, radius_ip_3]


### PR DESCRIPTION
For example, for our test organisation, they're now not in 'natural' order:

![screen shot 2018-09-27 at 11 44 01](https://user-images.githubusercontent.com/40758489/46141662-7cafd000-c24c-11e8-9202-e98dbd2f9bf4.png)

(We checked a few more and they're in different orders too)