### PR TITLE
Add basic permissions to users

### DIFF
--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,0 +1,3 @@
+class Permission < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ApplicationRecord
 
   validate :email_on_whitelist, on: :create
 
+  after_create :add_manage_team_permission!
+
   def only_if_unconfirmed
     pending_any_confirmation { yield }
   end
@@ -23,6 +25,34 @@ class User < ApplicationRecord
 
   def invitation_pending?
     invitation_sent_at && !invitation_accepted?
+  end
+
+  def can_view_logs?
+    true
+  end
+
+  def can_view_team?
+    true
+  end
+
+  def can_view_locations?
+    true
+  end
+
+  def can_manage_locations?
+    true
+  end
+
+  def can_manage_team?
+    @manage_team
+  end
+
+  def add_manage_team_permission!
+    @manage_team = true
+  end
+
+  def remove_manage_team_permission!
+    @manage_team = false
   end
 
 private

--- a/db/migrate/20181112122154_create_permissions.rb
+++ b/db/migrate/20181112122154_create_permissions.rb
@@ -1,0 +1,11 @@
+class CreatePermissions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :permissions do |t|
+      t.boolean :can_manage_team
+      t.boolean :can_manage_locations
+      t.belongs_to :user
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_31_150323) do
+ActiveRecord::Schema.define(version: 2018_11_12_122154) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -62,6 +62,15 @@ ActiveRecord::Schema.define(version: 2018_10_31_150323) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "service_email"
+  end
+
+  create_table "permissions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.boolean "can_manage_team"
+    t.boolean "can_manage_locations"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_permissions_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -104,21 +104,6 @@ describe User do
       it 'can manage locations' do
         expect(subject.can_manage_locations?).to be_truthy
       end
-
-      context 'after reload' do
-        let(:reloaded_user) do
-          subject.save!
-          User.find(subject.id)
-        end
-
-        it 'can manage team members' do
-          expect(reloaded_user.can_manage_team?).to be_truthy
-        end
-
-        it 'can manage locations' do
-          expect(reloaded_user.can_manage_locations?).to be_truthy
-        end
-      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,4 @@
-describe User, focus: true do
+describe User do
   context 'associations' do
     it { should belong_to(:organisation) }
   end
@@ -97,18 +97,6 @@ describe User, focus: true do
     context 'a new user' do
       subject { create(:user, :confirmed) }
 
-      it 'can view logs' do
-        expect(subject.can_view_logs?).to be_truthy
-      end
-
-      it 'can view team members' do
-        expect(subject.can_view_team?).to be_truthy
-      end
-
-      it 'can view locations' do
-        expect(subject.can_view_locations?).to be_truthy
-      end
-
       it 'can manage team members' do
         expect(subject.can_manage_team?).to be_truthy
       end
@@ -117,24 +105,18 @@ describe User, focus: true do
         expect(subject.can_manage_locations?).to be_truthy
       end
 
-      context 'after removing "manage team"' do
-        before { subject.remove_manage_team_permission! }
-
-        it 'cannot manage team' do
-          expect(subject.can_manage_team?).to be_falsey
+      context 'after reload' do
+        let(:reloaded_user) do
+          subject.save!
+          User.find(subject.id)
         end
 
-        context 'after save and load' do
-          # let(:reloaded_user) do
-          #   subject.save!
-          #   User.find(subject.id)
-          # end
+        it 'can manage team members' do
+          expect(reloaded_user.can_manage_team?).to be_truthy
+        end
 
-          let(:reloaded_user) { subject.reload }
-
-          it 'cannot manage team' do
-            expect(reloaded_user.can_manage_team?).to be_falsey
-          end
+        it 'can manage locations' do
+          expect(reloaded_user.can_manage_locations?).to be_truthy
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,4 @@
-describe User do
+describe User, focus: true do
   context 'associations' do
     it { should belong_to(:organisation) }
   end
@@ -89,6 +89,53 @@ describe User do
         end
 
         it { is_expected.to be_valid }
+      end
+    end
+  end
+
+  context 'permissions' do
+    context 'a new user' do
+      subject { create(:user, :confirmed) }
+
+      it 'can view logs' do
+        expect(subject.can_view_logs?).to be_truthy
+      end
+
+      it 'can view team members' do
+        expect(subject.can_view_team?).to be_truthy
+      end
+
+      it 'can view locations' do
+        expect(subject.can_view_locations?).to be_truthy
+      end
+
+      it 'can manage team members' do
+        expect(subject.can_manage_team?).to be_truthy
+      end
+
+      it 'can manage locations' do
+        expect(subject.can_manage_locations?).to be_truthy
+      end
+
+      context 'after removing "manage team"' do
+        before { subject.remove_manage_team_permission! }
+
+        it 'cannot manage team' do
+          expect(subject.can_manage_team?).to be_falsey
+        end
+
+        context 'after save and load' do
+          # let(:reloaded_user) do
+          #   subject.save!
+          #   User.find(subject.id)
+          # end
+
+          let(:reloaded_user) { subject.reload }
+
+          it 'cannot manage team' do
+            expect(reloaded_user.can_manage_team?).to be_falsey
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This PR allows you to check whether a User `can_manage_locations` or `can_manage_team`, and makes it so all new Users have both permissions, but does not implement checking these permissions anywhere.

At one point this did have more methods for the permissions everyone has - like `view_locations` - but given that _everyone_ has these for the foreseeable future, leaving them out for now.