### PR TITLE
Allow a user to edit team permissions

### DIFF
--- a/app/controllers/permission_controller.rb
+++ b/app/controllers/permission_controller.rb
@@ -1,0 +1,28 @@
+class PermissionController < ApplicationController
+  before_action :validate_can_manage_team, only: %i[edit update]
+
+  def edit
+    @permission = Permission.find(params.fetch(:id))
+  end
+
+  def update
+    Permission.find(params.fetch(:id)).update!(permission_params)
+
+    flash[:notice] = 'Permissions updated'
+    redirect_to team_members_path
+  end
+
+  private
+
+  def validate_can_manage_team
+    permission = Permission.find(params.fetch(:id))
+
+    unless current_user.organisation == permission.user.organisation && current_user.can_manage_team?
+      raise ActionController::RoutingError.new('Not Found')
+    end
+  end
+
+  def permission_params
+    params.require(:permission).permit(:can_manage_team, :can_manage_locations)
+  end
+end

--- a/app/controllers/permission_controller.rb
+++ b/app/controllers/permission_controller.rb
@@ -12,7 +12,7 @@ class PermissionController < ApplicationController
     redirect_to team_members_path
   end
 
-  private
+private
 
   def validate_can_manage_team
     permission = Permission.find(params.fetch(:id))

--- a/app/views/permission/edit.html.erb
+++ b/app/views/permission/edit.html.erb
@@ -1,0 +1,23 @@
+<h1 class="govuk-heading-m"><%= @permission.user.name %> - <%= @permission.user.email %></h1>
+
+<div class="actions">
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m"><span class="govuk-label">Permissions </span></legend>
+      <div class="govuk-checkboxes">
+        <%= form_for @permission, method: :put do |f| %>
+          <div class="govuk-checkboxes__item">
+            <%= f.check_box :can_manage_team, class: 'govuk-checkboxes__input' %>
+            <label class="govuk-label govuk-checkboxes__label"><%= f.label :can_manage_team, 'Manage team' %></label>
+          </div>
+
+          <div class="govuk-checkboxes__item">
+            <%= f.check_box :can_manage_locations, class: 'govuk-checkboxes__input' %>
+            <label class="govuk-label govuk-checkboxes__label"><%= f.label :can_manage_locations, 'Manage locations' %></label>
+          </div>
+          <%= f.submit 'Save', class: "govuk-button govuk-!-margin-top-4" %>
+        <% end %>
+      </div>
+    </fieldset>
+  </div>
+</div>

--- a/app/views/team_members/_table.html.erb
+++ b/app/views/team_members/_table.html.erb
@@ -56,6 +56,13 @@
         </div>
       </div>
     </li>
+
+    <li>
+      <% if current_user.can_manage_team? && member.id != current_user.id %>
+        <%= link_to 'Edit permissions', edit_permission_path(id: member.permission.id) %>
+      <% end %>
+    </li>
+
     <hr class='govuk-section-break--l govuk-!-margin-top-0'>
   <% end %>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
   resources :ips, only: %i[index new create]
   resources :help, only: %i[index create]
   resources :team_members, only: %i[index]
+
+  resources :permission, only: %i[edit update]
   resources :mou, only: %i[index create]
   resources :logs, only: %i[index] do
     get 'search', on: :collection

--- a/spec/features/team/edit_permissions_spec.rb
+++ b/spec/features/team/edit_permissions_spec.rb
@@ -30,7 +30,6 @@ describe 'Edit user permissions' do
 
   context 'When I have the .can_manage_team permission' do
     context 'User belongs to my organisation' do
-
       before do
         visit team_members_path
       end

--- a/spec/features/team/edit_permissions_spec.rb
+++ b/spec/features/team/edit_permissions_spec.rb
@@ -1,0 +1,60 @@
+require 'features/support/sign_up_helpers'
+
+describe 'Edit user permissions' do
+  let(:user) { create(:user, :confirmed) }
+  let(:invited_user_other_org) { User.find_by(email: 'invited_other_org@gov.uk') }
+  let(:invited_user_same_org) { User.find_by(email: 'invited_same_org@gov.uk') }
+
+  before do
+    create(:user, :confirmed, email: 'invited_other_org@gov.uk')
+    create(:user, :confirmed, email: 'invited_same_org@gov.uk', organisation: user.organisation)
+    sign_in_user user
+  end
+
+  context 'When I do not have the .can_manage_team permission' do
+    before do
+      user.permission.update!(can_manage_team: false)
+    end
+
+    it 'does not show the edit team member link' do
+      visit team_members_path
+      expect(page).to_not have_link('Edit permissions')
+    end
+
+    it 'Prevents visiting the edit permissions page directly' do
+      expect {
+        visit edit_permission_path(invited_user_same_org.permission)
+      }.to raise_error(ActionController::RoutingError)
+    end
+  end
+
+  context 'When I have the .can_manage_team permission' do
+    context 'User belongs to my organisation' do
+
+      before do
+        visit team_members_path
+      end
+
+      it 'allows me to edit the user permissions' do
+        visit team_members_path
+        click_link 'Edit permissions'
+        uncheck 'Manage team'
+        uncheck 'Manage locations'
+
+        click_on 'Save'
+
+        expect(invited_user_same_org.can_manage_team?).to eq(false)
+        expect(invited_user_same_org.can_manage_locations?).to eq(false)
+        expect(page).to have_content('Permissions updated')
+      end
+    end
+
+    context 'User does not belong to my organisation' do
+      it 'Restricts editing to only users in my organisation' do
+        expect {
+          visit edit_permission_path(invited_user_other_org.permission)
+        }.to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to restrict some features.
An admin with the .can_manage_team permission can change the permissions
of other existing users.