### PR TITLE
Add govuk-link class to all text links

### DIFF
--- a/app/views/admin/mou/index.html.erb
+++ b/app/views/admin/mou/index.html.erb
@@ -5,7 +5,7 @@
     <p class="govuk-body">Be aware that any version of the MOU template that is uploaded will be visible to all organisations requesting to sign up to GovWifi.</p>
     <hr class="govuk-section-break--m govuk-section-break--visible">
     <% if @mou.unsigned_document.attached? %>
-      <p class="govuk-body"><%= link_to "Download current template", rails_blob_path(@mou.unsigned_document, disposition: "attachment") %></p>
+      <%= link_to "Download current template", rails_blob_path(@mou.unsigned_document, disposition: "attachment"), class: "govuk-link" %>
     <% end %>
     <h3 class="govuk-heading-m">Upload Template</h3>
     <p class="govuk-body"> </p>

--- a/app/views/admin/organisations/_mou_form.html.erb
+++ b/app/views/admin/organisations/_mou_form.html.erb
@@ -3,7 +3,7 @@
 <% if mou_attached %>
   <p class="govuk-body">
     A signed MoU was uploaded on <%= organisation.signed_mou.attachment.created_at.strftime('%e %b %Y') %>,
-    <%= link_to "download and view the document.", rails_blob_path(organisation.signed_mou, disposition: "attachment") %>
+    <%= link_to "download and view the document.", rails_blob_path(organisation.signed_mou, disposition: "attachment"), class: "govuk-link" %>
   </p>
 
   <h3 class="govuk-heading-m">Replace MoU</h3>

--- a/app/views/admin/organisations/index.html.erb
+++ b/app/views/admin/organisations/index.html.erb
@@ -17,7 +17,7 @@
     <% @organisations.each do |organisation| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half" scope="row">
-          <%= link_to organisation.name, admin_organisation_path(organisation) %>
+          <%= link_to organisation.name, admin_organisation_path(organisation), class: "govuk-link" %>
         </td>
         <td class="govuk-table__cell" scope="row">
           <%= organisation.created_at.strftime('%e %b %Y') %>

--- a/app/views/application/_radius_details.html.erb
+++ b/app/views/application/_radius_details.html.erb
@@ -6,7 +6,7 @@
   </summary>
   <div class="govuk-details__text">
     <% if current_organisation.locations.empty? %>
-      <p>Your RADIUS secret keys will be generated when you <%=link_to('add your first IP address', new_ip_path, class: "govuk-link")%></p>
+      <p>Your RADIUS secret keys will be generated when you <%= link_to 'add your first IP address', new_ip_path, class: "govuk-link" %></p>
     <% else %>
       <p> Your RADIUS secrets are:</p>
       <ul class="govuk-list">

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -10,7 +10,7 @@
           </h2>
             <p class="govuk-body">
               If an end user is having trouble with GovWifi, we recommend directing them to
-              <%= link_to 'our guidance on common issues', SITE_CONFIG['end_user_troubleshooting_link'] %>.
+              <%= link_to 'our guidance on common issues', SITE_CONFIG['end_user_troubleshooting_link'], class: "govuk-link" %>.
             </p>
             <p class="govuk-body">
               If this doesn't resolve the issue, we recommend they contact their
@@ -29,11 +29,11 @@
       <h2 class="govuk-heading-s">Before you contact us</h2>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li><%= link_to 'Check the GovWifi service status', status_index_path %></li>
-        <li>Check your <%= link_to 'configured IP addresses', ips_path %> match your authenticator IPs </li>
+        <li><%= link_to 'Check the GovWifi service status', status_index_path, class: "govuk-link" %></li>
+        <li>Check your <%= link_to 'configured IP addresses', ips_path, class: "govuk-link" %> match your authenticator IPs </li>
         <li>Check your authenticators have the right RADIUS secret keys</li>
-        <li>Try logging in as an end user, then <%= link_to 'search our logs', search_logs_path %></li>
-        <li><%= link_to 'Browse the technical documentation', SITE_CONFIG['organisation_docs_link'] %></li>
+        <li>Try logging in as an end user, then <%= link_to 'search our logs', search_logs_path, class: "govuk-link" %></li>
+        <li><%= link_to 'Browse the technical documentation', SITE_CONFIG['organisation_docs_link'], class: "govuk-link" %></li>
       </ul>
     <p>
   </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -6,12 +6,12 @@
       <% if @ips.empty? %>
         <% if current_user.can_manage_locations? %>
           <p class="govuk-body">
-            You need to <%= link_to "add the IPs", new_ip_path %> of your authenticator(s).
+            You need to <%= link_to "add the IPs", new_ip_path, class: "govuk-link" %> of your authenticator(s).
           </p>
         <% end %>
       <% else %>
         <p class="govuk-body">
-          You have <%= link_to "#{pluralize(@ips.count, "IP")} configured.", ips_path  %>
+          You have <%= link_to "#{pluralize(@ips.count, "IP")} configured.", ips_path, class: "govuk-link"  %>
         </p>
       <% end %>
       <p class="govuk-body">If your authenticators are allocated IPs dynamically, you can use Firewall NAT rules, so that your requests come from consistent IPs.</p>
@@ -54,7 +54,7 @@
           </p>
           <p class="govuk-body"> You’ll receive your username and password in reply. </p>
           <p>
-            See our <%= link_to "full guidance", SITE_CONFIG['end_user_docs_link'] %> for individuals.
+            See our <%= link_to "full guidance", SITE_CONFIG['end_user_docs_link'], class: "govuk-link" %> for individuals.
           </p>
         </div>
       </details>
@@ -63,7 +63,7 @@
     <div>
       <h3 class="govuk-heading-m"> 6. Sign your agreement </h3>
       <p class="govuk-body">
-        <%= link_to "Sign a memorandum of understanding (MOU)", mou_index_path %> with the Government Digital Service (GDS).
+        <%= link_to "Sign a memorandum of understanding (MOU)", mou_index_path, class: "govuk-link" %> with the Government Digital Service (GDS).
       </p>
       <p class="govuk-body">This must be done by someone in your organisation who has permission to sign off and procure services'.</p>
     </div>

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -14,11 +14,11 @@
         <% end %>
         <td class="govuk-table__cell text-right">
           <% if current_user.can_manage_locations? %>
-            <%= link_to 'Remove', ip_remove_path(ip) %>
+            <%= link_to 'Remove', ip_remove_path(ip), class: "govuk-link" %>
           <% end %>
         </td>
         <td class="govuk-table__cell text-right">
-          <%= link_to 'View logs', logs_path(ip: ip.address) %>
+          <%= link_to 'View logs', logs_path(ip: ip.address), class: "govuk-link" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/logs/search.html.erb
+++ b/app/views/logs/search.html.erb
@@ -9,7 +9,7 @@
       </p>
       <p class="govuk-body">
         The system will only return logs for user activity on IP addresses you own. If you
-        need more info please <%= link_to "contact us.", help_index_path %>
+        need more info please <%= link_to "contact us.", help_index_path, class: "govuk-link" %>
       </p>
     </div>
 

--- a/app/views/mou/index.html.erb
+++ b/app/views/mou/index.html.erb
@@ -4,12 +4,14 @@
     <p class="govuk-body">You must sign a memorandum of understanding (MOU) to use GovWifi.</p>
     <% if @mou.unsigned_document.attached? %>
       <ul class="govuk-list govuk-list">
-        <li>1. <%= link_to "Download a copy of the MOU", rails_blob_path(@mou.unsigned_document, disposition: "attachment") %></li>
+        <li>1. <%= link_to "Download a copy of the MOU", rails_blob_path(@mou.unsigned_document, disposition: "attachment"), class: "govuk-link" %></li>
         <li>2. Sign the document</li>
         <li>3. Upload your signed MOU</li>
       </ul>
     <% else %>
-      <p class="govuk-body">The MOU template is not yet available for download. Contact us via our <%= link_to "support form", help_index_path %> if you need a copy.
+      <p class="govuk-body">
+        The MOU template is not yet available for download. Contact us via our
+        <%= link_to "support form", help_index_path, class: "govuk-link" %> if you need a copy.
       </p>
     <% end %>
     <div>

--- a/app/views/team_members/_table.html.erb
+++ b/app/views/team_members/_table.html.erb
@@ -59,7 +59,7 @@
 
     <li>
       <% if current_user.can_manage_team? && member.id != current_user.id %>
-        <%= link_to 'Edit permissions', edit_permission_path(id: member.permission.id) %>
+        <%= link_to 'Edit permissions', edit_permission_path(id: member.permission.id), class: "govuk-link" %>
       <% end %>
     </li>
 

--- a/app/views/team_members/index.html.erb
+++ b/app/views/team_members/index.html.erb
@@ -17,7 +17,10 @@
     <h4 class="govuk-heading-s">
       What if I want to edit or remove a team member?
     </h4>
-      <p class="govuk-body"> Contact us via our <%= link_to "support form", help_index_path %> and use this format:</p>
+      <p class="govuk-body">
+        Contact us via our <%= link_to "support form", help_index_path, class: "govuk-link" %>
+        and use this format:
+      </p>
         <ul class="govuk-list">
           <li> Subject: Edit or remove team member </li>
           <li> Text: Name of organisation, user details to amend </li>

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -2,4 +2,4 @@
 
 <p>You can confirm your account email through the link below:</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token, host: "http://localhost:3000") %></p>
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token, host: "http://localhost:3000"), class: "govuk-link" %></p>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -12,6 +12,6 @@
   <% end %>
 
   <% if devise_mapping.recoverable? && controller_name != 'passwords' %>
-    <%= link_to "Forgot your password?", new_password_path(resource_name) %>
+    <%= link_to "Forgot your password?", new_password_path(resource_name), class: "govuk-link" %>
   <% end %>
 </ul>


### PR DESCRIPTION
All text links require the `govuk-link` class.