### PR TITLE
Filter authorisation requests

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -4,7 +4,11 @@ class LogsController < ApplicationController
       authentication_logs_gateway: Gateways::LoggingApi.new
     ).execute(username: params[:username])
 
+    filter_auth_requests_by_organisation(auth_requests)
+  end
+
+  def filter_auth_requests_by_organisation(auth_requests)
     ips = current_organisation.ips.map(&:address)
-    @logs = auth_requests.select { |auth_request| ips.include? (auth_request["siteIP"]) }
+    @logs = auth_requests.select { |auth_request| ips.include?(auth_request["siteIP"]) }
   end
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -3,5 +3,7 @@ class LogsController < ApplicationController
     @logs = UseCases::Administrator::GetAuthRequestsForUsername.new(
       authentication_logs_gateway: Gateways::LoggingApi.new
     ).execute(username: params[:username])
+
+    # @raw_logs.filter{|log| log is from an ip that is in the current_organisation.ips array}
   end
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,9 +1,10 @@
 class LogsController < ApplicationController
   def index
-    @logs = UseCases::Administrator::GetAuthRequestsForUsername.new(
+    auth_requests = UseCases::Administrator::GetAuthRequestsForUsername.new(
       authentication_logs_gateway: Gateways::LoggingApi.new
     ).execute(username: params[:username])
 
-    # @raw_logs.filter{|log| log is from an ip that is in the current_organisation.ips array}
+    ips = current_organisation.ips.map(&:address)
+    @logs = auth_requests.select { |auth_request| ips.include? (auth_request["siteIP"]) }
   end
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -4,11 +4,11 @@ class LogsController < ApplicationController
       authentication_logs_gateway: Gateways::LoggingApi.new
     ).execute(username: params[:username])
 
-    filter_auth_requests_by_organisation(auth_requests)
+    @logs = filter_auth_requests(auth_requests)
   end
 
-  def filter_auth_requests_by_organisation(auth_requests)
+  def filter_auth_requests(auth_requests)
     ips = current_organisation.ips.map(&:address)
-    @logs = auth_requests.select { |auth_request| ips.include?(auth_request["siteIP"]) }
+    auth_requests.select { |auth_request| ips.include? (auth_request["siteIP"]) }
   end
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -18,7 +18,7 @@ private
 
   def filter_auth_requests(auth_requests)
     ips = current_organisation.ips.map(&:address)
-    auth_requests.select { |auth_request| ips.include? (auth_request["siteIP"]) }
+    auth_requests.select { |auth_request| ips.include?(auth_request["siteIP"]) }
   end
 
   def alert

--- a/spec/features/logging/view_auth_requests_for_a_username_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_a_username_spec.rb
@@ -55,11 +55,11 @@ describe "View authentication requests for a username" do
           })
         .to_return(status: 200, body: logs.to_json, headers: {})
 
-      organisation = create( :organisation )
-      location_two = create( :location, organisation: organisation )
+      organisation = create(:organisation)
+      location_two = create(:location, organisation: organisation)
 
-      create(:ip, location_id: location.id, address: "1.1.1.1" )
-      create(:ip, location: location_two, address: "2.2.2.2" )
+      create(:ip, location_id: location.id, address: "1.1.1.1")
+      create(:ip, location: location_two, address: "2.2.2.2")
 
       sign_in_user admin_user
       visit search_logs_path
@@ -71,7 +71,7 @@ describe "View authentication requests for a username" do
       expect(page).to have_content("Displaying logs for #{username}")
     end
 
-    it "displays the logs of the ips owned by the organisation location" do
+    it "displays the logs of the ip the organisation does own" do
       expect(page).to have_content("1.1.1.1")
     end
 

--- a/spec/features/logging/view_auth_requests_for_a_username_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_a_username_spec.rb
@@ -6,7 +6,6 @@ describe "View authentication requests for a username" do
     let(:organisation) { create(:organisation) }
     let(:admin_user) { create(:user, :confirmed, organisation_id: organisation.id) }
     let(:location) { create(:location, organisation_id: organisation.id) }
-    let(:ip) { create(:ip, location_id: location.id, address: "1.1.1.1" )}
     let(:logs) do
       [
         {
@@ -56,6 +55,12 @@ describe "View authentication requests for a username" do
           })
         .to_return(status: 200, body: logs.to_json, headers: {})
 
+      organisation = create( :organisation )
+      location_two = create( :location, organisation: organisation )
+
+      create(:ip, location_id: location.id, address: "1.1.1.1" )
+      create(:ip, location: location_two, address: "2.2.2.2" )
+
       sign_in_user admin_user
       visit search_logs_path
       fill_in "username", with: username
@@ -77,6 +82,8 @@ describe "View authentication requests for a username" do
 
   context "without results" do
     let(:user) { create(:user, :confirmed, :with_organisation) }
+    let(:admin_user) { create(:user, :confirmed, organisation_id: organisation.id) }
+    let(:organisation) { create(:organisation) }
 
     before do
       sign_in_user admin_user

--- a/spec/features/logging/view_auth_requests_for_a_username_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_a_username_spec.rb
@@ -2,8 +2,11 @@ require 'features/support/sign_up_helpers'
 
 describe "View authentication requests for a username" do
   context "with results" do
-    let(:user) { create(:user, :confirmed, :with_organisation) }
     let(:username) { "AAAAAA" }
+    let(:organisation) { create(:organisation) }
+    let(:admin_user) { create(:user, :confirmed, organisation_id: organisation.id) }
+    let(:location) { create(:location, organisation_id: organisation.id) }
+    let(:ip) { create(:ip, location_id: location.id, address: "1.1.1.1" )}
     let(:logs) do
       [
         {
@@ -11,7 +14,7 @@ describe "View authentication requests for a username" do
           "building_identifier" => "",
           "id" => 1,
           "mac" => "",
-          "siteIP" => "",
+          "siteIP" => "1.1.1.1",
           "start" => "2018-10-01 18:18:09 +0000",
           "stop" => nil,
           "success" => true,
@@ -22,7 +25,18 @@ describe "View authentication requests for a username" do
           "building_identifier" => "",
           "id" => 1,
           "mac" => "",
-          "siteIP" => "",
+          "siteIP" => "1.1.1.1",
+          "start" => "2018-10-01 18:18:09 +0000",
+          "stop" => nil,
+          "success" => true,
+          "username" => username
+        },
+        {
+          "ap" => "",
+          "building_identifier" => "",
+          "id" => 1,
+          "mac" => "",
+          "siteIP" => "2.2.2.2",
           "start" => "2018-10-01 18:18:09 +0000",
           "stop" => nil,
           "success" => true,
@@ -42,7 +56,7 @@ describe "View authentication requests for a username" do
           })
         .to_return(status: 200, body: logs.to_json, headers: {})
 
-      sign_in_user user
+      sign_in_user admin_user
       visit search_logs_path
       fill_in "username", with: username
       click_on "Submit"
@@ -51,13 +65,21 @@ describe "View authentication requests for a username" do
     it "displays the authentication requests" do
       expect(page).to have_content("Displaying logs for #{username}")
     end
+
+    it "displays the logs of the ips owned by the organisation location" do
+      expect(page).to have_content("1.1.1.1")
+    end
+
+    it "does not display the logs of the ip the organisation does not own" do
+      expect(page).to_not have_content("2.2.2.2")
+    end
   end
 
   context "without results" do
     let(:user) { create(:user, :confirmed, :with_organisation) }
 
     before do
-      sign_in_user user
+      sign_in_user admin_user
       visit search_logs_path
       fill_in "username", with: ""
       click_on "Submit"

--- a/spec/features/logging/view_auth_requests_for_a_username_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_a_username_spec.rb
@@ -71,7 +71,7 @@ describe "View authentication requests for a username" do
       expect(page).to have_content("Displaying logs for #{username}")
     end
 
-    it "displays the logs of the ip the organisation does own" do
+    it "displays the logs of the ip the organisation does not own" do
       expect(page).to have_content("1.1.1.1")
     end
 


### PR DESCRIPTION
Before: When searching the authorisation requests the logs showed ALL of the IP's, even if  that organisation did not own it.

After: When searching the authorisation request logs it now only displays the results for IP's that the organisation owns.