### PR TITLE
Allow 5-character usernames for log searching

### DIFF
--- a/lib/use_cases/administrator/validate_log_search_query.rb
+++ b/lib/use_cases/administrator/validate_log_search_query.rb
@@ -12,7 +12,7 @@ module UseCases
       end
 
       def valid_username?(username)
-        username.present? && username.length > 5
+        username.present? && username.length > 4
       end
 
       def valid_ip?(ip)

--- a/spec/use_cases/administrator/validate_log_search_query_spec.rb
+++ b/spec/use_cases/administrator/validate_log_search_query_spec.rb
@@ -5,6 +5,7 @@ describe UseCases::Administrator::ValidateLogSearchQuery do
     context 'valid username' do
       it 'returns true' do
         valid_params = [
+          { username: 'ABCDE', ip: nil },
           { username: 'ABCDEF', ip: nil },
           { username: nil, ip: '127.0.0.1' }
         ]


### PR DESCRIPTION
There's thousands of older GovWifi accounts with 5-character usernames, so feels like we should cover them here.