### PR TITLE
When adding IPs and this is the first location, hide locations dropdown (+minor styling fix)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,3 +17,7 @@ $govuk-font-url-function: "font-url";
 .govuk-phase-banner{
   margin-bottom: 25px;
 }
+
+.text-right{
+  text-align: right;
+}

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">IP addresses</h1>
   </div>
-  <div class="govuk-grid-column-one-third">
+  <div class="govuk-grid-column-one-third text-right">
     <%= link_to "Add IP address", new_ip_path, class: "govuk-button" %>
   </div>
 </div>

--- a/app/views/ips/new.html.erb
+++ b/app/views/ips/new.html.erb
@@ -9,12 +9,14 @@
     <%= render "activation_notice" %>
 
     <%= form_with model: @ip do |form| %>
-      <div class="govuk-form-group <%= field_error(@ip, :location_id) %>">
-        <%= form.label :location_id, "Add an IP to an existing location", class: "govuk-label" %>
-        <%= form.select :location_id, @locations, { prompt: '-- select --' }, { class: "govuk-select" } %>
-      </div>
+      <% if @locations.present? %>
+        <div class="govuk-form-group <%= field_error(@ip, :location_id) %>">
+          <%= form.label :location_id, "Add an IP to an existing location", class: "govuk-label" %>
+          <%= form.select :location_id, @locations, { prompt: '-- select --' }, { class: "govuk-select" } %>
+        </div>
 
-      <p class="govuk-body"><strong>OR</strong></p>
+        <p class="govuk-body"><strong>OR</strong></p>
+      <% end %>
 
       <%= form.fields_for :location, @ip.build_location do |location_form| %>
         <div class="govuk-form-group">

--- a/app/views/team_members/index.html.erb
+++ b/app/views/team_members/index.html.erb
@@ -3,7 +3,7 @@
     <h1 class="govuk-heading-l"> Team members </h1>
   </div>
 
-  <div class="govuk-grid-column-one-third">
+  <div class="govuk-grid-column-one-third text-right">
     <%= link_to "Invite team member", new_user_invitation_path, class: "govuk-button" %>
   </div>
 </div>


### PR DESCRIPTION
I don't think this needs any new tests, but I'm happy to hear opinions.

(Cheeky to put aligning in the same PR, can rebase rather than squash to keep them separate)

The form without locations, and an example of the right-aligned button looking nice:

![image](https://user-images.githubusercontent.com/429326/46943001-87e56700-d066-11e8-93be-7cf432c6fef7.png)

![image](https://user-images.githubusercontent.com/429326/46943023-99c70a00-d066-11e8-8711-d8521528471a.png)

