### PR TITLE
Replace old mock with new mock

### DIFF
--- a/spec/features/guidance_after_sign_in_spec.rb
+++ b/spec/features/guidance_after_sign_in_spec.rb
@@ -1,6 +1,6 @@
-require 'support/notifications_service'
-
 describe 'guidance after sign in' do
+  include_context 'with a mocked notifications client'
+
   let(:user) { create(:user) }
   before { sign_in_user user }
 

--- a/spec/features/ips/view_ip_address_readiness_spec.rb
+++ b/spec/features/ips/view_ip_address_readiness_spec.rb
@@ -1,7 +1,7 @@
 require 'timecop'
 
-describe 'with a stubbed notifications service' do
-  include_examples 'notifications service'
+describe 'view whether IPs are ready' do
+  include_context 'with a mocked notifications client'
 
   after { Timecop.return }
 

--- a/spec/features/ips/view_ip_addresses_spec.rb
+++ b/spec/features/ips/view_ip_addresses_spec.rb
@@ -1,14 +1,8 @@
-require 'support/notifications_service'
-require 'support/confirmation_use_case'
-
 describe 'View IP addresses' do
-  include_examples 'confirmation use case spy'
-  include_examples 'notifications service'
+  include_context 'with a mocked notifications client'
 
   context 'when logged out' do
-    before do
-      visit ips_path
-    end
+    before { visit ips_path }
 
     it_behaves_like 'not signed in'
   end

--- a/spec/features/locations/add_new_location_spec.rb
+++ b/spec/features/locations/add_new_location_spec.rb
@@ -1,9 +1,5 @@
-require 'support/notifications_service'
-require 'support/confirmation_use_case'
-
 describe 'Add new location' do
-  include_examples 'confirmation use case spy'
-  include_examples 'notifications service'
+  include_context 'with a mocked notifications client'
 
   let(:user) { create(:user) }
   let(:ip_input) { "location_ips_attributes_0_address" }

--- a/spec/features/team/invite_with_permissions_spec.rb
+++ b/spec/features/team/invite_with_permissions_spec.rb
@@ -1,7 +1,5 @@
-require 'support/notifications_service'
-
 describe 'Set user permissions on invite' do
-  include_examples 'notifications service'
+  include_context 'with a mocked notifications client'
 
   let(:user) { create(:user) }
   let(:invited_email) { 'invited@gov.uk' }

--- a/spec/features/team/permissions_spec.rb
+++ b/spec/features/team/permissions_spec.rb
@@ -1,12 +1,11 @@
 require 'support/notifications_service'
 
 describe 'Invite a team member' do
-  include_examples 'notifications service'
+  include_context 'with a mocked notifications client'
+
   let(:user) { create(:user) }
 
-  before do
-    sign_in_user user
-  end
+  before { sign_in_user user }
 
   context 'With the .manage_team permission' do
     before do


### PR DESCRIPTION
This should make what's going on with these specs a little clearer, plus less maintenance cost than all these separate mocks (which can eventually be removed). 

Some of the specs aren't just a drop-in replacement - going to address those more slowly, probably as we touch the related areas.