### PR TITLE
Make ‘forgot password’ link the correct blue

### DIFF
--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -12,6 +12,6 @@
   <% end %>
 
   <% if devise_mapping.recoverable? && controller_name != 'passwords' %>
-    <%= link_to "Forgot your password?", new_password_path(resource_name) %>
+    <%= link_to "Forgot your password?", new_password_path(resource_name), class: "govuk-link" %>
   <% end %>
 </ul>


### PR DESCRIPTION
There are probably other instances; this is just the first one I came across.

![image](https://user-images.githubusercontent.com/355079/48766624-c5b05d80-ecac-11e8-815b-f10d8a166e79.png)
