### PR TITLE
Read replica config in database yaml file

### DIFF
--- a/app/models/read_replica_base.rb
+++ b/app/models/read_replica_base.rb
@@ -1,14 +1,5 @@
 class ReadReplicaBase < ActiveRecord::Base
   self.abstract_class = true
 
-  CONFIG = {
-    adapter: 'mysql2',
-    encoding: 'utf8',
-    host: ENV.fetch('RR_DB_HOST'),
-    username: ENV.fetch('RR_DB_USER'),
-    password: ENV.fetch('RR_DB_PASS'),
-    database: ENV.fetch('RR_DB_NAME')
-  }.freeze
-
-  establish_connection CONFIG
+  establish_connection READ_REPLICA_DB
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,3 +21,12 @@ staging:
 production:
   <<: *mysql
   database: govwifi_admin_production
+
+read_replica:
+  adapter: mysql2
+  encoding: utf8
+  host: <%= ENV.fetch('RR_DB_HOST') %>
+  port: 3306
+  username: <%= ENV.fetch('RR_DB_USER') %>
+  password: <%= ENV.fetch('RR_DB_PASS') %>
+  database: <%= ENV.fetch('RR_DB_NAME') %>

--- a/config/initializers/read_replica_database.rb
+++ b/config/initializers/read_replica_database.rb
@@ -1,0 +1,2 @@
+config = File.read(File.join( Rails.root, 'config', 'database.yml'))
+READ_REPLICA_DB = YAML.load(ERB.new(config).result).fetch('read_replica')


### PR DESCRIPTION
Keep this configuration together which will make it easier to find down
the line. Can also access this constant easily if we were to manually
establish another database connection, which is going to be required by
database cleaner down the line.