### PR TITLE
Explain to user if log results are limited

### DIFF
--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -2,6 +2,18 @@
 
 <% if @logs.present? %>
   <h1 class="govuk-heading-l">Displaying logs for <%= params[:username] || params[:ip] %></h1>
+
+  <% if @logs.count >= Gateways::Sessions::MAXIMUM_RESULTS_COUNT %>
+    <div class="govuk-details">
+      <div class="govuk-details__text">
+        <p class="govuk-body">
+          Logs are limited to 500 results. If you require more logs than this, please
+          <%= link_to "contact us", help_index_path, class: "govuk-link" %>.
+        </p>
+      </div>
+    </div>
+  <% end %>
+
   <table class="govuk-table">
     <caption class="govuk-table__caption"><%= @logs.count %> results</caption>
     <thead class="govuk-table__head">

--- a/lib/gateways/sessions.rb
+++ b/lib/gateways/sessions.rb
@@ -1,5 +1,7 @@
 module Gateways
   class Sessions
+    MAXIMUM_RESULTS_COUNT = 500
+
     def initialize(ips:)
       @ips = ips
     end
@@ -9,7 +11,7 @@ module Gateways
 
       results = Session.where(query).where(
         'start >= ? and siteIP IN (?)', 2.weeks.ago, ips
-      ).order('start DESC').limit(500)
+      ).order('start DESC').limit(MAXIMUM_RESULTS_COUNT)
 
       results.map do |log|
         {


### PR DESCRIPTION
If there are 500 results returned, the user gets an explanation explaining that results are truncated:

![screenshot 2018-12-04 at 17 03 28](https://user-images.githubusercontent.com/2160769/49459484-0ea4fd80-f7e7-11e8-96c6-8692b37654fd.png)
