### PR TITLE
Direct feedback to contact us page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -117,8 +117,8 @@
       <div class="govuk-phase-banner feedback-banner">
         <p class="govuk-phase-banner__content">
          <span class="govuk-phase-banner__text">
-           This is a new service – your
-           <a class="govuk-link" href="mailto:govwifi-support@digital.cabinet-office.gov.uk?subject=User Feedback Suggestion">feedback</a> will help us to improve it.
+           This is a new service – your <%= link_to "feedback", help_index_path, class: "govuk-link" %>
+            will help us to improve it.
           </span>
        </p>
      </div>


### PR DESCRIPTION
Based on recommendations from researchers, the feedback banner needs to go to contact us page rather than be a mailto link.