### PR TITLE
Order locations by address

### DIFF
--- a/app/controllers/ips_controller.rb
+++ b/app/controllers/ips_controller.rb
@@ -22,7 +22,7 @@ class IpsController < ApplicationController
   end
 
   def index
-    @locations = Location.includes(:ips).where(organisation: current_organisation)
+    @locations = Location.includes(:ips).where(organisation: current_organisation).order(:address)
   end
 
 private


### PR DESCRIPTION
Some organisations have a lot of locations, and finding the correct
location becomes difficult.  By ordering them alphabetically, it's
easier to find.