### PR TITLE
Remove some noise in spec folders

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -17,6 +17,7 @@ class Location < ApplicationRecord
 private
 
   def set_radius_secret_key
-    self.radius_secret_key = RadiusSecretKeyGenerator.new.execute
+    use_case = UseCases::Administrator::GenerateRadiusSecretKey.new
+    self.radius_secret_key = use_case.execute
   end
 end

--- a/lib/use_cases/administrator/generate_radius_secret_key.rb
+++ b/lib/use_cases/administrator/generate_radius_secret_key.rb
@@ -1,4 +1,4 @@
-class RadiusSecretKeyGenerator
+class UseCases::Administrator::GenerateRadiusSecretKey
   BYTES = 10
 
   def execute

--- a/spec/requests/monitoring/healthcheck_spec.rb
+++ b/spec/requests/monitoring/healthcheck_spec.rb
@@ -1,6 +1,4 @@
-require_relative '../rails_helper'
-
-describe 'healthcheck', type: :request do
+describe 'healthcheck' do
   it 'responds successfully' do
     get '/healthcheck'
     expect(response).to be_successful

--- a/spec/use_cases/generate_radius_secret_key_spec.rb
+++ b/spec/use_cases/generate_radius_secret_key_spec.rb
@@ -1,4 +1,4 @@
-describe RadiusSecretKeyGenerator do
+describe UseCases::Administrator::GenerateRadiusSecretKey do
   it 'has a length of 20 characters' do
     expect(subject.execute.length).to eq(20)
   end


### PR DESCRIPTION
We had a couple of extra folders for specs, folded things together so there's less noise.

11 folders before, 9 with this change:

![image](https://user-images.githubusercontent.com/429326/50219093-fbb53000-0385-11e9-8364-2894c5478f51.png)

I've got my eyes on more changes, but this was simple and uncontroversial (I hope!), so just a quick one before I look at the mocks.