### PR TITLE
Clean up design of the page with confirmation instruction meant for after signing up

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -6,8 +6,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
 protected
 
   # The path used after sign up for inactive accounts.
-  def after_inactive_sign_up_path_for(_resource)
-    users_confirmations_pending_path
+  def after_inactive_sign_up_path_for(resource)
+    users_confirmations_pending_path(email: resource.email)
   end
 
   def validate_email_on_whitelist

--- a/app/views/users/confirmations/pending.html.erb
+++ b/app/views/users/confirmations/pending.html.erb
@@ -1,13 +1,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <div class="govuk-panel govuk-panel--confirmation">
-      <h1 class="govuk-panel__title">
-        Confirmation email sent
-      </h1>
-      <p class="govuk-panel__body">We've sent confirmation instructions to <strong>your email address.</strong></p>
-    </div>
-
-    <p class="govuk-inset-text">
-      Once you have confirmed your email address, you can continue to creating an account.
+    <h1 class="govuk-heading-l">Check your email</h1>
+    <p class="govuk-body-l">A confirmation email has been sent to <strong>your email address.</strong></p>
+    <p class="govuk-body">
+      Click on the link in the email to continue creating your account.
     </p>
+  </div>
 </div>

--- a/app/views/users/confirmations/pending.html.erb
+++ b/app/views/users/confirmations/pending.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <h1 class="govuk-heading-l">Check your email</h1>
-    <p class="govuk-body-l">A confirmation email has been sent to <strong>your email address.</strong></p>
+    <p class="govuk-body-l">A confirmation email has been sent to <strong><%= params[:email] %>.</strong></p>
     <p class="govuk-body">
       Click on the link in the email to continue creating your account.
     </p>

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -13,15 +13,7 @@ describe 'Sign up as an organisation' do
     let(:email) { 'newuser@gov.uk' }
     before { sign_up_for_account(email: email) }
 
-    # Current behaviour
-    it 'directs the user to check their confirmation email' do
-      expect(page).to have_content(
-        "A confirmation email has been sent"
-        )
-    end
-
-    # Desired behaviour
-    xit 'directs the user to check their confirmation email' do
+    it 'instructs the user to check their confirmation email' do
       expect(page).to have_content(
         "A confirmation email has been sent to #{email}"
         )

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -9,6 +9,25 @@ describe 'Sign up as an organisation' do
 
   let(:name) { 'Sally' }
 
+  context 'with a valid email' do
+    let(:email) { 'newuser@gov.uk' }
+    before { sign_up_for_account(email: email) }
+
+    # Current behaviour
+    it 'directs the user to check their confirmation email' do
+      expect(page).to have_content(
+        "A confirmation email has been sent"
+        )
+    end
+
+    # Desired behaviour
+    xit 'directs the user to check their confirmation email' do
+      expect(page).to have_content(
+        "A confirmation email has been sent to #{email}"
+        )
+    end
+  end
+
   context 'with correct data' do
     before do
       sign_up_for_account(email: email)


### PR DESCRIPTION
**WHY:**
It was suggested that the design of the pending confirmations page needed to be clearer. 
Currently a big green box is used and is unlike what other GDS services do.

**IN THIS PR:**
The text in the `pending.html.erb` was edited to sound more like an example from a GDS site. And the styles on the tags were changed too.

**BEFORE:**
<img width="1009" alt="screenshot_2018-12-05_at_14 41 39" src="https://user-images.githubusercontent.com/32823756/50102918-49168d80-021e-11e9-8360-5edf25338f82.png">

------------------------------------------------------------------------------------------------------
**AFTER:**
<img width="634" alt="screenshot 2018-12-18 at 16 07 51" src="https://user-images.githubusercontent.com/32823756/50166507-20a29800-02df-11e9-9957-03051ea8ed0c.png">

**SOLUTION**
In the snapshot above, the phrase " your email address " was left bold. The idea is to replace this phrase will the user's own email that they just used to sign up. 
To do this, a method in the `RegistrationsController` was modified to receive the user's email as an argument. This added the user's email as a parameter that could be accessed within the `pending` method.
