### PR TITLE
remove target from Jenkins docker build command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ def deploy(deploy_environment) {
         sh("eval \$(aws ecr get-login --no-include-email)")
         def appImage = docker.build(
           "govwifi/admin:${deploy_environment}",
-          "--build-arg BUNDLE_INSTALL_CMD='bundle install --without test' --target production ."
+          "--build-arg BUNDLE_INSTALL_CMD='bundle install --without test' ."
         )
         appImage.push()
         runMigrations(deploy_environment)


### PR DESCRIPTION
There's a bug in the Jenkins plugin that causes builds to fail if you specify a target.
Given it was only in to be explicit, we can safely remove the target