### PR TITLE
Explain that all team members can see logs when inviting a user

### DIFF
--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -42,6 +42,8 @@
                 <% end %>
               </div>
             </fieldset>
+
+            <p class="govuk-body govuk-!-margin-top-5"> All team members can view logs </p>
           </div>
         </div>
 


### PR DESCRIPTION
Already existed in `team_members/edit` but needed to be added to `invitations/new`

<img width="825" alt="screenshot 2018-12-05 at 16 32 33" src="https://user-images.githubusercontent.com/2160769/49528502-f2b75f80-f8ab-11e8-9060-99537d675a3e.png">
