### PR TITLE
Disable debug mode in asset pipelines

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,7 +1,7 @@
 require 'action_mailer/railtie'
 Rails.application.configure do
   config.active_storage.service = :local
-  
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on
@@ -38,7 +38,7 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  config.assets.debug = false
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true


### PR DESCRIPTION
This enables support for partial preprocessing, which greatly speeds
up page loads after a style change.