### PR TITLE
Extend notifications mock to include links

### DIFF
--- a/spec/features/authentication/lock_user_account_spec.rb
+++ b/spec/features/authentication/lock_user_account_spec.rb
@@ -41,7 +41,11 @@ describe 'Locking a users account' do
     end
 
     it 'sends the right type of email' do
-      expect(notifications.last).to eq 'unlock'
+      expect(last_notification_type).to eq 'unlock'
+    end
+
+    it 'sends an unlock link' do
+      expect(last_notification_link).to include(user_unlock_path)
     end
 
     it 'tells me my account is locked' do

--- a/spec/features/support/mock_notification_client.rb
+++ b/spec/features/support/mock_notification_client.rb
@@ -10,7 +10,19 @@ shared_context 'with a mocked notifications client' do
 
     # TODO: remove dependency on test entries in gov-notify.yml
     def send_email(args)
-      self.class.notifications << args[:template_id]
+      self.class.notifications << {
+        type: args[:template_id],
+        link: find_link(args)
+      }
+    end
+
+    def find_link(args)
+      invite_url = args.dig(:personalisation, :invite_url)
+      reset_url = args.dig(:personalisation, :reset_url)
+      confirmation_url = args.dig(:personalisation, :confirmation_url)
+      unlock_url = args.dig(:personalisation, :unlock_url)
+
+      reset_url || invite_url || confirmation_url || unlock_url
     end
 
     def self.reset!
@@ -22,4 +34,6 @@ shared_context 'with a mocked notifications client' do
   after { NotificationsMock.reset! }
 
   let(:notifications) { NotificationsMock.notifications }
+  let(:last_notification_type) { NotificationsMock.notifications.last[:type] }
+  let(:last_notification_link) { NotificationsMock.notifications.last[:link] }
 end


### PR DESCRIPTION
Doing these tests a few at the time to help inform the design of the notifications mock. This PR adds recording the URLs that are often found in the emails we sent out, should make it easier for these tests to.

Replacing five requires with a single one is pretty sweet.