### PR TITLE
Improve team members UX

### DIFF
--- a/app/assets/stylesheets/components/team_members.scss
+++ b/app/assets/stylesheets/components/team_members.scss
@@ -4,6 +4,7 @@
   cursor: pointer;
   text-decoration: underline;
   color: $govuk-link-colour;
+  background-color: transparent;
 
   &:hover {
     color: $govuk-link-hover-colour;

--- a/app/views/team_members/_table.html.erb
+++ b/app/views/team_members/_table.html.erb
@@ -46,7 +46,7 @@
           </ul>
         </div>
 
-        <div class='govuk-grid-column-one-third govuk-list govuk-!-padding-right-4'style="text-align:right">
+        <div class='govuk-grid-column-one-third govuk-list govuk-!-padding-right-4' style="text-align:right">
           <% if current_user.can_manage_team? && member.id != current_user.id %>
             <%= link_to 'Edit permissions', edit_team_member_path(member), class: "govuk-link" %>
 

--- a/app/views/team_members/_table.html.erb
+++ b/app/views/team_members/_table.html.erb
@@ -47,21 +47,19 @@
         </div>
 
         <div class='govuk-grid-column-one-third govuk-list'>
-          <% if member.invitation_pending? && current_user.can_manage_team? %>
-            <%= button_to("Resend invite",
-              user_invitation_path({ user: { email: member.email }}),
-              method: :post, class: 'resend-invite-button')
-            %>
+          <% if current_user.can_manage_team? && member.id != current_user.id %>
+            <%= link_to 'Edit permissions', edit_team_member_path(member), class: "govuk-link" %>
           <% end %>
-        </div>
       </div>
-    </li>
 
-    <li>
-      <% if current_user.can_manage_team? && member.id != current_user.id %>
-        <%= link_to 'Edit permissions', edit_team_member_path(member), class: "govuk-link" %>
-      <% end %>
-    </li>
+      <li>
+        <% if member.invitation_pending? && current_user.can_manage_team? %>
+          <%= button_to("Resend invite",
+            user_invitation_path({ user: { email: member.email }}),
+            method: :post, class: 'resend-invite-button')
+          %>
+        <% end %>
+      </li>
 
     <hr class='govuk-section-break--l govuk-!-margin-top-0'>
   <% end %>

--- a/app/views/team_members/_table.html.erb
+++ b/app/views/team_members/_table.html.erb
@@ -50,7 +50,7 @@
           <% if member.invitation_pending? && current_user.can_manage_team? %>
             <%= button_to("Resend invite",
               user_invitation_path({ user: { email: member.email }}),
-              method: :post, class: 'govuk-button')
+              method: :post, class: 'resend-invite-button')
             %>
           <% end %>
         </div>

--- a/app/views/team_members/_table.html.erb
+++ b/app/views/team_members/_table.html.erb
@@ -5,11 +5,10 @@
         <div class='govuk-grid-column-two-thirds'>
 
           <% if member.invitation_pending? %>
-            <h3 class='govuk-heading-m govuk-!-margin-bottom-0 text-light-grey'>Invitation pending</h3>
-
+            <h3 class='govuk-heading-m govuk-!-margin-bottom-0 text-light-grey'><%= member.email +  "(invited)" %></h3>
           <% else %>
-            <h3 class='govuk-heading-m govuk-!-margin-bottom-0'><%= member.name%>
-              <span class='govuk-body text-light-grey'><%= member.email %></span>
+            <h3 class='govuk-heading-m govuk-!-margin-bottom-0'><%= member.name %>
+              <span class='govuk-!-padding-left-1 govuk-body text-light-grey'><%= member.email %></span>
             </h3>
           <% end %>
 
@@ -47,20 +46,19 @@
           </ul>
         </div>
 
-        <div class='govuk-grid-column-one-third govuk-list'>
+        <div class='govuk-grid-column-one-third govuk-list govuk-!-padding-right-4'style="text-align:right">
           <% if current_user.can_manage_team? && member.id != current_user.id %>
             <%= link_to 'Edit permissions', edit_team_member_path(member), class: "govuk-link" %>
+
+            <% if member.invitation_pending? && current_user.can_manage_team? %>
+            <%= button_to("Resend invite",
+              user_invitation_path({ user: { email: member.email }}),
+              method: :post, class: 'resend-invite-button')
+            %>
+            <% end %>
           <% end %>
       </div>
-
-      <li>
-        <% if member.invitation_pending? && current_user.can_manage_team? %>
-          <%= button_to("Resend invite",
-            user_invitation_path({ user: { email: member.email }}),
-            method: :post, class: 'resend-invite-button')
-          %>
-        <% end %>
-        </li>
+      </li>
 
     <hr class='govuk-section-break--l govuk-!-margin-top-0'>
   <% end %>

--- a/app/views/team_members/_table.html.erb
+++ b/app/views/team_members/_table.html.erb
@@ -6,11 +6,12 @@
 
           <% if member.invitation_pending? %>
             <h3 class='govuk-heading-m govuk-!-margin-bottom-0 text-light-grey'>Invitation pending</h3>
-          <% else %>
-            <h3 class='govuk-heading-m govuk-!-margin-bottom-0'><%= member.name %></h3>
-          <% end %>
 
-          <p class='govuk-hint govuk-!-margin-top-0'><%= member.email %></p>
+          <% else %>
+            <h3 class='govuk-heading-m govuk-!-margin-bottom-0'><%= member.name%>
+              <span class='govuk-body text-light-grey'><%= member.email %></span>
+            </h3>
+          <% end %>
 
           <ul class='govuk-list'>
             <li>
@@ -59,7 +60,7 @@
             method: :post, class: 'resend-invite-button')
           %>
         <% end %>
-      </li>
+        </li>
 
     <hr class='govuk-section-break--l govuk-!-margin-top-0'>
   <% end %>

--- a/app/views/team_members/_table.html.erb
+++ b/app/views/team_members/_table.html.erb
@@ -5,7 +5,7 @@
         <div class='govuk-grid-column-two-thirds'>
 
           <% if member.invitation_pending? %>
-            <h3 class='govuk-heading-m govuk-!-margin-bottom-0 text-light-grey'><%= member.email +  "(invited)" %></h3>
+            <h3 class='govuk-heading-m govuk-!-margin-bottom-0 text-light-grey'><%= member.email %> (invited)</h3>
           <% else %>
             <h3 class='govuk-heading-m govuk-!-margin-bottom-0'><%= member.name %>
               <span class='govuk-!-padding-left-1 govuk-body text-light-grey'><%= member.email %></span>
@@ -46,9 +46,9 @@
           </ul>
         </div>
 
-        <div class='govuk-grid-column-one-third govuk-list govuk-!-padding-right-4' style="text-align:right">
+        <div class='govuk-grid-column-one-third govuk-list govuk-!-padding-right-4 text-right'>
           <% if current_user.can_manage_team? && member.id != current_user.id %>
-            <%= link_to 'Edit permissions', edit_team_member_path(member), class: "govuk-link" %>
+            <%= link_to 'Edit permissions', edit_team_member_path(member), class: "govuk-link govuk-!-padding-right-1"%>
 
             <% if member.invitation_pending? && current_user.can_manage_team? %>
             <%= button_to("Resend invite",

--- a/app/views/team_members/edit.html.erb
+++ b/app/views/team_members/edit.html.erb
@@ -1,6 +1,8 @@
 <%= link_to "Back to list", team_members_path, class: "govuk-back-link" %>
 <%= render "confirm_remove_team_member" if params[:remove_team_member] %>
-<h1 class="govuk-heading-m"><%= @user.name %> - <%= @user.email %></h1>
+
+<h1 class="govuk-heading-l govuk-!-margin-bottom-2"><%= @user.name %></h1>
+<p class="govuk-body"> <%= @user.email %> </p>
 
 <div class="actions">
   <div class="govuk-form-group">
@@ -19,13 +21,14 @@
               <label class="govuk-label govuk-checkboxes__label"><%= permission_form.label :can_manage_locations, 'Manage locations' %></label>
             </div>
           <% end %>
+            <p class="govuk-body govuk-!-margin-top-5"> All team members can view logs </p>
 
           <div class="govuk-!-margin-top-8">
             <%= form.submit 'Save', class: "govuk-button govuk-!-margin-0 govuk-!-margin-right-8 inline-block" %>
 
             <% unless params[:remove_team_member] %>
               <div class="govuk-body govuk-!-margin-top-2 inline-block">
-                <%= link_to 'Remove user from service', edit_team_member_path(@user, remove_team_member: true), class: 'govuk-link red-link' %>
+                <%= link_to 'Remove user from GovWifi admin', edit_team_member_path(@user, remove_team_member: true), class: 'govuk-link red-link' %>
               </div>
             <% end %>
           </div>

--- a/app/views/team_members/index.html.erb
+++ b/app/views/team_members/index.html.erb
@@ -11,19 +11,3 @@
 </div>
 
 <%= render "team_members/table", team_members: @team_members %>
-
-<div class="govuk-details">
-  <div class="govuk-details__text">
-    <h4 class="govuk-heading-s">
-      What if I want to edit or remove a team member?
-    </h4>
-      <p class="govuk-body">
-        Contact us via our <%= link_to "support form", help_index_path, class: "govuk-link" %>
-        and use this format:
-      </p>
-        <ul class="govuk-list">
-          <li> Subject: Edit or remove team member </li>
-          <li> Text: Name of organisation, user details to amend </li>
-        </ul>
-  </div>
-</div>

--- a/spec/features/team/remove_a_team_member_spec.rb
+++ b/spec/features/team/remove_a_team_member_spec.rb
@@ -11,7 +11,7 @@ describe "Remove a team member" do
   context "with the correct permissions" do
     before do
       visit edit_team_member_path(another_user)
-      click_on "Remove user from service"
+      click_on "Remove user from GovWifi admin"
     end
 
     it "shows the remove a team member confirmation box" do

--- a/spec/features/team/resend_invitation_spec.rb
+++ b/spec/features/team/resend_invitation_spec.rb
@@ -18,7 +18,7 @@ describe 'Resend invitation to team member' do
     end
 
     it 'shows that the invitation is pending' do
-      expect(page).to have_content('Invitation pending')
+      expect(page).to have_content('invited')
     end
 
     it 'sends an invitation' do


### PR DESCRIPTION
Change "resend invite" from button to link 
Pull "edit permissions" to be in right-hand column instead of below
Made changes to edit team member page with rewording and styling.

After:
<img width="757" alt="screenshot 2018-11-29 at 14 20 22" src="https://user-images.githubusercontent.com/40758489/49227848-fe091780-f3e1-11e8-9eba-1eec4550ddc3.png">

<img width="611" alt="screenshot 2018-11-29 at 14 20 39" src="https://user-images.githubusercontent.com/40758489/49227853-ffd2db00-f3e1-11e8-96cf-b1b652de5f79.png">
