### PR TITLE
Allow setting permissions for a new invite

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -32,7 +32,10 @@ private
 
   # Overrides https://github.com/scambra/devise_invitable/blob/master/app/controllers/devise/invitations_controller.rb#L105
   def invite_params
-    params.require(:user).permit(:email, :organisation_id)
+    params.require(:user).permit(:email, :organisation_id, permission_attributes: %i(
+      can_manage_team
+      can_manage_locations
+    ))
   end
 
   def authorise_manage_team

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,8 @@ class User < ApplicationRecord
   belongs_to :organisation, inverse_of: :users, optional: true
   accepts_nested_attributes_for :organisation
 
-  has_one :permission
+  has_one :permission, dependent: :destroy
+  accepts_nested_attributes_for :permission
 
   delegate :can_manage_locations?, :can_manage_team?, to: :permission
 

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -28,6 +28,27 @@
         </div>
 
         <div class="actions">
+          <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--m"><span class="govuk-label">Permissions </span></legend>
+              <div class="govuk-checkboxes">
+                <%= f.fields_for :permission, resource.permission || resource.build_permission(can_manage_team: true, can_manage_locations: true) do |p| %>
+                  <div class="govuk-checkboxes__item">
+                    <%= p.check_box :can_manage_team, class: 'govuk-checkboxes__input' %>
+                    <label class="govuk-label govuk-checkboxes__label"><%= p.label :can_manage_team, 'Manage team' %></label>
+                  </div>
+
+                  <div class="govuk-checkboxes__item">
+                    <%= p.check_box :can_manage_locations, class: 'govuk-checkboxes__input' %>
+                    <label class="govuk-label govuk-checkboxes__label"><%= p.label :can_manage_locations, 'Manage locations' %></label>
+                  </div>
+                <% end %>
+              </div>
+            </fieldset>
+          </div>
+        </div>
+
+        <div class="actions">
           <%= f.submit "Send invitation email", class: "govuk-button govuk-!-margin-top-4" %>
         </div>
       <% end %>

--- a/spec/features/team/invite_with_permissions_spec.rb
+++ b/spec/features/team/invite_with_permissions_spec.rb
@@ -1,0 +1,47 @@
+require 'features/support/sign_up_helpers'
+require 'support/notifications_service'
+
+describe 'Set user permissions on invite' do
+  include_examples 'notifications service'
+
+  let(:user) { create(:user, :confirmed) }
+  let(:invited_email) { 'invited@gov.uk' }
+  let(:invited_user) { User.find_by(email: invited_email) }
+
+  before do
+    sign_in_user user
+    visit new_user_invitation_path
+    fill_in 'Email', with: invited_email
+  end
+
+  context 'Given I set all the permissions' do
+    it 'should assign all the permissions to the user' do
+      click_on 'Send invitation email'
+
+      expect(invited_user.permission.can_manage_team?).to eq(true)
+      expect(invited_user.permission.can_manage_locations?).to eq(true)
+    end
+  end
+
+  context 'Given I set only the .can_manage_team permission' do
+    it 'should assign only that permission' do
+      uncheck 'Manage locations'
+      click_on 'Send invitation email'
+
+      expect(invited_user.permission.can_manage_team?).to eq(true)
+      expect(invited_user.permission.can_manage_locations?).to eq(false)
+    end
+  end
+
+  context 'Given I set no permissions' do
+    it 'should assign no permissions' do
+      uncheck 'Manage locations'
+      uncheck 'Manage team'
+
+      click_on 'Send invitation email'
+
+      expect(invited_user.permission.can_manage_team?).to eq(false)
+      expect(invited_user.permission.can_manage_locations?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
When you invite another network administrator, you can set their
permissions to manage their team and ips/locations.