### PR TITLE
Remove HTML5 validation from forms

### DIFF
--- a/app/views/ips/new.html.erb
+++ b/app/views/ips/new.html.erb
@@ -32,7 +32,7 @@
 
       <div class="govuk-form-group <%= field_error(@ip, :address) %>">
         <%= form.label :ip, "Enter IP address (IPv4 only)", class: "govuk-label" %>
-        <%= form.text_field :address, id: :address, autocomplete: "off", class: "govuk-input", required: true %>
+        <%= form.text_field :address, id: :address, autocomplete: "off", class: "govuk-input" %>
       </div>
 
       <div class="actions">

--- a/app/views/logs/search.html.erb
+++ b/app/views/logs/search.html.erb
@@ -17,7 +17,7 @@
     <%= form_with url: logs_path, method: :get do |form| %>
       <div class="govuk-form-group">
         <%= form.label :username, "Enter the username you wish to see logs for", class: "govuk-label" %><br />
-        <%= form.text_field :username, autofocus: true, class: "govuk-input", required: true %>
+        <%= form.text_field :username, autofocus: true, class: "govuk-input" %>
       </div>
 
       <div class="actions">

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -3,15 +3,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l">Resend confirmation instructions</h2>
-    <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, novalidate: '' }) do |f| %>
       <div class="govuk-form-group <%= field_error(resource, :email) %>">
         <%= f.label :email, "Enter your email address", class: "govuk-label" %>
         <%= f.email_field :email,
           autofocus: true,
           autocomplete: "email",
           class: "govuk-input",
-          value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email),
-          required: true
+          value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email)
         %>
       </div>
       <div class="actions">

--- a/app/views/users/confirmations/show.html.erb
+++ b/app/views/users/confirmations/show.html.erb
@@ -5,30 +5,30 @@
     <h2 class="govuk-heading-l">Create your account</h2>
 
     <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-      <%= form_for(resource, as: resource_name, url: users_confirmations_path, html: { method: :put }) do |f| %>
+      <%= form_for(resource, as: resource_name, url: users_confirmations_path, html: { method: :put, novalidate: '' }) do |f| %>
         <%= f.hidden_field :confirmation_token, value: params[:confirmation_token] || params[:user][:confirmation_token] %>
 
         <div class="govuk-form-group <%= field_error(resource, "organisation.name") %>">
           <%= f.fields_for :organisation, resource.build_organisation do |organisation_form| %>
             <%= organisation_form.label :name, "Organisation name", class: "govuk-label" %>
-            <%= organisation_form.text_field :name, autofocus: true, class: "govuk-input", required: true %>
+            <%= organisation_form.text_field :name, autofocus: true, class: "govuk-input" %>
           <% end %>
         </div>
 
         <div class="govuk-form-group">
           <%= f.label :name, "Your name", class: "govuk-label" %>
-          <%= f.text_field :name, class: "govuk-input", required: true %>
+          <%= f.text_field :name, class: "govuk-input" %>
         </div>
 
         <div class="govuk-form-group <%= field_error(resource, :password) %>">
           <%= f.label :password, "Password", class: "govuk-label" %>
           <div class="govuk-hint"> Must be at least 6 characters long</div>
-          <%= f.password_field :password, class: "govuk-input", autocomplete: "off", required: true %>
+          <%= f.password_field :password, class: "govuk-input", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= field_error(resource, :password_confirmation) %>">
           <%= f.label :password_confirmation, "Confirm password", class: "govuk-label" %>
-          <%= f.password_field :password_confirmation, class: "govuk-input", autocomplete: "off", required: true %>
+          <%= f.password_field :password_confirmation, class: "govuk-input", autocomplete: "off" %>
         </div>
 
         <div class="actions">

--- a/app/views/users/invitations/edit.html.erb
+++ b/app/views/users/invitations/edit.html.erb
@@ -6,23 +6,23 @@
 
     <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
 
-      <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { :method => :put } do |f| %>
+      <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { :method => :put, novalidate: '' } do |f| %>
         <%= f.hidden_field :invitation_token, readonly: true %>
 
         <div class="govuk-form-group">
           <%= f.label :name, "Your name", class: "govuk-label" %>
-          <%= f.text_field :name, class: "govuk-input", required: true %>
+          <%= f.text_field :name, class: "govuk-input" %>
         </div>
 
         <div class="govuk-form-group <%= field_error(resource, :password) %>">
           <%= f.label :password, "Password", class: "govuk-label" %>
           <div class="govuk-hint"> Must be at least 6 characters long</div>
-          <%= f.password_field :password, class: "govuk-input", autocomplete: "off", required: true %>
+          <%= f.password_field :password, class: "govuk-input", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= field_error(resource, :password_confirmation) %>">
           <%= f.label :password_confirmation, "Confirm password", class: "govuk-label" %>
-          <%= f.password_field :password_confirmation, class: "govuk-input", autocomplete: "off", required: true %>
+          <%= f.password_field :password_confirmation, class: "govuk-input", autocomplete: "off" %>
         </div>
 
         <div class="actions">

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -22,12 +22,12 @@
     </div>
 
     <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-      <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post } do |f| %>
+      <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post, novalidate: '' } do |f| %>
 
         <div class="govuk-form-group <%= field_error(resource, :email) %>">
           <%= f.label :email, "Email address", class: "govuk-label"  %>
           <div class="govuk-hint">Must be a valid government email address</div>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input", required: true %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input" %>
         </div>
 
         <div class="actions">

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -10,12 +10,12 @@
 
         <div class="govuk-form-group <%= field_error(resource, :password) %>">
           <%= f.label :password, "New password", class: "govuk-label" %>
-          <%= f.password_field :password, autofocus: true, class: "govuk-input", autocomplete: "off", required: true %>
+          <%= f.password_field :password, autofocus: true, class: "govuk-input", autocomplete: "off" %>
         </div>
 
         <div class="govuk-form-group <%= field_error(resource, :password_confirmation) %>">
           <%= f.label :password_confirmation, "Confirm new password", class: "govuk-label" %>
-          <%= f.password_field :password_confirmation, class: "govuk-input", autocomplete: "off", required: true %>
+          <%= f.password_field :password_confirmation, class: "govuk-input", autocomplete: "off" %>
         </div>
 
         <div class="actions">

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -5,7 +5,7 @@
     <h2 class="govuk-heading-l">Reset your password</h2>
 
     <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, novalidate: '' }) do |f| %>
         <div class="govuk-form-group">
           <%= f.label :email, "Provide your email address", class: "govuk-label" %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input" %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -8,12 +8,11 @@
       If you are trying to connect to GovWifi as an end user, see instructions <%= link_to "here", "", class: "govuk-link" %>
     </p>
 
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { novalidate: '' }) do |f| %>
       <div class="govuk-form-group <%= field_error(resource, :email)  %>">
         <%= f.label :email, "Enter your email address", class: "govuk-label"  %>
         <div class="govuk-hint"> Must be a valid government email address </div>
-        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input", required: true %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input" %>
       </div>
 
       <div class="actions">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -7,15 +7,15 @@
     </p>
 
     <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-      <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { novalidate: '' }) do |f| %>
 
         <div class="govuk-form-group">
           <%= f.label :email, class: "govuk-label" %>
-          <%= f.email_field :email, autofocus: true, class: "govuk-input", autocomplete: "email", required: true %>
+          <%= f.email_field :email, autofocus: true, class: "govuk-input" %>
         </div>
         <div class="govuk-form-group">
           <%= f.label :password, class: "govuk-label" %>
-          <%= f.password_field :password, class: "govuk-input", autocomplete: "off", required: true %>
+          <%= f.password_field :password, class: "govuk-input", autocomplete: "off" %>
         </div>
 
         <div>


### PR DESCRIPTION
GDS design guidelines recommend against HTML5 attribute-driven validation messages.

This PR removes explicit `required: true` attributes, and puts a `novalidate` marker on forms that have special field types. Removing the special field types is undesirable, as they have other useful behaviour (e.g. email fields giving you a different keyboard on mobile devices)

These messages (+positioning) still need some love, but this is a step forward.

![image](https://user-images.githubusercontent.com/429326/46957814-423d9400-d090-11e8-92c3-1932b1e56019.png)
