### PR TITLE
Npmfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,6 @@ RUN ${BUNDLE_INSTALL_CMD}
 COPY . .
 
 RUN ASSET_PRECOMPILATION_ONLY=true RAILS_ENV=production bundle exec rails assets:precompile
+RUN cp -R /usr/src/app/node_modules /usr/src/.node_modules
 
 CMD ["bundle", "exec", "rails", "server"]

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ serve:
 	./mysql/bin/wait_for_rr_db
 	$(DOCKER_COMPOSE) run --rm app rm -f tmp/pids/server.pid
 	$(DOCKER_COMPOSE) run --rm app ./bin/rails db:create db:schema:load db:seed
+	$(DOCKER_COMPOSE) run --rm app cp -R --remove-destination /usr/src/.node_modules ./node_modules
 	$(DOCKER_COMPOSE) up -d app
 
 lint:
@@ -36,6 +37,7 @@ test:
 	./mysql/bin/wait_for_mysql
 	./mysql/bin/wait_for_rr_db
 	$(DOCKER_COMPOSE) run -e RACK_ENV=test --rm app ./bin/rails db:create db:schema:load db:migrate
+	$(DOCKER_COMPOSE) run --rm app cp -R --remove-destination /usr/src/.node_modules ./node_modules
 	$(DOCKER_COMPOSE) run --rm app bundle exec rspec
 
 bash: serve

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,7 @@
 # The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
 require 'faker'
 
-admin_organisation = Organisation.create(name: "Super Admins")
+admin_organisation = Organisation.create(name: "Super Admins", service_email: 'it@gds.com')
 admin_user = admin_organisation.users.create(email: "admin@gov.uk", password: "password", name: "Steve", admin: true)
 admin_user.confirm
 


### PR DESCRIPTION
Ensure node_modules is available in the docker image

When running a fresh setup, you will get an error unless you have run
npm install.  This fixes it, so new setups don't require that,
contribution by Craig.
