### PR TITLE
Disable devise's sign in error messages

### DIFF
--- a/app/views/layouts/_flash_notices.html.erb
+++ b/app/views/layouts/_flash_notices.html.erb
@@ -1,4 +1,6 @@
 <% flash.each do |name, msg| -%>
+  <% next if msg.empty? %>
+
   <% if name == 'notice' %>
     <div class='flash-holder'>
       <%= content_tag :p, msg, class: "govuk-heading-m flash-message-notice" %>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -7,14 +7,14 @@ en:
       send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:
-      already_authenticated: "You are already signed in."
+      already_authenticated: ""
       inactive: "Your account is not activated yet."
       invalid: "Invalid %{authentication_keys} or password."
       locked: "Your account is locked."
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "Invalid %{authentication_keys} or password."
       timeout: "Your session expired. Please sign in again to continue."
-      unauthenticated: "You need to sign in or sign up before continuing."
+      unauthenticated: ""
       unconfirmed: "You have to confirm your email address before continuing."
     invitations:
       updated: ""


### PR DESCRIPTION
This disables two error messages:

1. When a user is signed in and visits a non-authenticated route (eg `/users/sign_in`), devise flashes a notice that says "You are already signed in.". This is now disabled.
2. When a user is not signed in and tries to visit an authenticated route (eg: `/team_members`), devise redirects to the login page and flashes a notice "You need to sign in or sign up before continuing". This is also disabled.

Now when users are already signed in, they will be silently redirected to the correct place. When they are not signed in, they will simply be presented with the sign in screen.

This approach seemed preferable to overriding this controller: https://www.rubydoc.info/github/plataformatec/devise/DeviseController:require_no_authentication 