### PR TITLE
Fix seeding of organisations in development

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,6 +25,6 @@ location_2 = Location.create!(
 Ip.create!(address: '127.3.3.1', location: location_1)
 Ip.create!(address: '193.1.1.9', location: location_2)
 
-5.times { Organisation.create(name: Faker::Company.name, service_email: Faker::Company.email) }
+5.times { Organisation.create(name: Faker::Company.name, service_email: 'some-service@email.com') }
 
 MouTemplate.create!


### PR DESCRIPTION
The .email on Faker::Company is raising an error about missing
translations.  We don't need this to be a dynamic email, just use a
static one.