### PR TITLE
Remove outdated text from team members page

### DIFF
--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -12,9 +12,6 @@
         <p class="govuk-body">
           Team members will receive an email invitation to join your organisation's GovWifi Admin dashboard.
         </p>
-        <p class="govuk-body">
-          New team members will be able to add locations, IP addresses and invite new team members.
-        </p>
       </div>
     </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,11 @@ en:
   activerecord:
     errors:
       models:
+        user:
+          attributes:
+            email:
+              taken: " is already invited, or already registered with \n
+              another organisation."
         organisation:
           attributes:
             name:

--- a/spec/features/team/invite_a_team_member_spec.rb
+++ b/spec/features/team/invite_a_team_member_spec.rb
@@ -73,7 +73,7 @@ describe "Invite a team member" do
             click_on "Send invitation email"
           }.to change { User.count }.by(0)
           expect(InviteUseCaseSpy.invite_count).to eq(0)
-          expect(page).to have_content("Email has already been taken")
+          expect(page).to have_content("Email is already invited, or already registered with another organisation")
         end
       end
 


### PR DESCRIPTION
Previously:
![screenshot 2018-12-04 at 15 08 23](https://user-images.githubusercontent.com/2160769/49451657-96830b80-f7d7-11e8-8776-763bd8d34ddc.png)

Now:
![screenshot 2018-12-04 at 15 15 32](https://user-images.githubusercontent.com/2160769/49451683-a3076400-f7d7-11e8-89ec-e8a0f6d83136.png)

and with error:
![screenshot 2018-12-04 at 15 15 23](https://user-images.githubusercontent.com/2160769/49451697-ab5f9f00-f7d7-11e8-9cff-36514b7ac17a.png)
