### PR TITLE
Allow non-gov.uk email addresses to be invited

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -14,15 +14,25 @@ private
 
   def validate_invited_user
     return if invited_user_already_exists?
-    render_invite_user_page if user_is_invalid?
+    return_user_to_invite_page unless email_is_valid?
   end
 
-  def user_is_invalid?
+  def email_is_valid?
+    return true if email_passes_validation?
+    set_user_object_with_errors
+    false
+  end
+
+  def email_passes_validation?
+    invite_params[:email].match(URI::MailTo::EMAIL_REGEXP).present?
+  end
+
+  def set_user_object_with_errors
     @user = User.new(invite_params)
-    !@user.validate
+    @user.errors.add(:email, " must be a valid email address")
   end
 
-  def render_invite_user_page
+  def return_user_to_invite_page
     render :new, resource: @user
   end
 

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -20,7 +20,6 @@
 
         <div class="govuk-form-group <%= field_error(resource, :email) %>">
           <%= f.label :email, "Email address", class: "govuk-label"  %>
-          <div class="govuk-hint">Must be a valid government email address</div>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input" %>
         </div>
 

--- a/spec/features/team/invite_a_team_member_spec.rb
+++ b/spec/features/team/invite_a_team_member_spec.rb
@@ -55,13 +55,13 @@ describe "Invite a team member" do
         let(:invited_user_email) { "incorrect@gmail.com" }
         let(:invited_user) { User.find_by(email: invited_user_email) }
 
-        it "tells user that email must be a valid gov.uk email" do
+        it "creates an unconfirmed user" do
           expect {
             click_on "Send invitation email"
-          }.to change { User.count }.by(0)
-          expect(InviteUseCaseSpy.invite_count).to eq(0)
-          expect(invited_user).to eq(nil)
-          expect(page).to have_content("Email must be from a government domain")
+          }.to change { User.count }.by(1)
+          expect(InviteUseCaseSpy.invite_count).to eq(1)
+          expect(invited_user.confirmed?).to eq(false)
+          expect(invited_user.organisation).to eq(user.organisation)
         end
       end
 
@@ -80,16 +80,16 @@ describe "Invite a team member" do
       context "without an email" do
         let(:invited_user_email) { "" }
 
-        it "tells the user that email cannot be blank" do
+        it "tells the user that email must be a valid email address" do
           expect {
             click_on "Send invitation email"
           }.to change { User.count }.by(0)
           expect(InviteUseCaseSpy.invite_count).to eq(0)
-          expect(page).to have_content("Email can't be blank")
+          expect(page).to have_content("Email must be a valid email address")
         end
       end
 
-      context "tells user that email must be a valid gov.uk email" do
+      context "tells user that email must be a valid email address" do
         let(:invited_user_email) { "hello" }
 
         it "tells the user " do
@@ -97,7 +97,7 @@ describe "Invite a team member" do
             click_on "Send invitation email"
           }.to change { User.count }.by(0)
           expect(InviteUseCaseSpy.invite_count).to eq(0)
-          expect(page).to have_content("Email must be from a government domain")
+          expect(page).to have_content("Email must be a valid email address")
         end
       end
     end


### PR DESCRIPTION
A requirement as often GovWifi admins will be external suppliers eg: bt.com