### PR TITLE
Add profiler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,4 +37,5 @@ group :development, :test do
   gem 'byebug', '~> 10'
   gem 'listen', '~> 3'
   gem 'pry'
+  gem 'rack-mini-profiler', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,8 @@ GEM
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.5)
+    rack-mini-profiler (1.0.0)
+      rack (>= 1.2.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.1)
@@ -307,6 +309,7 @@ DEPENDENCIES
   notifications-ruby-client (~> 2.9.0)
   pry
   puma (~> 3.12)
+  rack-mini-profiler
   rails (~> 5.2.1)
   rspec-rails (~> 3)
   sass-rails (~> 5.0)
@@ -319,4 +322,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.5
+   1.16.6

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,0 +1,5 @@
+if Rails.env.development?
+    require "rack-mini-profiler"
+  
+    Rack::MiniProfilerRails.initialize!(Rails.application)
+end

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,5 +1,5 @@
 if Rails.env.development?
-    require "rack-mini-profiler"
-  
-    Rack::MiniProfilerRails.initialize!(Rails.application)
+  require "rack-mini-profiler"
+
+  Rack::MiniProfilerRails.initialize!(Rails.application)
 end


### PR DESCRIPTION
**What**

Enables [`rack-mini-profiler`][link_rack_mini_profiler] for the development environment.

**Why**

Required for [Live Services Supportability][link_lss].

[link_rack_mini_profiler]: https://github.com/MiniProfiler/rack-mini-profiler
[link_lss]: https://github.com/madetech/live-services-field-guide/blob/master/processes/checklists/supportability.md