### PR TITLE
Restrict managing team to users with permissions

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,4 +1,5 @@
 class Users::InvitationsController < Devise::InvitationsController
+  before_action :authorise_manage_team, only: %i(create new)
   before_action :add_organisation_to_params, :validate_invited_user, only: :create
 
 private
@@ -32,5 +33,9 @@ private
   # Overrides https://github.com/scambra/devise_invitable/blob/master/app/controllers/devise/invitations_controller.rb#L105
   def invite_params
     params.require(:user).permit(:email, :organisation_id)
+  end
+
+  def authorise_manage_team
+    redirect_to(root_path) unless current_user.can_manage_team?
   end
 end

--- a/app/views/team_members/_table.html.erb
+++ b/app/views/team_members/_table.html.erb
@@ -6,11 +6,12 @@
           <td class="govuk-table__cell"><strong>Invitation pending</strong></td>
           <td class="govuk-table__cell text-light-grey"><%= member.email %></td>
           <td class="govuk-table__cell text-right">
-            <%= button_to("Resend invite",
-              user_invitation_path({ user: { email: member.email }}),
-              method: :post,
-              class: "resend-invite-button")
-            %>
+            <% if current_user.can_manage_team? %>
+              <%= button_to('Resend invite',
+                user_invitation_path({ user: { email: member.email }}),
+                method: :post,
+                class: 'resend-invite-button') %>
+            <% end %>
           </td>
         <% else %>
           <td class="govuk-table__cell"><strong><%= member.name %></strong></td>

--- a/app/views/team_members/index.html.erb
+++ b/app/views/team_members/index.html.erb
@@ -4,7 +4,9 @@
   </div>
 
   <div class="govuk-grid-column-one-third text-right">
-    <%= link_to "Invite team member", new_user_invitation_path, class: "govuk-button" %>
+    <% if current_user.can_manage_team? %>
+      <%= link_to 'Invite team member', new_user_invitation_path, class: 'govuk-button' %>
+    <% end %>
   </div>
 </div>
 

--- a/spec/features/team/permissions_spec.rb
+++ b/spec/features/team/permissions_spec.rb
@@ -1,0 +1,60 @@
+require 'features/support/sign_up_helpers'
+require 'support/notifications_service'
+
+describe 'Invite a team member' do
+  include_examples 'notifications service'
+  let(:user) { create(:user, :confirmed) }
+
+  before do
+    sign_in_user user
+  end
+
+  context 'With the .manage_team permission' do
+    before do
+      user.permission.update!(can_manage_team: true)
+      visit team_members_path
+    end
+
+    it 'shows the invite team member link' do
+      expect(page).to have_link('Invite team member')
+    end
+
+    it 'allows visiting the invites page directly' do
+      visit new_user_invitation_path
+      expect(page.current_path).to eq(new_user_invitation_path)
+    end
+
+    it 'allows re-sending invites' do
+      create(:user, organisation: user.organisation, invitation_sent_at: Date.today)
+      visit team_members_path
+
+      expect(page).to have_button('Resend invite')
+    end
+  end
+
+  context 'Without the .manage_team permission' do
+    before do
+      user.permission.update!(can_manage_team: false)
+      sign_in_user user
+    end
+
+    it 'hides the invite team member link' do
+      visit team_members_path
+
+      expect(page).to_not have_link('Invite team member')
+    end
+
+    it 'prevents visiting the invites page directly' do
+      visit new_user_invitation_path
+
+      expect(page.current_path).to eq(root_path)
+    end
+
+    it 'does not allow re-sending invites' do
+      create(:user, organisation: user.organisation, invitation_sent_at: Date.today)
+      visit team_members_path
+
+      expect(page).to_not have_button('Resend invite')
+    end
+  end
+end


### PR DESCRIPTION
We don't want everyone to be able to add and remove team members.
Use the permission system to check that a user is allowed to manage the
team before displaying the button to the invite page.

Also redirect to the root page if the URL was visited directly.