### PR TITLE
Dynamic dates for log search spec

### DIFF
--- a/spec/features/logging/view_auth_requests_for_a_username_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_a_username_spec.rb
@@ -9,7 +9,7 @@ describe "View authentication requests for a username" do
 
     before do
       Session.create!(
-        start: "2018-10-01 18:18:09 +0000",
+        start: 3.days.ago,
         username: username,
         mac: '',
         ap: '',
@@ -19,7 +19,7 @@ describe "View authentication requests for a username" do
       )
 
       Session.create!(
-        start: "2018-10-01 18:18:09 +0000",
+        start: 3.days.ago,
         username: username,
         mac: '',
         ap: '',
@@ -29,7 +29,7 @@ describe "View authentication requests for a username" do
       )
 
       Session.create!(
-        start: "2018-10-01 18:18:09 +0000",
+        start: 3.days.ago,
         username: username,
         mac: '',
         ap: '',

--- a/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
@@ -10,7 +10,7 @@ describe 'View authentication requests for an IP' do
 
     before do
       Session.create!(
-        start: "2018-10-01 18:18:09 +0000",
+        start: 3.days.ago,
         username: username,
         siteIP: '127.0.0.1',
         success: true


### PR DESCRIPTION
Log requests are only shown for the last two weeks, so hardcoding the date meant they switched from passing to failing yesterday.