### PR TITLE
Extract log search query validator

### DIFF
--- a/lib/use_cases/administrator/validate_log_search_query.rb
+++ b/lib/use_cases/administrator/validate_log_search_query.rb
@@ -1,0 +1,23 @@
+module UseCases
+  module Administrator
+    class ValidateLogSearchQuery
+      def execute(params)
+        { success: success?(params) }
+      end
+
+    private
+
+      def success?(params)
+        valid_username?(params.fetch(:username)) || valid_ip?(params.fetch(:ip))
+      end
+
+      def valid_username?(username)
+        username.present? && username.length > 5
+      end
+
+      def valid_ip?(ip)
+        UseCases::Administrator::CheckIfValidIp.new.execute(ip).fetch(:success)
+      end
+    end
+  end
+end

--- a/spec/use_cases/administrator/validate_log_search_query_spec.rb
+++ b/spec/use_cases/administrator/validate_log_search_query_spec.rb
@@ -1,0 +1,35 @@
+describe UseCases::Administrator::ValidateLogSearchQuery do
+  let(:email) { 'test@example.com' }
+
+  context 'Valid search params' do
+    context 'valid username' do
+      it 'returns true' do
+        valid_params = [
+          { username: 'ABCDEF', ip: nil },
+          { username: nil, ip: '127.0.0.1' }
+        ]
+
+        valid_params.each do |valid_param|
+          expect(subject.execute(valid_param)).to eq(success: true)
+        end
+      end
+    end
+  end
+
+  context 'Invalid search params' do
+    context 'invalid username and invalid ip' do
+      it 'returns false' do
+        invalid_params = [
+          { username: nil, ip: nil },
+          { username: nil, ip: '1' },
+          { username: '', ip: '' },
+          { username: 'A', ip: '' }
+        ]
+
+        invalid_params.each do |invalid_param|
+          expect(subject.execute(invalid_param)).to eq(success: false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will be used to ensure that search queries are valid for viewing
logs.