### PR TITLE
Ensure the top navigation is consistent for all 3 apps

### DIFF
--- a/app/assets/stylesheets/components/main_nav.scss
+++ b/app/assets/stylesheets/components/main_nav.scss
@@ -8,3 +8,7 @@
   font-weight: 400;
   padding-left: 5px;
 }
+
+.govuk-header__link.active {
+  color: #1d8feb;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-TNHHHPZ');</script>
   <!-- End Google Tag Manager -->
-    
+
     <title>Govwifi Admin</title>
 
     <meta charset="utf-8" />
@@ -95,16 +95,16 @@
             <li class="govuk-header__navigation-item">
               <%= link_to 'Documentation', SITE_CONFIG['organisation_docs_link'], class: "govuk-header__link" %>
             </li>
+            <li class="govuk-header__navigation-item">
+              <%= link_to 'Support', help_index_path, class: "govuk-header__link #{active_tab(help_index_path)}" %>
+            </li>
             <% if user_signed_in? %>
-              <li class="govuk-header__navigation-item">
-                <%= link_to 'Support', help_index_path, class: "govuk-header__link" %>
-              </li>
               <li class="govuk-header__navigation-item">
                 <%= link_to 'Sign out', destroy_user_session_path, method: :delete, class: "govuk-header__link" %>
               </li>
             <% else %>
               <li class="govuk-header__navigation-item">
-                <%= link_to 'Sign in', new_user_session_path, class: "govuk-header__link" %>
+                <%= link_to 'Sign in', new_user_session_path, class: "govuk-header__link #{active_tab(new_user_session_path)}" %>
               </li>
             <% end %>
           </ul>


### PR DESCRIPTION
We want the active state to be blue like the other applications.
This adds a style to do this and markup.
No need to do this on sign out as you will be redirected.

<img width="1027" alt="screen shot 2018-10-30 at 15 53 52" src="https://user-images.githubusercontent.com/1215147/47731439-0abc1380-dc5c-11e8-93b6-5c31676e9006.png">
