### PR TITLE
Remove previous gtag script for google tag manager.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,12 +8,6 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
-      gtag('config', '<%= SITE_CONFIG['google_analytics_script_id'] %>', {
-        'linker': {
-          'domains': ['admin.wifi.service.gov.uk', 'docs.wifi.service.gov.uk', 'wifi.service.gov.uk']
-        }
-      });
     </script>
 
   <!-- Google Tag Manager -->


### PR DESCRIPTION
Remove gtag script
Script for installing tag manager has been added on a previous commit in a different branch.