### PR TITLE
Correct size of input boxes on admin

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -47,7 +47,7 @@
         <label class="govuk-label" for="contact_number">
           Contact number (optional)
         </label>
-        <%= text_field_tag 'contact_number', nil, class: 'govuk-input', type: 'tel' %>
+        <%= text_field_tag 'contact_number', nil, class: 'govuk-input govuk-input--width-20', type: 'tel' %>
       </div>
 
       <div class="govuk-form-group">

--- a/app/views/ips/new.html.erb
+++ b/app/views/ips/new.html.erb
@@ -28,10 +28,10 @@
         </div>
 
         <div class="govuk-form-group">
-          <%= location_form.label :postcode, "Enter new location postcode", class: "govuk-label" %>
+          <%= location_form.label :postcode, "Enter new location postcode", class: "govuk-label govuk-!-width-one-quarter", for: "one-quarter" %>
           <%= location_form.text_field :postcode,
             autocomplete: 'off',
-            class: 'govuk-input',
+            class: 'govuk-input govuk-!-width-one-quarter',
             value: (params || {}).dig(:ip, :location_attributes, :postcode) %>
         </div>
       <% end %>

--- a/app/views/ips/new.html.erb
+++ b/app/views/ips/new.html.erb
@@ -39,8 +39,8 @@
       <p><hr></p>
 
       <div class="govuk-form-group <%= field_error(@ip, :address) %>">
-        <%= form.label :ip, "Enter IP address (IPv4 only)", class: "govuk-label" %>
-        <%= form.text_field :address, id: :address, autocomplete: "off", class: "govuk-input" %>
+        <%= form.label :ip, "Enter IP address (IPv4 only)", class: "govuk-label", for: "width-20" %>
+        <%= form.text_field :address, id: :address, autocomplete: "off", class: "govuk-input govuk-input--width-20" %>
       </div>
 
       <div class="actions">

--- a/app/views/locations/ips/new.html.erb
+++ b/app/views/locations/ips/new.html.erb
@@ -10,8 +10,8 @@
 
     <%= form_with model: @ip, url: location_ips_path do |form| %>
       <div class="govuk-form-group <%= field_error(@ip, :address) %>">
-        <%= form.label :ip, "Enter IP address (IPv4 only)", class: "govuk-label" %>
-        <%= form.text_field :address, id: :address, autocomplete: "off", class: "govuk-input" %>
+        <%= form.label :ip, "Enter IP address (IPv4 only)", class: "govuk-label", for: "width-20" %>
+        <%= form.text_field :address, id: :address, autocomplete: "off", class: "govuk-input govuk-input--width-20" %>
       </div>
 
       <div class="actions">

--- a/app/views/logs/search.html.erb
+++ b/app/views/logs/search.html.erb
@@ -15,8 +15,8 @@
 
     <%= form_with url: logs_path, method: :get do |form| %>
       <div class="govuk-form-group">
-        <%= form.label :username, "Enter the username you wish to see logs for", class: "govuk-label" %><br />
-        <%= form.text_field :username, autofocus: true, class: "govuk-input" %>
+        <%= form.label :username, "Enter the username you wish to see logs for", class: "govuk-label", for: "width-10" %><br />
+        <%= form.text_field :username, autofocus: true, class: "govuk-input govuk-input--width-10" %>
       </div>
 
       <div class="actions">


### PR DESCRIPTION
**WHY:**
This was done based on a suggestion to edit the design of text boxes to suit the length of the input required in them.

**IN THIS PR:** 
Edit the input classnames for the appropriate text fields. Done this with Postcode, IP addresses, Username and Contact number

**SOLUTION EXAMPLE:**
**BEFORE:**
<img width="744" alt="screenshot 2018-12-19 at 12 07 03" src="https://user-images.githubusercontent.com/32823756/50219417-07552680-0387-11e9-8947-9358411d22dd.png">

------------------------------------------------------------------------------------------------------

**AFTER:**
<img width="802" alt="screenshot 2018-12-19 at 12 09 54" src="https://user-images.githubusercontent.com/32823756/50219433-18059c80-0387-11e9-9940-a6fd1a835238.png">
