### PR TITLE
Prevent duplicate organisation signups

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -4,6 +4,6 @@ class Organisation < ApplicationRecord
   has_many :locations
   has_many :ips, through: :locations
 
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :service_email, presence: true, on: :create
 end

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -5,7 +5,7 @@
     <h1 class="govuk-heading-l">Sign up your Organisation to GovWifi</h1>
 
     <p class="govuk-body">
-      If you are trying to connect to GovWifi as an end user, see instructions <%= link_to "here", "", class: "govuk-link" %>
+      If you are trying to connect to GovWifi as an end user, see the <%= link_to "instructions.", SITE_CONFIG['end_user_docs_link'], class: "govuk-link" %>
     </p>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { novalidate: '' }) do |f| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,11 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  activerecord:
+    errors:
+      models:
+        organisation:
+          attributes:
+            name:
+              taken: " is already registered. If you wish to administer an \n
+              existing GovWifi installation, you must be invited to the \n
+              account. Please contact govwifi-support@digital.cabinet-office.gov.uk \n
+              if you need help."

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -105,7 +105,7 @@ describe 'Sign up as an organisation' do
     it_behaves_like 'errors in form'
 
     it 'tells the user that the organisation name must be unique' do
-      expect(page).to have_content 'Organisation name has already been taken'
+      expect(page).to have_content 'Organisation name is already registered'
     end
   end
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -6,10 +6,10 @@ describe Organisation do
     it { should validate_uniqueness_of(:name).case_insensitive }
 
     it "requires a unique name regardless of case" do
-      organisation = Organisation.create(name: "Parks & Rec Dept")
+      Organisation.create(name: "Parks & Rec Dept")
       expect {
         Organisation.create(name: "parks & rec dept")
-      }.to_not change { Organisation.count }
+      }.to change { Organisation.count }.by(0)
     end
   end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -3,6 +3,13 @@ describe Organisation do
     it { should have_many(:users) }
     it { should have_many(:locations) }
     it { should validate_presence_of(:name) }
-    it { should validate_uniqueness_of(:name) }
+    it { should validate_uniqueness_of(:name).case_insensitive }
+
+    it "requires a unique name regardless of case" do
+      organisation = Organisation.create(name: "Parks & Rec Dept")
+      expect {
+        Organisation.create(name: "parks & rec dept")
+      }.to_not change { Organisation.count }
+    end
   end
 end


### PR DESCRIPTION
Two ways:
1. Organisation name validation is now case insensitive, eg: `Toms Org == toms org`.
2. There is a more explanatory error message when a duplicate organisation tries to sign up:

![screenshot 2018-11-21 at 16 05 30](https://user-images.githubusercontent.com/2160769/48853644-dbef1400-eda7-11e8-8681-6935f58ad4a3.png)
