### PR TITLE
Replace end user support links

### DIFF
--- a/config/site.yml
+++ b/config/site.yml
@@ -1,6 +1,6 @@
 default: &default
   end_user_docs_link: 'https://www.gov.uk/government/collections/connect-to-govwifi'
-  end_user_troubleshooting_link: 'https://www.gov.uk/government/collections/connect-to-govwifi'
+  end_user_troubleshooting_link: 'https://www.gov.uk/guidance/solve-problems-with-connecting-to-govwifi'
   organisation_docs_link: 'https://docs.wifi.service.gov.uk'
   product_page_link: 'https://wifi.service.gov.uk'
   google_tag_container_ID: 'GTM-TNHHHPZ'

--- a/config/site.yml
+++ b/config/site.yml
@@ -1,6 +1,6 @@
 default: &default
   end_user_docs_link: 'https://wifi.service.gov.uk/connect'
-  end_user_troubleshooting_link: 'https://wifi.service.gov.uk/troubleshooting'
+  end_user_troubleshooting_link: 'https://www.gov.uk/government/collections/connect-to-govwifi'
   organisation_docs_link: 'https://docs.wifi.service.gov.uk'
   product_page_link: 'https://wifi.service.gov.uk'
   google_tag_container_ID: 'GTM-TNHHHPZ'

--- a/config/site.yml
+++ b/config/site.yml
@@ -1,5 +1,5 @@
 default: &default
-  end_user_docs_link: 'https://wifi.service.gov.uk/connect'
+  end_user_docs_link: 'https://www.gov.uk/government/collections/connect-to-govwifi'
   end_user_troubleshooting_link: 'https://www.gov.uk/government/collections/connect-to-govwifi'
   organisation_docs_link: 'https://docs.wifi.service.gov.uk'
   product_page_link: 'https://wifi.service.gov.uk'


### PR DESCRIPTION
Based on suggestions from the content designers to separate end-user support and admin-user support, end user support links redirect to the GOV.uk page and not to the GovWifi Product page.