### PR TITLE
Change external app links to new paths

### DIFF
--- a/config/site.yml
+++ b/config/site.yml
@@ -1,6 +1,6 @@
 default: &default
-  end_user_docs_link: 'https://wifi.service.gov.uk/connect.html'
-  end_user_troubleshooting_link: 'https://wifi.service.gov.uk/troubleshooting.html'
+  end_user_docs_link: 'https://wifi.service.gov.uk/connect'
+  end_user_troubleshooting_link: 'https://wifi.service.gov.uk/troubleshooting'
   organisation_docs_link: 'https://docs.wifi.service.gov.uk'
   product_page_link: 'https://wifi.service.gov.uk'
 


### PR DESCRIPTION
Couple of links are broken because of the product page's new paths (no .html).

![image](https://user-images.githubusercontent.com/429326/47640733-2d670300-db5c-11e8-8b7c-990e49dd944d.png)

Should have looked for these when changing the product page paths. Not sure how best to prevent these links breaking in general, feels like they'll be changing less often now.