### PR TITLE
Resize the input boxes on admin

### DIFF
--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -47,7 +47,7 @@
         <label class="govuk-label" for="contact_number">
           Contact number (optional)
         </label>
-        <%= text_field_tag 'contact_number', nil, class: 'govuk-input', type: 'tel' %>
+        <%= text_field_tag 'contact_number', nil, class: 'govuk-input govuk-input--width-20', type: 'tel' %>
       </div>
 
       <div class="govuk-form-group">

--- a/app/views/ips/new.html.erb
+++ b/app/views/ips/new.html.erb
@@ -16,7 +16,7 @@
 
       <div class="govuk-form-group <%= field_error(@ip, :address) %>">
         <%= form.label :ip, "Enter IP address (IPv4 only)", class: "govuk-label" %>
-        <%= form.text_field :address, id: :address, autocomplete: "off", class: "govuk-input" %>
+        <%= form.text_field :address, id: :address, autocomplete: "off", class: "govuk-input govuk-input--width-10" %>
       </div>
 
       <div class="actions">

--- a/app/views/logs/search.html.erb
+++ b/app/views/logs/search.html.erb
@@ -16,7 +16,7 @@
     <%= form_with url: logs_path, method: :get do |form| %>
       <div class="govuk-form-group">
         <%= form.label :username, "Enter the username you wish to see logs for", class: "govuk-label" %><br />
-        <%= form.text_field :username, autofocus: true, class: "govuk-input" %>
+        <%= form.text_field :username, autofocus: true, class: "govuk-input govuk-input--width-10" %>
       </div>
 
       <div class="actions">


### PR DESCRIPTION
**WHY:**
This was done based on a suggestion to edit the design of text boxes to suit the length of the input required in them.

**IN THIS PR:** 
Edit the input classnames for the appropriate text fields.

**SOLUTION EXAMPLE:**

**BEFORE:**

<img width="737" alt="screenshot 2018-12-19 at 13 20 47" src="https://user-images.githubusercontent.com/32823756/50222699-f4475400-0390-11e9-8d09-22e701f0bd9c.png">
------------------------------------------------------------------------------------------------------

**AFTER:**
<img width="474" alt="screenshot 2018-12-19 at 13 24 48" src="https://user-images.githubusercontent.com/32823756/50222921-a121d100-0391-11e9-97e6-36b8732c0444.png">