### PR TITLE
Revert "ensure the database is created before setting the environment"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ lint: build
 
 .PHONY: test
 test: build launch_db
-	$(DOCKER_COMPOSE) run -e RACK_ENV=test --rm app ./bin/rails db:create db:environment:set RAILS_ENV=test db:schema:load db:migrate
+	$(DOCKER_COMPOSE) run -e RACK_ENV=test --rm app ./bin/rails db:environment:set RAILS_ENV=test db:create db:schema:load db:migrate
 	$(DOCKER_COMPOSE) run --rm app bundle exec rspec
 
 .PHONY: bash


### PR DESCRIPTION
Reverts alphagov/govwifi-admin#197

Jenkins Docker plugin has a bug that breaks for multi-stage dockerfiles. You need to change how you reference the stages.
Reverting until time is made for implementing this workaround.