### PR TITLE
Link to referenced guidance, correct language

### DIFF
--- a/app/views/help/new.html.erb
+++ b/app/views/help/new.html.erb
@@ -22,7 +22,9 @@
         <%= submit_tag('Continue', class: 'govuk-button') %>
       <% end %>
 
-      <p class="govuk-body"> If you are having trouble connecting to GovWifi in your organisation, please use our guidance on common issues.</p>
+      <p class="govuk-body"> If you are having trouble connecting to GovWifi, see <%= link_to 'our guidance on common issues', SITE_CONFIG['end_user_troubleshooting_link'], class: "govuk-link" %>.
+      </p>
+
       <p class="govuk-body"> If this doesn't resolve the issue, we recommend you contact your organisation’s IT support team.</p>
     </div>
   </div>


### PR DESCRIPTION
Just noticed this as I was looking at the signed-out support page.

OLD;

![image](https://user-images.githubusercontent.com/429326/50593036-989bc100-0e8e-11e9-965e-4bcb7fd473a1.png)


NEW:

![image](https://user-images.githubusercontent.com/429326/50593032-92a5e000-0e8e-11e9-9455-026bd485b905.png)
