### PR TITLE
Rename make bash -> make shell, simplify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,11 @@ test:
 	$(DOCKER_COMPOSE) run --rm app cp -R --remove-destination /usr/src/.node_modules ./node_modules
 	$(DOCKER_COMPOSE) run --rm app bundle exec rspec
 
-bash: serve
-	docker exec -it `docker-compose ps -q app | awk 'END{print}'` bash
+shell: serve
+	docker exec -it app bash
 
 stop:
 	$(DOCKER_COMPOSE) kill
 	$(DOCKER_COMPOSE) rm -f
 
-.PHONY: build serve lint test stop bash
+.PHONY: build lint serve shell stop test


### PR DESCRIPTION
Switch to adhere to [Made Tech's Makefile standards](https://github.com/madetech/rfcs/blob/master/rfc-012-makefile-standards.md), but mainly because I forget this particular app is `bash` not `shell` when I'm working on multiple apps.

Also simplify the command within it, `docker-compose` can handle finding the container to run against by its friendly name.