### PR TITLE
Run aws update-service command to deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,7 @@ def deploy(deploy_environment, requires_confirmation, desired_count) {
         appImage.push()
         runMigrations(deploy_environment)
 
-        sh("aws ecs update-service --cluster ${deploy_environment}-admin-cluster --service admin-${deploy_environment} --force-new-deployment --deployment-configuration maximumPercent=200,minimumHealthyPercent=100")
+        sh('aws ecs update-service --cluster ${deploy_environment}-admin-cluster --service admin-${deploy_environment} --force-new-deployment')
       }
     }
   } catch(err) { // timeout reached or input false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,6 +82,8 @@ def deploy(deploy_environment, requires_confirmation, desired_count) {
         )
         appImage.push()
         runMigrations(deploy_environment)
+
+        sh("aws ecs update-service --cluster ${deploy_environment}-admin-cluster --service admin-${deploy_environment} --force-new-deployment --deployment-configuration maximumPercent=200,minimumHealthyPercent=100")
       }
     }
   } catch(err) { // timeout reached or input false

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
+    <!-- test post please ignore -->
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=<%= SITE_CONFIG['google_analytics_script_id'] %>"></script>


### PR DESCRIPTION
From the AWS docs:
> If your updated Docker image uses the same tag as what is in the existing task definition for your service (for example, my_image:latest), you do not need to create a new revision of your task definition.

> You can update the service using the procedure below, keep the current settings for your service, and select `Force new deployment`.

> The new tasks launched by the deployment pull the current image/tag combination from your repository when they start."

Pretty sure this is the model we're following - tagging a docker image as 'latest' or similar and then wanting to deploy it.

This command seems to works locally, but 
a) I'd need to get a new master build up to check and 
b) it leaves an extra container running (this PR might need a terraform friend for autoscaling staging back down to one task.)

If there's a nice way to multi-line this string in a bash script, I'd rather do that.  Quick google gave me nothing.

Would also like comments on the best way to test this - want a quick feedback loop, don't want to get in the way of other development.