### PR TITLE
Remove text explaining how to remove IPs

### DIFF
--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -22,21 +22,3 @@
     <%= render "ips/table", location: location %>
   <% end %>
 <% end %>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-
-    <div class="govuk-details">
-      <div class="govuk-details__text">
-        <h4 class="govuk-heading-s">
-          What if I want to remove an IP?
-        </h4>
-        <p class="govuk-body"> Contact us via our <%= link_to "support form", help_index_path %> and use this format:</p>
-        <ul class="govuk-list">
-          <li> Subject: Remove IP </li>
-          <li> Text: Name of organisation, IPs you want to remove </li>
-        </ul>
-      </div>
-    </div>
-  </div>
-</div>


### PR DESCRIPTION
Removes this:

<img width="1068" alt="screenshot 2018-11-20 at 16 12 02" src="https://user-images.githubusercontent.com/2160769/48786570-09bc5600-ecdf-11e8-91b6-daed0b201a43.png">
