### PR TITLE
Start read-replica container for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,9 @@ lint:
 test:
 	$(MAKE) build
 	$(DOCKER_COMPOSE) up -d db
+	$(DOCKER_COMPOSE) up -d rr_db
 	./mysql/bin/wait_for_mysql
+	./mysql/bin/wait_for_rr_db
 	$(DOCKER_COMPOSE) run -e RACK_ENV=test --rm app ./bin/rails db:create db:schema:load db:migrate
 	$(DOCKER_COMPOSE) run --rm app bundle exec rspec
 


### PR DESCRIPTION
I'm not sure how `make test` is working in our pipeline without this, but it doesn't work on a fresh checkout. If you `serve` before you `test` it'll work, which might give the false impression things are fine.

Should we `make stop` before we `serve` or `test`, to make sure we don't have problems like this in the future?

Alternately, is this something about my specific machine setup, rather than an actual problem?