### PR TITLE
Restrict managing IP addresses and locations

### DIFF
--- a/app/controllers/ips_controller.rb
+++ b/app/controllers/ips_controller.rb
@@ -1,4 +1,6 @@
 class IpsController < ApplicationController
+  before_action :authorise_manage_locations, only: %i(create new)
+
   def new
     @ip = Ip.new
     @locations = available_locations
@@ -74,5 +76,9 @@ private
 
   def params_with_existing_location
     ip_params.except(:location_attributes)
+  end
+
+  def authorise_manage_locations
+    redirect_to(root_path) unless current_user.can_manage_locations?
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,8 +4,11 @@
     <div>
       <h3 class="govuk-heading-m"> 1. Add IPs </h3>
         <% if @ips.empty? %>
-          <p class="govuk-body">
-            You need to <%= link_to "add the IPs", new_ip_path %> of your authenticator(s).</p>
+          <% if current_user.can_manage_locations? %>
+            <p class="govuk-body">
+              You need to <%= link_to "add the IPs", new_ip_path %> of your authenticator(s).
+            </p>
+          <% end %>
         <% else %>
           <p class="govuk-body">
             You have <%= link_to "#{pluralize(@ips.count, "IP")} configured.", ips_path  %></p>

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -3,7 +3,9 @@
     <h1 class="govuk-heading-l">IP addresses</h1>
   </div>
   <div class="govuk-grid-column-one-third text-right">
-    <%= link_to "Add IP address", new_ip_path, class: "govuk-button" %>
+    <% if current_user.can_manage_locations? %>
+      <%= link_to 'Add IP address', new_ip_path, class: 'govuk-button' %>
+    <% end %>
   </div>
 </div>
 

--- a/spec/features/ips/permissions_spec.rb
+++ b/spec/features/ips/permissions_spec.rb
@@ -1,0 +1,73 @@
+require 'features/support/sign_up_helpers'
+
+describe 'Add an IP' do
+  let!(:user) { create(:user, :confirmed) }
+
+  before do
+    sign_in_user user
+  end
+
+  context 'with .can_manage_locations permission' do
+    before do
+      user.permission.update!(can_manage_locations: true)
+    end
+
+    context 'visiting the add IP page directly' do
+      before do
+        visit new_ip_path
+      end
+
+      it 'does not redirect them to the homepage' do
+        expect(page.current_path).to eq(new_ip_path)
+      end
+    end
+
+    it 'displays the add new IP link' do
+      visit ips_path
+      expect(page).to have_link('Add IP address')
+    end
+
+    context 'Homepage instructions' do
+      before do
+        Ip.delete_all
+      end
+
+      it 'has a link to add new IP addresses' do
+        visit root_path
+        expect(page).to have_link('add the IPs')
+      end
+    end
+  end
+
+  context 'without .can_manage_locations permission' do
+    before do
+      user.permission.update!(can_manage_locations: false)
+    end
+
+    it 'hides the add new IP link' do
+      visit ips_path
+      expect(page).to_not have_link('Add IP address')
+    end
+
+    context 'visiting the add IP page directly' do
+      before do
+        visit new_ip_path
+      end
+
+      it 'redirects them to the homepage' do
+        expect(page.current_path).to eq(root_path)
+      end
+    end
+
+    context 'Homepage instructions' do
+      before do
+        Ip.delete_all
+      end
+
+      it 'has a link to add new IP addresses' do
+        visit root_path
+        expect(page).to_not have_link('add the IPs')
+      end
+    end
+  end
+end


### PR DESCRIPTION
We don't want everyone to be able to add and remove IP addresses and
locations.
Use the permission system to check that a user is allowed to manage
this.

This will hide certain UI elements and redirect people if a page was
visited directly for managing IP addresses.