### PR TITLE
Add IP to location

### DIFF
--- a/app/controllers/ips_controller.rb
+++ b/app/controllers/ips_controller.rb
@@ -18,8 +18,13 @@ class IpsController < ApplicationController
         notice: "#{@ip.address} added, it will be active starting tomorrow"
       )
     else
-      @locations = available_locations
-      render :new
+      if adding_ip_to_location?
+        @location = Location.find_by(id: ip_params[:location_id])
+        render "locations/ips/new"
+      else
+        @locations = available_locations
+        render :new
+      end
     end
   end
 
@@ -75,6 +80,10 @@ private
 
   def user_creates_new_location?
     ip_params[:location_id].blank?
+  end
+
+  def adding_ip_to_location?
+    !ip_params.has_key?(:location_attributes)
   end
 
   def params_with_new_location

--- a/app/controllers/ips_controller.rb
+++ b/app/controllers/ips_controller.rb
@@ -6,6 +6,7 @@ class IpsController < ApplicationController
     @locations = available_locations
   end
 
+  # rubocop:disable Style/IfInsideElse
   def create
     @ip = Ip.new(create_params)
 
@@ -27,6 +28,7 @@ class IpsController < ApplicationController
       end
     end
   end
+  # rubocop:enable Style/IfInsideElse
 
   def index
     set_ip_to_delete if ip_removal_requested?

--- a/app/controllers/locations/ips_controller.rb
+++ b/app/controllers/locations/ips_controller.rb
@@ -1,0 +1,25 @@
+class Locations::IpsController < ApplicationController
+  def new
+    @location = current_organisation.locations.find_by(id: params[:location_id])
+    @ip = @location.ips.new
+  end
+
+  def create
+    ip.create(params[:ip])
+
+    @ip = Ip.new(create_params)
+
+    if @ip.save
+      publish_for_performance_platform
+      publish_radius_whitelist
+      redirect_to(
+        ips_path,
+        anchor: 'ips',
+        notice: "#{@ip.address} added, it will be active starting tomorrow"
+      )
+    else
+      @locations = available_locations
+      render :new
+    end
+  end
+end

--- a/app/controllers/locations/ips_controller.rb
+++ b/app/controllers/locations/ips_controller.rb
@@ -3,23 +3,4 @@ class Locations::IpsController < ApplicationController
     @location = current_organisation.locations.find_by(id: params[:location_id])
     @ip = @location.ips.new
   end
-
-  def create
-    ip.create(params[:ip])
-
-    @ip = Ip.new(create_params)
-
-    if @ip.save
-      publish_for_performance_platform
-      publish_radius_whitelist
-      redirect_to(
-        ips_path,
-        anchor: 'ips',
-        notice: "#{@ip.address} added, it will be active starting tomorrow"
-      )
-    else
-      @locations = available_locations
-      render :new
-    end
-  end
 end

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -1,10 +1,13 @@
 <table class="govuk-table govuk-!-margin-bottom-8">
   <caption class="govuk-table__caption">
     <%= location.full_address %>
-    <p class="govuk-body govuk-!-margin-bottom-2">
-      <%= link_to "+ add IP", new_location_ip_path(location), class: "govuk-link" %>
-    </p>
+    <% if current_user.can_manage_locations? %>
+      <p class="govuk-body govuk-!-margin-bottom-2">
+        <%= link_to "+ add IP", new_location_ip_path(location), class: "govuk-link" %>
+      </p>
+    <% end %>
   </caption>
+  
   <tbody class="govuk-table__body" id="ips-table">
     <% location.ips.each do |ip| %>
       <tr class="govuk-table__row">

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -1,6 +1,9 @@
-<table class="govuk-table">
-  <caption class="govuk-table__caption">
+<table class="govuk-table govuk-!-margin-bottom-8">
+  <caption class="govuk-table__caption"">
     <%= location.full_address %>
+    <p class="govuk-body govuk-!-margin-bottom-2">
+      <%= link_to "+ add IP", new_location_ip_path(location), class: "govuk-link" %>
+    </p>
   </caption>
   <tbody class="govuk-table__body" id="ips-table">
     <% location.ips.each do |ip| %>

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -1,5 +1,5 @@
 <table class="govuk-table govuk-!-margin-bottom-8">
-  <caption class="govuk-table__caption"">
+  <caption class="govuk-table__caption">
     <%= location.full_address %>
     <p class="govuk-body govuk-!-margin-bottom-2">
       <%= link_to "+ add IP", new_location_ip_path(location), class: "govuk-link" %>

--- a/app/views/ips/new.html.erb
+++ b/app/views/ips/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= link_to "Back to list", ips_path(anchor: :ips), class: "govuk-back-link" %>
+    <%= link_to "Back to list", ips_path, class: "govuk-back-link" %>
 
     <h2 class="govuk-heading-l">Add a new IP address</h2>
 

--- a/app/views/locations/ips/new.html.erb
+++ b/app/views/locations/ips/new.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= link_to "Back to list", ips_path, class: "govuk-back-link" %>
 
-    <h2 class="govuk-heading-l">Add an IP address to <%= @location.address %></h2>
+    <h2 class="govuk-heading-l" id="title">Add an IP address to <%= @location.address %></h2>
 
     <%= render "ips/activation_notice" %>
 

--- a/app/views/locations/ips/new.html.erb
+++ b/app/views/locations/ips/new.html.erb
@@ -1,0 +1,23 @@
+<%= render "layouts/form_errors", resource: @ip %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= link_to "Back to list", ips_path, class: "govuk-back-link" %>
+
+    <h2 class="govuk-heading-l">Add an IP address to <%= @location.address %></h2>
+
+    <%= render "ips/activation_notice" %>
+
+    <%= form_with model: @ip do |form| %>
+      <div class="govuk-form-group <%= field_error(@ip, :address) %>">
+        <%= form.label :ip, "Enter IP address (IPv4 only)", class: "govuk-label" %>
+        <%= form.text_field :address, id: :address, autocomplete: "off", class: "govuk-input" %>
+      </div>
+      <%= form.hidden_field :location_id, value: @location.id %>
+
+      <div class="actions">
+        <%= form.submit "Add new IP address", class: "govuk-button" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
     get 'remove', to: 'ips#index'
   end
   resources :locations, only: [] do
-    resources :ips, only: %i[new create], controller: "locations/ips"
+    resources :ips, only: :new, controller: "locations/ips"
   end
   resources :help, only: %i[index create]
   resources :team_members, only: %i[index edit update destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
   resources :ips, only: %i[index new create destroy] do
     get 'remove', to: 'ips#index'
   end
+  resources :locations, only: [] do
+    resources :ips, only: %i[new create], controller: "locations/ips"
+  end
   resources :help, only: %i[index create]
   resources :team_members, only: %i[index edit update destroy]
   resources :mou, only: %i[index create]

--- a/spec/features/ips/add_ip_to_location_spec.rb
+++ b/spec/features/ips/add_ip_to_location_spec.rb
@@ -3,14 +3,14 @@ require 'features/support/errors_in_form'
 
 describe 'Add an IP to my account' do
   context 'and the new location is invalid' do
-    let!(:user) { create(:user) }
+    let(:user) { create(:user) }
     let(:location) { create(:location, address: '10 Street', postcode: 'XX YYY', organisation: user.organisation) }
     let!(:ip) { create(:ip, location: location) }
 
     before do
       sign_in_user user
       visit ips_path
-      click_on 'add IP to this location'
+      click_on '+ add IP'
     end
 
     context 'when logged in' do

--- a/spec/features/ips/add_ip_to_location_spec.rb
+++ b/spec/features/ips/add_ip_to_location_spec.rb
@@ -1,58 +1,72 @@
 require 'features/support/sign_up_helpers'
 require 'features/support/errors_in_form'
 
-describe 'Add an IP to my account' do
-  context 'and the new location is invalid' do
-    let(:user) { create(:user) }
-    let(:location) { create(:location, address: '10 Street', postcode: 'XX YYY', organisation: user.organisation) }
-    let!(:ip) { create(:ip, location: location) }
+describe 'Add an IP to a location' do
+  let(:user) { create(:user) }
+  let(:location) { create(:location, address: '10 Street', postcode: 'XX YYY', organisation: user.organisation) }
+  let!(:ip) { create(:ip, location: location) }
 
+  before do
+    sign_in_user user
+    visit ips_path
+  end
+
+  context 'with permissions' do
     before do
-      sign_in_user user
-      visit ips_path
       click_on '+ add IP'
     end
 
-    context 'when logged in' do
-      it 'asks me to enter an IP' do
-        expect(page).to have_content('Enter IP address (IPv4 only)')
+    it 'asks me to enter an IP' do
+      expect(page).to have_content('Enter IP address (IPv4 only)')
+    end
+
+    context 'with valid data' do
+      before do
+        fill_in 'address', with: '10.0.0.1'
       end
 
-      context 'with valid data' do
-        before do
-          fill_in 'address', with: '10.0.0.1'
-        end
-
-        it 'adds the IP' do
-          expect {
-            click_on 'Add new IP address'
-          }.to change { Ip.count }.by(1)
-
-          expect(page).to have_content('10.0.0.1 added')
-          expect(Ip.last.location).to eq(location)
-        end
-      end
-
-      context 'with invalid data' do
-        before do
-          fill_in 'address', with: '10.wrong.0.1'
+      it 'adds the IP' do
+        expect {
           click_on 'Add new IP address'
-        end
+        }.to change { Ip.count }.by(1)
 
-        it_behaves_like 'errors in form'
+        expect(page).to have_content('10.0.0.1 added')
+        expect(Ip.last.location).to eq(location)
+      end
+    end
 
-        it 'renders the add ip to location form' do
-          within("h2#title") do
-            expect(page).to have_content("Add an IP address to #{location.address}")
-          end
-        end
+    context 'with invalid data' do
+      before do
+        fill_in 'address', with: '10.wrong.0.1'
+        click_on 'Add new IP address'
+      end
 
-        it 'tells me what I entered was invalid' do
-          expect(page).to have_content(
-            'Address must be a valid IPv4 address (without subnet)'
-          )
+      it_behaves_like 'errors in form'
+
+      it 'renders the add ip to location form' do
+        within("h2#title") do
+          expect(page).to have_content("Add an IP address to #{location.address}")
         end
       end
+
+      it 'tells me what I entered was invalid' do
+        expect(page).to have_content(
+          'Address must be a valid IPv4 address (without subnet)'
+        )
+      end
+    end
+  end
+
+  context 'without permissions' do
+    before do
+      user.permission.update(can_manage_locations: false)
+      sign_out
+      sign_in_user user
+      visit ips_path
+    end
+
+    it 'does not show the add IP link' do
+      expect(page).to_not have_link('+ add IP')
     end
   end
 end

--- a/spec/features/ips/add_ip_to_location_spec.rb
+++ b/spec/features/ips/add_ip_to_location_spec.rb
@@ -6,13 +6,10 @@ describe 'Add an IP to a location' do
   let(:location) { create(:location, address: '10 Street', postcode: 'XX YYY', organisation: user.organisation) }
   let!(:ip) { create(:ip, location: location) }
 
-  before do
-    sign_in_user user
-    visit ips_path
-  end
-
   context 'with permissions' do
     before do
+      sign_in_user user
+      visit ips_path
       click_on '+ add IP'
     end
 
@@ -60,7 +57,6 @@ describe 'Add an IP to a location' do
   context 'without permissions' do
     before do
       user.permission.update(can_manage_locations: false)
-      sign_out
       sign_in_user user
       visit ips_path
     end

--- a/spec/features/ips/add_ip_to_location_spec.rb
+++ b/spec/features/ips/add_ip_to_location_spec.rb
@@ -41,8 +41,10 @@ describe 'Add an IP to my account' do
 
         it_behaves_like 'errors in form'
 
-        it 'asks me to re-enter my IP' do
-          expect(page).to have_content('Enter IP address')
+        it 'renders the add ip to location form' do
+          within("h2#title") do
+            expect(page).to have_content("Add an IP address to #{location.address}")
+          end
         end
 
         it 'tells me what I entered was invalid' do

--- a/spec/features/ips/add_ip_to_location_spec.rb
+++ b/spec/features/ips/add_ip_to_location_spec.rb
@@ -1,0 +1,56 @@
+require 'features/support/sign_up_helpers'
+require 'features/support/errors_in_form'
+
+describe 'Add an IP to my account' do
+  context 'and the new location is invalid' do
+    let!(:user) { create(:user) }
+    let(:location) { create(:location, address: '10 Street', postcode: 'XX YYY', organisation: user.organisation) }
+    let!(:ip) { create(:ip, location: location) }
+
+    before do
+      sign_in_user user
+      visit ips_path
+      click_on 'add IP to this location'
+    end
+
+    context 'when logged in' do
+      it 'asks me to enter an IP' do
+        expect(page).to have_content('Enter IP address (IPv4 only)')
+      end
+
+      context 'with valid data' do
+        before do
+          fill_in 'address', with: '10.0.0.1'
+        end
+
+        it 'adds the IP' do
+          expect {
+            click_on 'Add new IP address'
+          }.to change { Ip.count }.by(1)
+
+          expect(page).to have_content('10.0.0.1 added')
+          expect(Ip.last.location).to eq(location)
+        end
+      end
+
+      context 'with invalid data' do
+        before do
+          fill_in 'address', with: '10.wrong.0.1'
+          click_on 'Add new IP address'
+        end
+
+        it_behaves_like 'errors in form'
+
+        it 'asks me to re-enter my IP' do
+          expect(page).to have_content('Enter IP address')
+        end
+
+        it 'tells me what I entered was invalid' do
+          expect(page).to have_content(
+            'Address must be a valid IPv4 address (without subnet)'
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the first cut using a `hidden_field` and utilising the existing `IpsController#create` action.

Next step will be using the `Locations::IpsController#create` action and refactoring the "after creating an IP" logic into a re-useable service. This won't change the user experience, it will just be a refactor.

![screenshot 2018-11-29 at 15 34 14](https://user-images.githubusercontent.com/2160769/49234858-c0f85180-f3f0-11e8-8b44-2baa4ddc447c.png)
![screenshot 2018-11-29 at 16 06 50](https://user-images.githubusercontent.com/2160769/49234894-ceadd700-f3f0-11e8-9ce4-109fc2df2677.png)
