### PR TITLE
Ensure error when password is blank when signing up

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,9 @@ class User < ApplicationRecord
     :rememberable, :trackable, :timeoutable, :validatable, :lockable
 
   validates :name, presence: true, on: :update
+  validates :password, presence: true,
+    length: { within: 6..80 },
+    on: :update
 
   validate :email_on_whitelist, on: :create
 

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -65,7 +65,6 @@ describe 'Sign up as an organisation' do
     end
   end
 
-
   context 'when password is too short' do
     before do
       sign_up_for_account
@@ -77,6 +76,21 @@ describe 'Sign up as an organisation' do
 
     it 'tells the user that the password is too short' do
       expect(page).to have_content 'Password is too short (minimum is 6 characters)'
+    end
+  end
+
+  context 'without a password' do
+    let(:email) { 'someone@gov.uk' }
+
+    before do
+      sign_up_for_account
+      update_user_details(password: '')
+    end
+
+    it_behaves_like 'errors in form'
+
+    it 'tells me my password is not valid' do
+      expect(page).to have_content("Password can't be blank")
     end
   end
 


### PR DESCRIPTION
This validation was removed when the password confirmation was removed.
Restore this and print the error in the form if the password is left
blank.