### PR TITLE
 Improve results message that appears when logs are not found

### DIFF
--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -28,5 +28,8 @@
     </tbody>
   </table>
 <% else %>
-  <h3 class="govuk-heading-m">No results found</h3>
+  <h3 class="govuk-heading-m">No authentication requests found for username: <%= params[:username] %></h3>
+    <p class="govuk-body">
+      If this user has tried to connect GovWifi, there is likely a problem with the local network forwarding authentication requests.
+    </p>
 <% end %>

--- a/spec/features/logging/view_auth_requests_for_a_username_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_a_username_spec.rb
@@ -113,7 +113,7 @@ describe "View authentication requests for a username" do
     end
 
     it 'displays the no results message' do
-      expect(page).to have_content('No results found')
+      expect(page).to have_content("No authentication requests found for username: #{username}")
     end
   end
 end


### PR DESCRIPTION
Before:

<img width="319" alt="screenshot 2018-12-04 at 16 41 00" src="https://user-images.githubusercontent.com/32823756/49457823-70636880-f7e3-11e8-9aba-1a197d8c944c.png">

After:

<img width="1013" alt="screenshot 2018-12-04 at 16 39 22" src="https://user-images.githubusercontent.com/32823756/49457707-32fedb00-f7e3-11e8-9ea4-698ae99d5ed8.png">