### PR TITLE
Add double quotes for interpolation string

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,7 @@ def deploy(deploy_environment, requires_confirmation, desired_count) {
         appImage.push()
         runMigrations(deploy_environment)
 
-        sh('aws ecs update-service --cluster ${deploy_environment}-admin-cluster --service admin-${deploy_environment} --force-new-deployment')
+        sh("aws ecs update-service --cluster ${deploy_environment}-admin-cluster --service admin-${deploy_environment} --force-new-deployment")
       }
     }
   } catch(err) { // timeout reached or input false


### PR DESCRIPTION
The bash command currently runs as 
`aws ecs update-service --cluster -admin-cluster --service admin- --force-new-deployment`
on Jenkins.

This is because the interpolated values aren't working in single-quoted string.