### PR TITLE
Move email whitelist validation to controller

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -14,22 +14,12 @@ private
 
   def validate_invited_user
     return if invited_user_already_exists?
-    return_user_to_invite_page unless email_is_valid?
+    return_user_to_invite_page if user_is_invalid?
   end
 
-  def email_is_valid?
-    return true if email_passes_validation?
-    set_user_object_with_errors
-    false
-  end
-
-  def email_passes_validation?
-    invite_params[:email].match(URI::MailTo::EMAIL_REGEXP).present?
-  end
-
-  def set_user_object_with_errors
+  def user_is_invalid?
     @user = User.new(invite_params)
-    @user.errors.add(:email, " must be a valid email address")
+    !@user.validate
   end
 
   def return_user_to_invite_page

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,10 +1,27 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :validate_email_on_whitelist, only: :create
+
 protected
 
   # The path used after sign up for inactive accounts.
   def after_inactive_sign_up_path_for(_resource)
     users_confirmations_pending_path
+  end
+
+  def validate_email_on_whitelist
+    checker = UseCases::Administrator::CheckIfWhitelistedEmail.new
+    whitelisted = checker.execute(sign_up_params[:email])[:success]
+    set_user_object_with_errors && return_user_to_registration_page unless whitelisted
+  end
+
+  def set_user_object_with_errors
+    @user = User.new(sign_up_params)
+    @user.errors.add(:email, 'must be from a government domain')
+  end
+
+  def return_user_to_registration_page
+    render :new, resource: @user
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,8 +15,6 @@ class User < ApplicationRecord
     length: { within: 6..80 },
     on: :update
 
-  validate :email_on_whitelist, on: :create
-
   after_create :create_default_permissions
 
   def only_if_unconfirmed
@@ -40,11 +38,5 @@ private
       can_manage_team: true,
       can_manage_locations: true
     )
-  end
-
-  def email_on_whitelist
-    checker = UseCases::Administrator::CheckIfWhitelistedEmail.new
-    whitelisted = checker.execute(self.email)[:success]
-    errors.add(:email, 'must be from a government domain') unless whitelisted
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
             email:
               taken: " is already invited, or already registered with \n
               another organisation."
+              invalid: " must be a valid email address"
         organisation:
           attributes:
             name:

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -50,7 +50,7 @@ describe 'Sign up as an organisation' do
 
       it 'tells me my email is not valid' do
         expect(page).to have_content(
-          "Email can't be blank"
+          "Email must be from a government domain"
         )
       end
     end

--- a/spec/features/team/invite_a_team_member_spec.rb
+++ b/spec/features/team/invite_a_team_member_spec.rb
@@ -80,12 +80,12 @@ describe "Invite a team member" do
       context "without an email" do
         let(:invited_user_email) { "" }
 
-        it "tells the user that email must be a valid email address" do
+        it "tells the user that email cannot be blank" do
           expect {
             click_on "Send invitation email"
           }.to change { User.count }.by(0)
           expect(InviteUseCaseSpy.invite_count).to eq(0)
-          expect(page).to have_content("Email must be a valid email address")
+          expect(page).to have_content("Email can't be blank")
         end
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,56 +7,6 @@ describe User do
     it { is_expected.to validate_presence_of(:name).on(:update) }
   end
 
-  describe '#save' do
-    subject { build(:user) }
-
-    context 'with the factory-built model' do
-      it { is_expected.to be_valid }
-    end
-
-    context 'with valid data' do
-      subject { build(:user, email: 'name@gov.uk') }
-
-      it { is_expected.to be_valid }
-
-      context 'when saved' do
-        before { subject.save }
-
-        it 'saves the user' do
-          expect(subject.persisted?).to be true
-        end
-      end
-    end
-
-    context 'with a non-gov.uk email' do
-      context 'for a new record' do
-        subject { build(:user, email: 'name@arbitrary-domain.com') }
-
-        it { is_expected.to_not be_valid }
-
-        context 'when saved' do
-          before { subject.save }
-
-          it 'explains the email must be from the correct domain' do
-            expect(subject.errors.full_messages).to eq(
-              ['Email must be from a government domain']
-            )
-          end
-        end
-      end
-
-      context 'for an existing record' do
-        subject do
-          user = create(:user)
-          user.email = 'name@arbitrary-domain.com'
-          user
-        end
-
-        it { is_expected.to be_valid }
-      end
-    end
-  end
-
   context 'permissions' do
     context 'a new user' do
       subject { create(:user) }


### PR DESCRIPTION
The validation that checks that a user's email is on the whitelist is only used during registration. During invitation the user can have any email address.

Having this validation on the model meant there was a lot of code in the invitations controller trying to avoid this check. 

As it only applies to 20% of the users, I have moved the whitelist validation off the model to the only controller that uses it. This simplifies the code changes coming in https://github.com/alphagov/govwifi-admin/pull/360