### PR TITLE
Block unconfirmed users from resetting passwords

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-gem 'aws-sdk-route53', '~> 1.16.0'
+gem 'aws-sdk-route53', '~> 1.17.0'
 gem 'aws-sdk-s3', '~> 1'
 gem 'devise', '~> 4.5.0'
 gem 'devise_invitable', '~> 1.7.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,8 +47,8 @@ GEM
     arel (9.0.0)
     ast (2.4.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.122.0)
-    aws-sdk-core (3.43.0)
+    aws-partitions (1.123.0)
+    aws-sdk-core (3.44.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -56,7 +56,7 @@ GEM
     aws-sdk-kms (1.13.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
-    aws-sdk-route53 (1.16.0)
+    aws-sdk-route53 (1.17.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
     aws-sdk-s3 (1.30.0)
@@ -300,7 +300,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk-route53 (~> 1.16.0)
+  aws-sdk-route53 (~> 1.17.0)
   aws-sdk-s3 (~> 1)
   byebug (~> 10)
   capybara

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,12 +1,15 @@
 class Users::PasswordsController < Devise::PasswordsController
-  before_action :validate_user_is_confirmed, only: :edit
+  append_before_action :validate_user_is_confirmed, only: :create
+  append_before_action :assert_reset_token_passed, only: :edit
 
 protected
 
   def validate_user_is_confirmed
-    unless @user.confirmed?
-      redirect_to new_user_session_path
-      flash[:notice] = "Please confirm your account first"
+    current_user_details = params[:user]
+    user_email = current_user_details[:email]
+    unless User.find_by(email: user_email).nil? || User.find_by(email: user_email).confirmed?
+      set_flash_message(:alert, :unconfirmed)
+      redirect_to new_user_confirmation_path
     end
   end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,13 +1,11 @@
 class Users::PasswordsController < Devise::PasswordsController
   append_before_action :validate_user_is_confirmed, only: :create
-  append_before_action :assert_reset_token_passed, only: :edit
 
 protected
 
   def validate_user_is_confirmed
-    current_user_details = params[:user]
-    user_email = current_user_details[:email]
-    unless User.find_by(email: user_email).nil? || User.find_by(email: user_email).confirmed?
+    user = User.find_by(email: params[:user][:email])
+    unless user.nil? || user.confirmed?
       set_flash_message(:alert, :unconfirmed)
       redirect_to new_user_confirmation_path
     end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,12 @@
+class Users::PasswordsController < Devise::PasswordsController
+  before_action :validate_user_is_confirmed, only: :edit
+
+protected
+
+  def validate_user_is_confirmed
+    unless @user.confirmed?
+      redirect_to new_user_session_path
+      flash[:notice] = "Please confirm your account first"
+    end
+  end
+end

--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -18,7 +18,6 @@ class AuthenticationMailer < ::Devise::Mailer
 
   # Overrides https://github.com/plataformatec/devise/blob/master/app/mailers/devise/mailer.rb#L12
   def reset_password_instructions(record, token, _opts = {})
-
     reset_link = edit_password_url(record, reset_password_token: token)
     template_id = GOV_NOTIFY_CONFIG['reset_password_email']['template_id']
 

--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -17,8 +17,8 @@ class AuthenticationMailer < ::Devise::Mailer
   end
 
   # Overrides https://github.com/plataformatec/devise/blob/master/app/mailers/devise/mailer.rb#L12
-  def reset_password_instructions(record, token, opts = {})
-    return confirmation_instructions(record, record.confirmation_token, opts) unless record.confirmed?
+  def reset_password_instructions(record, token, _opts = {})
+    # return confirmation_instructions(record, record.confirmation_token, opts) unless record.confirmed?
 
     reset_link = edit_password_url(record, reset_password_token: token)
     template_id = GOV_NOTIFY_CONFIG['reset_password_email']['template_id']

--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -18,7 +18,6 @@ class AuthenticationMailer < ::Devise::Mailer
 
   # Overrides https://github.com/plataformatec/devise/blob/master/app/mailers/devise/mailer.rb#L12
   def reset_password_instructions(record, token, _opts = {})
-    # return confirmation_instructions(record, record.confirmation_token, opts) unless record.confirmed?
 
     reset_link = edit_password_url(record, reset_password_token: token)
     template_id = GOV_NOTIFY_CONFIG['reset_password_email']['template_id']

--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -18,7 +18,7 @@ class AuthenticationMailer < ::Devise::Mailer
 
   # Overrides https://github.com/plataformatec/devise/blob/master/app/mailers/devise/mailer.rb#L12
   def reset_password_instructions(record, token, opts = {})
-    confirmation_instructions(record, record.confirmation_token, opts) unless record.confirmed?
+    return confirmation_instructions(record, record.confirmation_token, opts) unless record.confirmed?
 
     reset_link = edit_password_url(record, reset_password_token: token)
     template_id = GOV_NOTIFY_CONFIG['reset_password_email']['template_id']

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -34,6 +34,7 @@ en:
       success: "Successfully authenticated from %{kind} account."
     passwords:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      unconfirmed: "You can't reset your password without confirming your account. To recieve another confirmation email, please enter your email below."
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
       updated: "Your password has been changed successfully. You are now signed in."

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -34,7 +34,7 @@ en:
       success: "Successfully authenticated from %{kind} account."
     passwords:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
-      unconfirmed: "You can't reset your password without confirming your account. To recieve another confirmation email, please enter your email below."
+      unconfirmed: "You must confirm your account before resetting your password."
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
       updated: "Your password has been changed successfully. You are now signed in."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     confirmations: 'users/confirmations',
     registrations: 'users/registrations',
-    invitations: 'users/invitations'
+    invitations: 'users/invitations',
+    passwords: 'users/passwords'
   }
   devise_scope :user do
     put 'users/confirmations', to: 'users/confirmations#update'

--- a/spec/features/authentication/reset_password_spec.rb
+++ b/spec/features/authentication/reset_password_spec.rb
@@ -38,15 +38,13 @@ describe "Resetting a password" do
 
     let(:user) { create(:user, :unconfirmed) }
 
-    it "sends the confirmation instructions instead of reset password" do
+    it "tells them to confirm their account first" do
       visit new_user_password_path
       fill_in "user_email", with: user.email
+      click_on "Send me reset password instructions"
 
-      expect {
-        click_on "Send me reset password instructions"
-      }.to change { ConfirmationUseCaseSpy.confirmations_count }.by(1)
-
-      expect(page).to have_content("You will receive an email with instructions")
+      expect(page).to have_content("Resend confirmation instructions")
+      expect(page.current_path).to eq(new_user_confirmation_path)
     end
 
     it 'does not send a reset password link' do

--- a/spec/features/authentication/reset_password_spec.rb
+++ b/spec/features/authentication/reset_password_spec.rb
@@ -32,6 +32,7 @@ describe "Resetting a password" do
   end
 
   context "when user is not yet confirmed" do
+    include_examples 'reset password use case spy'
     include_examples 'confirmation use case spy'
     include_examples 'notifications service'
 
@@ -46,6 +47,15 @@ describe "Resetting a password" do
       }.to change { ConfirmationUseCaseSpy.confirmations_count }.by(1)
 
       expect(page).to have_content("You will receive an email with instructions")
+    end
+
+    it 'does not send a reset password link' do
+      visit new_user_password_path
+      fill_in "user_email", with: user.email
+
+      expect {
+        click_on "Send me reset password instructions"
+      }.to change { ResetPasswordUseCaseSpy.reset_count }.by(0)
     end
   end
 


### PR DESCRIPTION
**WHAT:** The aim was to stop a user who hadn't confirmed their account from trying to reset their password.

**WHY:** Users who went down this route encountered an error stating that `Name can't be blank`. The name referred to here is the name they would have set through _confirming and finishing the creation of their account._

![screenshot_2018-12-04_at_14 44 21](https://user-images.githubusercontent.com/32823756/49894786-b5704600-fe46-11e8-82f4-9d932df3dc9b.png)

**IN THIS PR:** An initial solution was to send a confirmation email to the unconfirmed user instead of the reset password email, whenever they clicked on the reset password link in the admin portal. 

However, in terms of user experience, the user still sees a flash notice along the lines of `An email with instructions on how to reset your password has been sent`. So, the current idea of a solution is to deal with this at the controller level so that the appropriate flash message from the `devise.en.yml` is seen by the user.

**UPDATE ON SOLUTION**
A method was added to the `PasswordsContoller` to check if a user has been confirmed before proceeding with reset password pathway. 

As a result of this, the user is now redirected to the `new_user_confirmation_path` and are informed that they need to confirm their account before attempting to reset their password. 
- This now also means that the user no longer receives an email with the confirmation link automatically but has to initiate the confirmation journey themselves.

<img width="1095" alt="screenshot 2018-12-14 at 13 29 00" src="https://user-images.githubusercontent.com/32823756/50006016-414bb480-ffa4-11e8-9816-0287aba11b45.png">


Any feedback on this would be appreciated.