### PR TITLE
Increase limit on the amount of logs shown

### DIFF
--- a/lib/gateways/sessions.rb
+++ b/lib/gateways/sessions.rb
@@ -9,7 +9,7 @@ module Gateways
 
       results = Session.where(query).where(
         'start >= ? and siteIP IN (?)', 2.weeks.ago, ips
-      ).order('start DESC').limit(100)
+      ).order('start DESC').limit(500)
 
       results.map do |log|
         {


### PR DESCRIPTION
We limit results to be within the last 2 weeks, but even so it can be a
large number of results.

There was an additional limit of 100, this isn't enough.

Increase this to 500.