### PR TITLE
Fix bug with filtering by IP

### DIFF
--- a/lib/gateways/sessions.rb
+++ b/lib/gateways/sessions.rb
@@ -5,9 +5,9 @@ module Gateways
     end
 
     def search(username:)
-      results = Session.where(
-        'username = ? and start >= ? and siteIP in (?)', username, 2.weeks.ago, ips.join(',')
-      ).order('start DESC').limit(100)
+      results = Session.where('username = ? and start >= ? and siteIP IN (?)', username, 2.weeks.ago, ips)
+        .order('start DESC')
+        .limit(100)
 
       results.map do |log|
         {

--- a/spec/gateways/sessions_spec.rb
+++ b/spec/gateways/sessions_spec.rb
@@ -72,6 +72,19 @@ describe Gateways::Sessions do
         result = subject.search(username: username)
         expect(result.count).to eq(1)
       end
+
+      context 'Multiple IP addresses' do
+        let(:my_ips) { ['1.1.1.1', '2.2.2.2'] }
+
+        it 'only selects logs matching my IP addresses' do
+          Session.create(start: today_date, username: username, siteIP: '1.1.1.1')
+          Session.create(start: today_date, username: username, siteIP: '2.2.2.2')
+          Session.create(start: today_date, username: username, siteIP: '3.3.3.3')
+
+          result = subject.search(username: username)
+          expect(result.count).to eq(2)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
The IN syntax was not correct, and not adding the correct quotes around
the ip addresses for filtering.