### PR TITLE
Autoload support files in spec_helper

### DIFF
--- a/spec/features/admin/delete_organisation_as_super_admin_spec.rb
+++ b/spec/features/admin/delete_organisation_as_super_admin_spec.rb
@@ -1,5 +1,3 @@
-require 'features/support/sign_up_helpers'
-
 describe 'deleting an organisation' do
   let!(:admin_user) { create(:user, super_admin: true) }
   let!(:organisation) { create(:organisation, name: "TestMe & Company") }

--- a/spec/features/admin/sign_in_as_super_admin_spec.rb
+++ b/spec/features/admin/sign_in_as_super_admin_spec.rb
@@ -1,6 +1,3 @@
-require 'features/support/sign_up_helpers'
-require 'features/support/not_signed_in'
-
 describe 'signing in as a super admin' do
   let!(:user) { create(:user, super_admin: true) }
 

--- a/spec/features/admin/sort_view_in_organisation_list_spec.rb
+++ b/spec/features/admin/sort_view_in_organisation_list_spec.rb
@@ -1,5 +1,3 @@
-require 'features/support/sign_up_helpers'
-
 describe 'sorting the values in the organisation list' do
   context 'when super admin views the list' do
     let(:super_admin) { create(:user, super_admin: true) }

--- a/spec/features/admin/view_organisation_list_spec.rb
+++ b/spec/features/admin/view_organisation_list_spec.rb
@@ -1,6 +1,3 @@
-require 'features/support/not_signed_in'
-require 'features/support/sign_up_helpers'
-
 describe 'view list of signed up organisations' do
   before do
     login_as user

--- a/spec/features/admin/view_organisation_page_spec.rb
+++ b/spec/features/admin/view_organisation_page_spec.rb
@@ -1,7 +1,3 @@
-require 'features/support/not_signed_in'
-require 'features/support/sign_up_helpers'
-require 'features/support/user_not_authorised'
-
 describe 'view details of a signed up organisation' do
   let(:organisation) { create(:organisation) }
 

--- a/spec/features/admin/view_organisation_tab_spec.rb
+++ b/spec/features/admin/view_organisation_tab_spec.rb
@@ -1,6 +1,3 @@
-require 'features/support/not_signed_in'
-require 'features/support/sign_up_helpers'
-
 describe 'the visibility of the organisation depending on user' do
   context 'when logged out' do
     before { visit admin_organisations_path }

--- a/spec/features/authentication/asking_users_to_sign_in_spec.rb
+++ b/spec/features/authentication/asking_users_to_sign_in_spec.rb
@@ -1,5 +1,3 @@
-require 'features/support/sign_up_helpers'
-require 'features/support/not_signed_in'
 require 'support/notifications_service'
 require 'support/confirmation_use_case'
 

--- a/spec/features/authentication/logging_in_after_signing_up_spec.rb
+++ b/spec/features/authentication/logging_in_after_signing_up_spec.rb
@@ -1,5 +1,3 @@
-require 'features/support/not_signed_in'
-require 'features/support/sign_up_helpers'
 require 'support/notifications_service'
 require 'support/confirmation_use_case'
 

--- a/spec/features/authentication/reset_password_spec.rb
+++ b/spec/features/authentication/reset_password_spec.rb
@@ -3,7 +3,6 @@ require 'support/reset_password_use_case_spy'
 require 'support/reset_password_use_case'
 require 'support/confirmation_use_case_spy'
 require 'support/confirmation_use_case'
-require 'features/support/errors_in_form'
 
 describe "Resetting a password" do
   it "displays the forgot password link at login" do

--- a/spec/features/contact_us_submit_spec.rb
+++ b/spec/features/contact_us_submit_spec.rb
@@ -1,4 +1,3 @@
-require 'features/support/sign_up_helpers'
 require 'support/notifications_service'
 require 'support/send_help_email_use_case_spy'
 require 'support/send_help_email_use_case'

--- a/spec/features/guidance_after_sign_in_spec.rb
+++ b/spec/features/guidance_after_sign_in_spec.rb
@@ -1,4 +1,3 @@
-require 'features/support/sign_up_helpers'
 require 'support/notifications_service'
 
 describe 'guidance after sign in' do

--- a/spec/features/invite_existing_user_spec.rb
+++ b/spec/features/invite_existing_user_spec.rb
@@ -1,4 +1,3 @@
-require 'features/support/sign_up_helpers'
 require 'support/invite_use_case'
 require 'support/notifications_service'
 require 'support/confirmation_use_case'

--- a/spec/features/ips/add_an_ip_address_spec.rb
+++ b/spec/features/ips/add_an_ip_address_spec.rb
@@ -1,7 +1,3 @@
-require 'features/support/not_signed_in'
-require 'features/support/sign_up_helpers'
-require 'features/support/errors_in_form'
-require 'features/support/activation_notice'
 require 'support/notifications_service'
 require 'support/confirmation_use_case'
 

--- a/spec/features/ips/add_ip_to_location_spec.rb
+++ b/spec/features/ips/add_ip_to_location_spec.rb
@@ -1,6 +1,3 @@
-require 'features/support/sign_up_helpers'
-require 'features/support/errors_in_form'
-
 describe 'Add an IP to a location' do
   let(:user) { create(:user) }
   let(:location) { create(:location, address: '10 Street', postcode: 'XX YYY', organisation: user.organisation) }

--- a/spec/features/ips/permissions_spec.rb
+++ b/spec/features/ips/permissions_spec.rb
@@ -1,5 +1,3 @@
-require 'features/support/sign_up_helpers'
-
 describe 'Add an IP' do
   let!(:user) { create(:user) }
 

--- a/spec/features/ips/remove_an_ip_spec.rb
+++ b/spec/features/ips/remove_an_ip_spec.rb
@@ -1,5 +1,3 @@
-require 'features/support/sign_up_helpers'
-
 describe 'Remove an IP' do
   let(:user) { create(:user) }
   let(:location) { create(:location, organisation: user.organisation) }

--- a/spec/features/ips/view_ip_address_readiness_spec.rb
+++ b/spec/features/ips/view_ip_address_readiness_spec.rb
@@ -1,4 +1,3 @@
-require 'features/support/sign_up_helpers'
 require 'timecop'
 
 describe 'with a stubbed notifications service' do

--- a/spec/features/ips/view_ip_addresses_spec.rb
+++ b/spec/features/ips/view_ip_addresses_spec.rb
@@ -1,5 +1,3 @@
-require 'features/support/not_signed_in'
-require 'features/support/sign_up_helpers'
 require 'support/notifications_service'
 require 'support/confirmation_use_case'
 

--- a/spec/features/logging/view_auth_requests_for_a_username_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_a_username_spec.rb
@@ -1,5 +1,3 @@
-require 'features/support/sign_up_helpers'
-
 describe "View authentication requests for a username" do
   context "with results" do
     let(:username) { "AAAAAA" }

--- a/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
@@ -1,5 +1,3 @@
-require 'features/support/sign_up_helpers'
-
 describe 'View authentication requests for an IP' do
   context 'with results' do
     let(:ip) { '127.0.0.1' }

--- a/spec/features/logout_user_after_inactivity_spec.rb
+++ b/spec/features/logout_user_after_inactivity_spec.rb
@@ -1,4 +1,3 @@
-require 'features/support/sign_up_helpers'
 require 'timecop'
 
 describe 'logout users after specific period of inactivity' do

--- a/spec/features/registration/resend_confirmation_instructions_spec.rb
+++ b/spec/features/registration/resend_confirmation_instructions_spec.rb
@@ -1,5 +1,3 @@
-require 'features/support/sign_up_helpers'
-require 'features/support/errors_in_form'
 require 'support/notifications_service'
 require 'support/confirmation_use_case_spy'
 require 'support/confirmation_use_case'

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -1,5 +1,3 @@
-require 'features/support/sign_up_helpers'
-require 'features/support/errors_in_form'
 require 'support/notifications_service'
 require 'support/confirmation_use_case'
 

--- a/spec/features/status/view_status_spec.rb
+++ b/spec/features/status/view_status_spec.rb
@@ -1,6 +1,3 @@
-require 'features/support/not_signed_in'
-require 'features/support/sign_up_helpers'
-
 describe 'View GovWifi Status' do
   context 'when logged out' do
     before do

--- a/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
+++ b/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
@@ -1,4 +1,3 @@
-require 'features/support/sign_up_helpers'
 require 'support/invite_use_case_spy'
 require 'support/invite_use_case'
 require 'support/notifications_service'

--- a/spec/features/team/edit_permissions_spec.rb
+++ b/spec/features/team/edit_permissions_spec.rb
@@ -1,5 +1,3 @@
-require 'features/support/sign_up_helpers'
-
 describe 'Edit user permissions' do
   let(:user) { create(:user) }
   let(:invited_user_other_org) { User.find_by(email: 'invited_other_org@gov.uk') }

--- a/spec/features/team/invite_a_team_member_spec.rb
+++ b/spec/features/team/invite_a_team_member_spec.rb
@@ -1,5 +1,3 @@
-require 'features/support/not_signed_in'
-require 'features/support/sign_up_helpers'
 require 'support/invite_use_case_spy'
 require 'support/invite_use_case'
 require 'support/notifications_service'

--- a/spec/features/team/invite_with_permissions_spec.rb
+++ b/spec/features/team/invite_with_permissions_spec.rb
@@ -1,4 +1,3 @@
-require 'features/support/sign_up_helpers'
 require 'support/notifications_service'
 
 describe 'Set user permissions on invite' do

--- a/spec/features/team/permissions_spec.rb
+++ b/spec/features/team/permissions_spec.rb
@@ -1,4 +1,3 @@
-require 'features/support/sign_up_helpers'
 require 'support/notifications_service'
 
 describe 'Invite a team member' do

--- a/spec/features/team/remove_a_team_member_spec.rb
+++ b/spec/features/team/remove_a_team_member_spec.rb
@@ -1,5 +1,3 @@
-require 'features/support/sign_up_helpers'
-
 describe "Remove a team member" do
   let(:user) { create(:user) }
   let(:another_user) { create(:user, organisation: user.organisation) }

--- a/spec/features/team/resend_invitation_spec.rb
+++ b/spec/features/team/resend_invitation_spec.rb
@@ -1,4 +1,3 @@
-require 'features/support/sign_up_helpers'
 require 'support/invite_use_case_spy'
 require 'support/invite_use_case'
 require 'support/notifications_service'

--- a/spec/features/team/view_team_members_spec.rb
+++ b/spec/features/team/view_team_members_spec.rb
@@ -1,6 +1,3 @@
-require 'features/support/not_signed_in'
-require 'features/support/sign_up_helpers'
-
 describe 'View team members of my organisation' do
   context 'when logged out' do
     before { visit team_members_path }

--- a/spec/features/upload_download_mous_spec.rb
+++ b/spec/features/upload_download_mous_spec.rb
@@ -1,6 +1,3 @@
-require 'features/support/not_signed_in'
-require 'features/support/sign_up_helpers'
-
 describe 'the upload and download of MOUs' do
   context 'when logged out' do
     before { visit mou_index_path }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  Dir["./spec/features/support/*.rb"].sort.each { |f| require f }
+
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
   config.before { ActionMailer::Base.deliveries.clear }


### PR DESCRIPTION
A quick one before I dive into spies/mocks. Load time isn't significantly different in any situation, but reduces noise on each spec (tradeoff: some things are now more hidden).

For the whole suite:

![image](https://user-images.githubusercontent.com/429326/50168737-00c1a300-02e4-11e9-83a9-48b7144ed4ba.png)

For a single focused test that doesn't use these files:

![image](https://user-images.githubusercontent.com/429326/50169135-dfad8200-02e4-11e9-8ea4-d94b9ee71045.png)

For a single focused test that does use these files: 

![image](https://user-images.githubusercontent.com/429326/50169026-a1b05e00-02e4-11e9-833e-8d627c23d1db.png)


