### PR TITLE
Remove Password Confirmation

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -54,6 +54,6 @@ protected
   end
 
   def user_params
-    params.require(:user).permit(:name, :password, :password_confirmation, organisation_attributes: %i[name service_email])
+    params.require(:user).permit(:name, :password, organisation_attributes: %i[name service_email])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,9 +12,6 @@ class User < ApplicationRecord
 
   validates :name, presence: true, on: :update
 
-  validates :password, confirmation: true, on: :update
-  validates :password_confirmation, presence: true, on: :update
-
   validate :email_on_whitelist, on: :create
 
   after_create :create_default_permissions

--- a/app/views/users/confirmations/show.html.erb
+++ b/app/views/users/confirmations/show.html.erb
@@ -32,11 +32,6 @@
           <%= f.password_field :password, class: "govuk-input", autocomplete: "off" %>
         </div>
 
-        <div class="govuk-form-group <%= field_error(resource, :password_confirmation) %>">
-          <%= f.label :password_confirmation, "Confirm password", class: "govuk-label" %>
-          <%= f.password_field :password_confirmation, class: "govuk-input", autocomplete: "off" %>
-        </div>
-
         <div class="actions">
           <%= f.submit "Create my account", class: "govuk-button govuk-!-margin-top-2" %>
         </div>

--- a/app/views/users/invitations/edit.html.erb
+++ b/app/views/users/invitations/edit.html.erb
@@ -20,11 +20,6 @@
           <%= f.password_field :password, class: "govuk-input", autocomplete: "off" %>
         </div>
 
-        <div class="govuk-form-group <%= field_error(resource, :password_confirmation) %>">
-          <%= f.label :password_confirmation, "Confirm password", class: "govuk-label" %>
-          <%= f.password_field :password_confirmation, class: "govuk-input", autocomplete: "off" %>
-        </div>
-
         <div class="actions">
           <%= f.submit "Create my account", class: "govuk-button govuk-!-margin-top-2" %>
         </div>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -13,11 +13,6 @@
           <%= f.password_field :password, autofocus: true, class: "govuk-input", autocomplete: "off" %>
         </div>
 
-        <div class="govuk-form-group <%= field_error(resource, :password_confirmation) %>">
-          <%= f.label :password_confirmation, "Confirm new password", class: "govuk-label" %>
-          <%= f.password_field :password_confirmation, class: "govuk-input", autocomplete: "off" %>
-        </div>
-
         <div class="actions">
           <%= f.submit "Change my password", class: "govuk-button govuk-!-margin-top-2" %>
         </div>

--- a/lib/tasks/repair_migrated_data.rake
+++ b/lib/tasks/repair_migrated_data.rake
@@ -14,7 +14,6 @@ namespace :repair_migrated_data do
       random_password = Devise.friendly_token.first(16)
       user.update!(
         password: random_password,
-        password_confirmation: random_password,
         confirmed_at: user.created_at
       )
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
       "test#{n}@gov.uk"
     end
     password { '123456' }
-    password_confirmation { '123456' }
     name { "bob" }
     confirmed_at { Time.zone.now }
 

--- a/spec/features/authentication/lock_user_account_spec.rb
+++ b/spec/features/authentication/lock_user_account_spec.rb
@@ -5,7 +5,7 @@ describe 'Locking a users account' do
 
   let(:correct_password) { 'password' }
   let(:incorrect_password) { 'incorrectpassword' }
-  let(:user) { create(:user, password: correct_password, password_confirmation: correct_password) }
+  let(:user) { create(:user, password: correct_password) }
 
   before { visit new_user_session_path }
 

--- a/spec/features/authentication/logging_in_after_signing_up_spec.rb
+++ b/spec/features/authentication/logging_in_after_signing_up_spec.rb
@@ -11,10 +11,7 @@ describe 'logging in after signing up' do
 
   before do
     sign_up_for_account(email: 'tom@gov.uk')
-    update_user_details(
-      password: correct_password,
-      confirmed_password: correct_password
-    )
+    update_user_details(password: correct_password)
 
     click_on 'Sign out'
 

--- a/spec/features/authentication/reset_password_spec.rb
+++ b/spec/features/authentication/reset_password_spec.rb
@@ -86,7 +86,6 @@ describe "Resetting a password" do
       context "when entering correct passwords" do
         before do
           fill_in "user_password", with: "password"
-          fill_in "user_password_confirmation", with: "password"
           click_on "Change my password"
         end
 
@@ -99,7 +98,6 @@ describe "Resetting a password" do
       context "when entering a password that is too short" do
         before do
           fill_in "user_password", with: "1"
-          fill_in "user_password_confirmation", with: "1"
           click_on "Change my password"
         end
 
@@ -107,20 +105,6 @@ describe "Resetting a password" do
 
         it "tells the user the password is too short" do
           expect(page).to have_content("Password is too short")
-        end
-      end
-
-      context "when password confirmation does not match" do
-        before do
-          fill_in "user_password", with: "password"
-          fill_in "user_password_confirmation", with: "password1"
-          click_on "Change my password"
-        end
-
-        it_behaves_like "errors in form"
-
-        it "tells the user the passwords must match" do
-          expect(page).to have_content("Password confirmation doesn't match Password")
         end
       end
     end

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -65,24 +65,11 @@ describe 'Sign up as an organisation' do
     end
   end
 
-  context 'when password does not match password confirmation' do
-    before do
-      sign_up_for_account
-      update_user_details(password: 'password', confirmed_password: 'password1')
-      expect(page).to have_content 'Create your account'
-    end
-
-    it_behaves_like 'errors in form'
-
-    it 'tells the user that the passwords do not match' do
-      expect(page).to have_content "Password confirmation doesn't match Password"
-    end
-  end
 
   context 'when password is too short' do
     before do
       sign_up_for_account
-      update_user_details(password: '1', confirmed_password: '1')
+      update_user_details(password: '1')
       expect(page).to have_content 'Create your account'
     end
 
@@ -126,7 +113,7 @@ describe 'Sign up as an organisation' do
   context 'when password is too short' do
     before do
       sign_up_for_account
-      update_user_details(password: '1', confirmed_password: '1')
+      update_user_details(password: '1')
       expect(page).to have_content 'Create your account'
     end
 
@@ -148,25 +135,6 @@ describe 'Sign up as an organisation' do
 
     it 'tells the user the email is already confirmed' do
       expect(page).to have_content 'Email was already confirmed'
-    end
-  end
-
-  context 'when making two errors in a row' do
-    before do
-      sign_up_for_account
-      update_user_details(password: '1', confirmed_password: '1')
-      expect(page).to have_content 'Password is too short (minimum is 6 characters)'
-      expect(page).to have_content 'Create your account'
-
-      fill_in 'Password', with: "password"
-      fill_in 'Confirm password', with: "password1"
-      click_on 'Create my account'
-    end
-
-    it_behaves_like 'errors in form'
-
-    it 'correctly sets the second error' do
-      expect(page).to have_content "Password confirmation doesn't match Password"
     end
   end
 end

--- a/spec/features/support/sign_up_helpers.rb
+++ b/spec/features/support/sign_up_helpers.rb
@@ -8,7 +8,6 @@ end
 
 def update_user_details(
   password: 'supersecret',
-  confirmed_password: 'supersecret',
   name: 'bob',
   organisation_name: 'Parks and Recreation',
   service_email: 'admin@gov.uk'
@@ -19,7 +18,6 @@ def update_user_details(
   fill_in 'Service email', with: service_email
   fill_in 'Your name', with: name
   fill_in 'Password', with: password
-  fill_in 'Confirm password', with: confirmed_password
   click_on 'Create my account'
 end
 

--- a/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
+++ b/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
@@ -32,7 +32,6 @@ describe "Sign up from invitation" do
       before do
         fill_in "Your name", with: "Ron Swanson"
         fill_in "Password", with: "password"
-        fill_in "Confirm password", with: "password"
         click_on "Create my account"
       end
 

--- a/spec/features/team/resend_invitation_spec.rb
+++ b/spec/features/team/resend_invitation_spec.rb
@@ -42,7 +42,6 @@ describe 'Resend invitation to team member' do
         before do
           fill_in 'Your name', with: 'Ron Swanson'
           fill_in 'Password', with: 'password'
-          fill_in 'Confirm password', with: 'password'
           click_on 'Create my account'
         end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,60 +5,6 @@ describe User do
 
   context 'validations' do
     it { is_expected.to validate_presence_of(:name).on(:update) }
-
-    describe 'password confirmation' do
-      subject { create(:user) }
-
-      before do
-        subject.update(
-          name: 'new name',
-          password: 'new_password',
-          password_confirmation: password_confirmation
-        )
-      end
-
-      context 'matches password' do
-        let(:password_confirmation) { 'new_password' }
-
-        it { is_expected.to be_valid }
-
-        it 'updates the name' do
-          expect(subject.reload.name).to eq('new name')
-        end
-      end
-
-      context 'does not match password' do
-        let(:password_confirmation) { 'other_password' }
-
-        it { is_expected.to_not be_valid }
-
-        it 'does not update the name' do
-          expect(subject.reload.name).to_not eq('new name')
-        end
-
-        it 'explains the error' do
-          expect(subject.errors.full_messages).to include(
-            "Password confirmation doesn't match Password"
-          )
-        end
-      end
-
-      context 'is blank' do
-        let(:password_confirmation) { '' }
-
-        it { is_expected.to_not be_valid }
-
-        it 'does not update the name' do
-          expect(subject.reload.name).to_not eq('new name')
-        end
-
-        it 'explains the error' do
-          expect(subject.errors.full_messages).to include(
-            "Password confirmation can't be blank"
-          )
-        end
-      end
-    end
   end
 
   describe '#save' do


### PR DESCRIPTION
Requiring a user to confirm their password is rare and not done at GDS.
It was advised that we remove this as it doesn't provide that much
value.