### PR TITLE
Make confirmed standard on user factory

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,10 +6,12 @@ FactoryBot.define do
     password { '123456' }
     password_confirmation { '123456' }
     name { "bob" }
+    confirmed_at { Time.zone.now }
+
     association :organisation
 
-    trait :confirmed do
-      confirmed_at { Time.zone.now }
+    trait :unconfirmed do
+      confirmed_at { nil }
     end
   end
 end

--- a/spec/features/admin/sign_in_as_admin_spec.rb
+++ b/spec/features/admin/sign_in_as_admin_spec.rb
@@ -2,7 +2,7 @@ require 'features/support/sign_up_helpers'
 require 'features/support/not_signed_in'
 
 describe 'signing as an admin user' do
-  let!(:user) { create(:user, :confirmed, admin: true) }
+  let!(:user) { create(:user, admin: true) }
 
   context 'when visiting the home page' do
     before do

--- a/spec/features/admin/sort_view_in_organisation_list_spec.rb
+++ b/spec/features/admin/sort_view_in_organisation_list_spec.rb
@@ -2,7 +2,7 @@ require 'features/support/sign_up_helpers'
 
 describe 'sorting the values in the organisation list' do
   context 'when super admin views the list' do
-    let(:super_admin) { create(:user, :confirmed, admin: true) }
+    let(:super_admin) { create(:user, admin: true) }
 
     before do
       create(:organisation, name: "Department of Silly Hats", created_at: '10 Dec 2013')

--- a/spec/features/admin/view_organisation_list_spec.rb
+++ b/spec/features/admin/view_organisation_list_spec.rb
@@ -13,7 +13,7 @@ describe 'view list of signed up organisations' do
   end
 
   context 'when logged in as a normal user' do
-    let(:user) { create(:user, :confirmed) }
+    let(:user) { create(:user) }
 
     it 'redirects me to the landing guidance' do
       expect(page).to have_content 'Get GovWifi'
@@ -22,7 +22,7 @@ describe 'view list of signed up organisations' do
   end
 
   context 'when logged in as an admin' do
-    let(:user) { create(:user, :confirmed, admin: true) }
+    let(:user) { create(:user, admin: true) }
 
     context 'and one organisation exists' do
       let(:org) { create(:organisation, name: "Fake Org", created_at: '1 Feb 2014') }

--- a/spec/features/admin/view_organisation_page_spec.rb
+++ b/spec/features/admin/view_organisation_page_spec.rb
@@ -13,7 +13,7 @@ describe 'view details of a signed up organisation' do
 
   context 'when logged in as a normal user' do
     before do
-      sign_in_user create(:user, :confirmed)
+      sign_in_user create(:user)
       visit admin_organisation_path(organisation)
     end
 
@@ -24,10 +24,10 @@ describe 'view details of a signed up organisation' do
     let(:location) { create(:location, organisation: organisation) }
 
     before do
-      create(:user, :confirmed, organisation: organisation)
+      create(:user, organisation: organisation)
       create(:ip, location: location)
 
-      sign_in_user create(:user, :confirmed, admin: true)
+      sign_in_user create(:user, admin: true)
       visit admin_organisation_path(organisation)
     end
 

--- a/spec/features/admin/view_organisation_tab_spec.rb
+++ b/spec/features/admin/view_organisation_tab_spec.rb
@@ -10,7 +10,7 @@ describe 'the visibility of the organisation depending on user' do
 
   context 'when logged in as Admin' do
     let(:organisation) { create(:organisation) }
-    let(:user) { create(:user, :confirmed, email: 'me@example.gov.uk', organisation: organisation, admin: true) }
+    let(:user) { create(:user, email: 'me@example.gov.uk', organisation: organisation, admin: true) }
 
     it 'displays the organisation tab' do
       sign_in_user user
@@ -22,7 +22,7 @@ describe 'the visibility of the organisation depending on user' do
 
   context 'when logged in as normal user' do
     let(:organisation) { create(:organisation) }
-    let(:user) { create(:user, :confirmed, email: 'me@example.gov.uk', organisation: organisation) }
+    let(:user) { create(:user, email: 'me@example.gov.uk', organisation: organisation) }
 
     it 'will not display the organisation tab' do
       sign_in_user user
@@ -43,7 +43,7 @@ describe 'the visibility of the organisation depending on user' do
     let!(:organisation_def) { create(:organisation, name: "DEF") }
     let!(:organisation_xyz) { create(:organisation, name: "XYZ") }
     let!(:organisation_abc) { create(:organisation, name: "ABC") }
-    let(:user) { create(:user, :confirmed, email: 'me@example.gov.uk', organisation: organisation_abc, admin: true) }
+    let(:user) { create(:user, email: 'me@example.gov.uk', organisation: organisation_abc, admin: true) }
 
     it 'display list of organisations in alphabetical order' do
       sign_in_user user

--- a/spec/features/authentication/lock_user_account_spec.rb
+++ b/spec/features/authentication/lock_user_account_spec.rb
@@ -5,7 +5,7 @@ describe 'Locking a users account' do
 
   let(:correct_password) { 'password' }
   let(:incorrect_password) { 'incorrectpassword' }
-  let(:user) { create(:user, :confirmed, password: correct_password, password_confirmation: correct_password) }
+  let(:user) { create(:user, password: correct_password, password_confirmation: correct_password) }
 
   before { visit new_user_session_path }
 

--- a/spec/features/authentication/reset_password_spec.rb
+++ b/spec/features/authentication/reset_password_spec.rb
@@ -35,7 +35,7 @@ describe "Resetting a password" do
     include_examples 'confirmation use case spy'
     include_examples 'notifications service'
 
-    let(:user) { create(:user) }
+    let(:user) { create(:user, :unconfirmed) }
 
     it "sends the confirmation instructions instead of reset password" do
       visit new_user_password_path
@@ -53,7 +53,7 @@ describe "Resetting a password" do
     include_examples 'reset password use case spy'
     include_examples 'notifications service'
 
-    let(:user) { create(:user, :confirmed) }
+    let(:user) { create(:user) }
 
     it "sends the reset password instructions" do
       expect {

--- a/spec/features/contact_us_submit_spec.rb
+++ b/spec/features/contact_us_submit_spec.rb
@@ -7,7 +7,7 @@ describe 'contact us page' do
   include_examples 'notifications service'
   include_examples 'send help email use case spy'
 
-  let(:user) { create(:user, :confirmed) }
+  let(:user) { create(:user) }
 
   context 'with support ticket details filled in' do
     before do

--- a/spec/features/guidance_after_sign_in_spec.rb
+++ b/spec/features/guidance_after_sign_in_spec.rb
@@ -2,7 +2,7 @@ require 'features/support/sign_up_helpers'
 require 'support/notifications_service'
 
 describe 'guidance after sign in' do
-  let(:user) { create(:user, :confirmed) }
+  let(:user) { create(:user) }
   before { sign_in_user user }
 
   context 'without locations' do

--- a/spec/features/ips/add_an_ip_address_spec.rb
+++ b/spec/features/ips/add_an_ip_address_spec.rb
@@ -10,7 +10,7 @@ describe 'Add an IP to my account' do
   include_examples 'notifications service'
 
   context 'and the new location is invalid' do
-    let!(:user) { create(:user, :confirmed) }
+    let!(:user) { create(:user) }
 
     before do
       sign_in_user user
@@ -37,7 +37,7 @@ describe 'Add an IP to my account' do
   end
 
   context 'to an already existing location' do
-    let!(:user) { create(:user, :confirmed) }
+    let!(:user) { create(:user) }
     let!(:location_1) { create(:location, address: '10 Street', postcode: 'XX YYY', organisation: user.organisation) }
     let!(:location_2) { create(:location, address: '50 Road', postcode: 'ZZ AAA', organisation: user.organisation) }
 
@@ -133,7 +133,7 @@ describe 'Add an IP to my account' do
     end
 
     context 'to new location' do
-      let!(:user) { create(:user, :confirmed) }
+      let!(:user) { create(:user) }
       let!(:location_1) { create(:location, address: '10 Street', postcode: 'XX YYY', organisation: user.organisation) }
 
       context 'when logged in' do

--- a/spec/features/ips/permissions_spec.rb
+++ b/spec/features/ips/permissions_spec.rb
@@ -1,7 +1,7 @@
 require 'features/support/sign_up_helpers'
 
 describe 'Add an IP' do
-  let!(:user) { create(:user, :confirmed) }
+  let!(:user) { create(:user) }
 
   before do
     sign_in_user user

--- a/spec/features/ips/remove_an_ip_spec.rb
+++ b/spec/features/ips/remove_an_ip_spec.rb
@@ -1,7 +1,7 @@
 require 'features/support/sign_up_helpers'
 
 describe 'Remove an IP' do
-  let(:user) { create(:user, :confirmed) }
+  let(:user) { create(:user) }
   let(:location) { create(:location, organisation: user.organisation) }
   let!(:ip) { create(:ip, location: location) }
 

--- a/spec/features/ips/view_ip_address_readiness_spec.rb
+++ b/spec/features/ips/view_ip_address_readiness_spec.rb
@@ -8,7 +8,7 @@ describe 'with a stubbed notifications service' do
 
   describe 'Viewing IPs' do
     context 'when one has been added' do
-      let(:user) { create(:user, :confirmed) }
+      let(:user) { create(:user) }
 
       before do
         sign_in_user user

--- a/spec/features/ips/view_ip_addresses_spec.rb
+++ b/spec/features/ips/view_ip_addresses_spec.rb
@@ -16,7 +16,7 @@ describe 'View IP addresses' do
   end
 
   context 'when logged in' do
-    let(:user) { create(:user, :confirmed) }
+    let(:user) { create(:user) }
 
     context 'with no IPs' do
       before do

--- a/spec/features/logging/view_auth_requests_for_a_username_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_a_username_spec.rb
@@ -4,7 +4,7 @@ describe "View authentication requests for a username" do
   context "with results" do
     let(:username) { "AAAAAA" }
     let(:organisation) { create(:organisation) }
-    let(:admin_user) { create(:user, :confirmed, organisation_id: organisation.id) }
+    let(:admin_user) { create(:user, organisation_id: organisation.id) }
     let(:location) { create(:location, organisation_id: organisation.id) }
 
     before do
@@ -80,7 +80,7 @@ describe "View authentication requests for a username" do
   end
 
   context 'without results' do
-    let(:user) { create(:user, :confirmed) }
+    let(:user) { create(:user) }
     let(:username) { 'random' }
 
     before do

--- a/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
@@ -5,7 +5,7 @@ describe 'View authentication requests for an IP' do
     let(:ip) { '127.0.0.1' }
     let(:username) { 'ABCDEF' }
     let(:organisation) { create(:organisation) }
-    let(:admin_user) { create(:user, :confirmed, organisation_id: organisation.id) }
+    let(:admin_user) { create(:user, organisation_id: organisation.id) }
     let(:location) { create(:location, organisation_id: organisation.id) }
 
     before do

--- a/spec/features/logout_user_after_inactivity_spec.rb
+++ b/spec/features/logout_user_after_inactivity_spec.rb
@@ -2,7 +2,7 @@ require 'features/support/sign_up_helpers'
 require 'timecop'
 
 describe 'logout users after specific period of inactivity' do
-  let(:user) { create(:user, :confirmed) }
+  let(:user) { create(:user) }
 
   context 'when a signed in user has been inactive for 59 minutes' do
     before do

--- a/spec/features/status/view_status_spec.rb
+++ b/spec/features/status/view_status_spec.rb
@@ -11,7 +11,7 @@ describe 'View GovWifi Status' do
   end
 
   context 'when logged in' do
-    let(:user) { create(:user, :confirmed) }
+    let(:user) { create(:user) }
 
     before do
       allow_any_instance_of(

--- a/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
+++ b/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
@@ -7,7 +7,7 @@ describe "Sign up from invitation" do
   include_examples 'invite use case spy'
   include_examples 'notifications service'
 
-  let(:user) { create(:user, :confirmed) }
+  let(:user) { create(:user) }
   let(:invited_user_email) { "invited@gov.uk" }
 
   before do

--- a/spec/features/team/edit_permissions_spec.rb
+++ b/spec/features/team/edit_permissions_spec.rb
@@ -1,13 +1,13 @@
 require 'features/support/sign_up_helpers'
 
 describe 'Edit user permissions' do
-  let(:user) { create(:user, :confirmed) }
+  let(:user) { create(:user) }
   let(:invited_user_other_org) { User.find_by(email: 'invited_other_org@gov.uk') }
   let(:invited_user_same_org) { User.find_by(email: 'invited_same_org@gov.uk') }
 
   before do
-    create(:user, :confirmed, email: 'invited_other_org@gov.uk')
-    create(:user, :confirmed, email: 'invited_same_org@gov.uk', organisation: user.organisation)
+    create(:user, email: 'invited_other_org@gov.uk')
+    create(:user, email: 'invited_same_org@gov.uk', organisation: user.organisation)
     sign_in_user user
   end
 

--- a/spec/features/team/invite_a_team_member_spec.rb
+++ b/spec/features/team/invite_a_team_member_spec.rb
@@ -17,7 +17,7 @@ describe "Invite a team member" do
   end
 
   context "when logged in" do
-    let(:user) { create(:user, :confirmed) }
+    let(:user) { create(:user) }
     before do
       sign_in_user user
       visit root_path

--- a/spec/features/team/invite_with_permissions_spec.rb
+++ b/spec/features/team/invite_with_permissions_spec.rb
@@ -4,7 +4,7 @@ require 'support/notifications_service'
 describe 'Set user permissions on invite' do
   include_examples 'notifications service'
 
-  let(:user) { create(:user, :confirmed) }
+  let(:user) { create(:user) }
   let(:invited_email) { 'invited@gov.uk' }
   let(:invited_user) { User.find_by(email: invited_email) }
 

--- a/spec/features/team/permissions_spec.rb
+++ b/spec/features/team/permissions_spec.rb
@@ -3,7 +3,7 @@ require 'support/notifications_service'
 
 describe 'Invite a team member' do
   include_examples 'notifications service'
-  let(:user) { create(:user, :confirmed) }
+  let(:user) { create(:user) }
 
   before do
     sign_in_user user

--- a/spec/features/team/remove_a_team_member_spec.rb
+++ b/spec/features/team/remove_a_team_member_spec.rb
@@ -1,8 +1,8 @@
 require 'features/support/sign_up_helpers'
 
 describe "Remove a team member" do
-  let(:user) { create(:user, :confirmed) }
-  let(:another_user) { create(:user, :confirmed, organisation: user.organisation) }
+  let(:user) { create(:user) }
+  let(:another_user) { create(:user, organisation: user.organisation) }
 
   before do
     sign_in_user user

--- a/spec/features/team/resend_invitation_spec.rb
+++ b/spec/features/team/resend_invitation_spec.rb
@@ -8,7 +8,7 @@ describe 'Resend invitation to team member' do
     include_examples 'invite use case spy'
     include_examples 'notifications service'
 
-    let(:user) { create(:user, :confirmed) }
+    let(:user) { create(:user) }
     let(:invited_user_email) { 'invited@gov.uk' }
 
     before do

--- a/spec/features/team/view_team_members_spec.rb
+++ b/spec/features/team/view_team_members_spec.rb
@@ -10,7 +10,7 @@ describe 'View team members of my organisation' do
 
   context 'when logged in' do
     let(:organisation) { create(:organisation) }
-    let(:user) { create(:user, :confirmed, email: 'me@example.gov.uk', organisation: organisation) }
+    let(:user) { create(:user, email: 'me@example.gov.uk', organisation: organisation) }
 
     before do
       ENV['LONDON_RADIUS_IPS'] = "1.1.1.1,2.2.2.2"
@@ -38,7 +38,7 @@ describe 'View team members of my organisation' do
 
     context 'when there are many users in my organisation' do
       before do
-        create(:user, :confirmed, email: 'friend@example.gov.uk', organisation: organisation)
+        create(:user, email: 'friend@example.gov.uk', organisation: organisation)
       end
 
       it 'renders all users within my organisation' do
@@ -53,7 +53,7 @@ describe 'View team members of my organisation' do
     context 'when there are users outside of my organisation' do
       before do
         other_organisation = create(:organisation, name: 'Org 2')
-        create(:user, :confirmed, email: 'stranger@example.gov.uk', organisation: other_organisation)
+        create(:user, email: 'stranger@example.gov.uk', organisation: other_organisation)
       end
 
       it 'does not include users from other organisations' do

--- a/spec/features/upload_download_mous_spec.rb
+++ b/spec/features/upload_download_mous_spec.rb
@@ -10,7 +10,7 @@ describe 'the upload and download of MOUs' do
 
   context 'As normal user' do
     let!(:organisation) { create(:organisation) }
-    let!(:user) { create(:user, :confirmed, email: 'me@example.gov.uk', organisation: organisation) }
+    let!(:user) { create(:user, email: 'me@example.gov.uk', organisation: organisation) }
 
     before do
       sign_in_user user
@@ -47,7 +47,7 @@ describe 'the upload and download of MOUs' do
 
   context 'As a super admin' do
     let!(:organisation) { create(:organisation) }
-    let!(:user) { create(:user, :confirmed, email: 'me@example.gov.uk', organisation: organisation, admin: true) }
+    let!(:user) { create(:user, email: 'me@example.gov.uk', organisation: organisation, admin: true) }
 
     it 'uploads and downloads the mou template' do
       sign_in_user user

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ describe User do
     it { is_expected.to validate_presence_of(:name).on(:update) }
 
     describe 'password confirmation' do
-      subject { create(:user, :confirmed) }
+      subject { create(:user) }
 
       before do
         subject.update(
@@ -62,14 +62,14 @@ describe User do
   end
 
   describe '#save' do
-    subject { build(:user, :confirmed) }
+    subject { build(:user) }
 
     context 'with the factory-built model' do
       it { is_expected.to be_valid }
     end
 
     context 'with valid data' do
-      subject { build(:user, :confirmed, email: 'name@gov.uk') }
+      subject { build(:user, email: 'name@gov.uk') }
 
       it { is_expected.to be_valid }
 
@@ -84,7 +84,7 @@ describe User do
 
     context 'with a non-gov.uk email' do
       context 'for a new record' do
-        subject { build(:user, :confirmed, email: 'name@arbitrary-domain.com') }
+        subject { build(:user, email: 'name@arbitrary-domain.com') }
 
         it { is_expected.to_not be_valid }
 
@@ -101,7 +101,7 @@ describe User do
 
       context 'for an existing record' do
         subject do
-          user = create(:user, :confirmed)
+          user = create(:user)
           user.email = 'name@arbitrary-domain.com'
           user
         end
@@ -113,7 +113,7 @@ describe User do
 
   context 'permissions' do
     context 'a new user' do
-      subject { create(:user, :confirmed) }
+      subject { create(:user) }
 
       it 'can manage team members' do
         expect(subject.can_manage_team?).to be_truthy

--- a/spec/requests/ips/create_spec.rb
+++ b/spec/requests/ips/create_spec.rb
@@ -1,5 +1,5 @@
 describe "POST /ips", type: :request do
-  let(:user) { create(:user, :confirmed) }
+  let(:user) { create(:user) }
   let(:location) { create(:location, organisation: user.organisation) }
   let(:ip_address) { "10.0.0.1" }
 

--- a/spec/requests/ips/delete_spec.rb
+++ b/spec/requests/ips/delete_spec.rb
@@ -1,5 +1,5 @@
 describe "DELETE /ips/:id", type: :request do
-  let(:user) { create(:user, :confirmed) }
+  let(:user) { create(:user) }
   let(:location) { create(:location, organisation: user.organisation) }
   let!(:ip) { create(:ip, location: location) }
 

--- a/spec/requests/team_members/delete_spec.rb
+++ b/spec/requests/team_members/delete_spec.rb
@@ -1,6 +1,6 @@
 describe "DELETE /team_members/:id", type: :request do
-  let(:user) { create(:user, :confirmed) }
-  let!(:team_member) { create(:user, :confirmed, organisation: user.organisation) }
+  let(:user) { create(:user) }
+  let!(:team_member) { create(:user, organisation: user.organisation) }
 
   before do
     https!
@@ -16,7 +16,7 @@ describe "DELETE /team_members/:id", type: :request do
   end
 
   context "when the team member belongs to another team" do
-    let!(:other_team_member) { create(:user, :confirmed) }
+    let!(:other_team_member) { create(:user) }
     it "does not delete the user" do
       expect {
         delete team_member_path(other_team_member)


### PR DESCRIPTION
`create(:user, :confirmed)` is gone.

It is now:
```
  create(:user)
  create(:user, :unconfirmed)
```