### PR TITLE
Use .present? instead of .empty? for displaying logs

### DIFF
--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,9 +1,6 @@
 <%= link_to "Back to search", search_logs_path, class: "govuk-back-link" %>
 
-<% if @logs.empty? %>
-  <h3 class="govuk-heading-m">No results found for that username, please try again</h3>
-<% else %>
-
+<% if @logs.present? %>
   <h1>Displaying logs for <%= params[:username] || params[:ip] %></h1>
   <table class="govuk-table">
     <caption class="govuk-table__caption"><%= @logs.count %> results</caption>
@@ -30,4 +27,6 @@
       <% end %>
     </tbody>
   </table>
+<% else %>
+  <h3 class="govuk-heading-m">No results found</h3>
 <% end %>

--- a/spec/features/logging/view_auth_requests_for_a_username_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_a_username_spec.rb
@@ -91,7 +91,7 @@ describe "View authentication requests for a username" do
     end
 
     it 'displays the no results message' do
-      expect(page).to have_content("No results found for that username, please try again")
+      expect(page).to have_content('No results found')
     end
   end
 end


### PR DESCRIPTION
@logs can be nil if the search has not happened yet.
Check for this and make the error message more general since we are
searching for usernames and IP addresses now.