### PR TITLE
Add dashboard display to overview page

### DIFF
--- a/app/assets/stylesheets/utilities/layout.scss
+++ b/app/assets/stylesheets/utilities/layout.scss
@@ -13,3 +13,11 @@
 .inline-block {
   display: inline-block;
 }
+
+.dashboard-colour {
+  background:#2b8cc4;
+}
+
+.dashboard-font-size {
+  font-size: 35px;
+}

--- a/app/assets/stylesheets/utilities/layout.scss
+++ b/app/assets/stylesheets/utilities/layout.scss
@@ -15,9 +15,5 @@
 }
 
 .dashboard-colour {
-  background:#2b8cc4;
-}
-
-.dashboard-font-size {
-  font-size: 35px;
+  background: govuk-colour("light-blue");
 }

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,8 @@ class HomeController < ApplicationController
   def index
     redirect_to admin_organisations_path if current_user.super_admin?
     @ips = current_organisation.ips
+    @locations = current_organisation.locations
+    @team_members = current_organisation.users
     @london_radius_ips = radius_ips[:london]
     @dublin_radius_ips = radius_ips[:dublin]
   end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,14 +1,14 @@
 <div class="govuk-grid-row">
   <h2 class="govuk-heading-l govuk-grid-column-full">Overview</h2>
-  <div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
     <div class="govuk-grid-column-one-third">
       <div class="govuk-panel govuk-panel--confirmation dashboard-colour">
         <h1 class="govuk-panel__title text-left">
           <%= @team_members.count %>
         </h1>
-        <div class="govuk-panel__body text-left dashboard-font-size">
+        <p class="govuk-panel__body text-left govuk-!-font-size-27">
           Team Members
-        </div>
+        </p>
       </div>
     </div>
     <div class="govuk-grid-column-one-third">
@@ -16,9 +16,9 @@
         <h1 class="govuk-panel__title text-left">
           <%= @locations.count %>
         </h1>
-        <div class="govuk-panel__body text-left dashboard-font-size">
+        <p class="govuk-panel__body text-left govuk-!-font-size-27">
           Locations
-        </div>
+        </p>
       </div>
     </div>
     <div class="govuk-grid-column-one-third">
@@ -26,13 +26,13 @@
         <h1 class="govuk-panel__title text-left">
           <%= @ips.count %>
         </h1>
-        <div class="govuk-panel__body text-left dashboard-font-size">
+        <p class="govuk-panel__body text-left govuk-!-font-size-27">
           Active IPs
-        </div>
+        </p>
       </div>
     </div>
+    <hr class="govuk-section-break--m govuk-section-break--visible">
   </div>
-  <hr class="govuk-section-break--m govuk-section-break--visible">
   <h2 class="govuk-heading-l govuk-grid-column-full">Get GovWifi Access in your Organisation</h2>
   <div class="govuk-grid-column-two-thirds">
     <div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,38 @@
 <div class="govuk-grid-row">
+  <h2 class="govuk-heading-l govuk-grid-column-full">Overview</h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      <div class="govuk-panel govuk-panel--confirmation dashboard-colour">
+        <h1 class="govuk-panel__title text-left">
+          <%= @team_members.count %>
+        </h1>
+        <div class="govuk-panel__body text-left dashboard-font-size">
+          Team Members
+        </div>
+      </div>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <div class="govuk-panel govuk-panel--confirmation dashboard-colour">
+        <h1 class="govuk-panel__title text-left">
+          <%= @locations.count %>
+        </h1>
+        <div class="govuk-panel__body text-left dashboard-font-size">
+          Locations
+        </div>
+      </div>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <div class="govuk-panel govuk-panel--confirmation dashboard-colour">
+        <h1 class="govuk-panel__title text-left">
+          <%= @ips.count %>
+        </h1>
+        <div class="govuk-panel__body text-left dashboard-font-size">
+          Active IPs
+        </div>
+      </div>
+    </div>
+  </div>
+  <hr class="govuk-section-break--m govuk-section-break--visible">
   <h2 class="govuk-heading-l govuk-grid-column-full">Get GovWifi Access in your Organisation</h2>
   <div class="govuk-grid-column-two-thirds">
     <div>


### PR DESCRIPTION
**WHY:**
It was suggested that if an organisation has setup and are running GovWifi then they don't need to see the get started checklist as the first page when they login. They should instead see something that gives them an overview of their current installation.

**IN THIS PR:**
The changes to get to the solution would be added in increments and not implemented as a one large feature. This may allow for user feedback changes/additions to be easily implemented. 
The `index.html` file for the `HomeController` was modified to include a separator. 
Above the separator, html elements were added to create the overview dashboard look.
Below the separator, the setup instructions remain unchanged in this PR.

**BEFORE:**
<img width="598" alt="screenshot 2019-01-03 at 11 35 50" src="https://user-images.githubusercontent.com/32823756/50635844-be3ad000-0f4b-11e9-9c09-546401d323a3.png">

**AFTER:**
<img width="1036" alt="screenshot 2019-01-03 at 11 36 38" src="https://user-images.githubusercontent.com/32823756/50635881-e1fe1600-0f4b-11e9-8116-9a53772b01ef.png">

**NEXT STEPS:**
The next iteration would involve reorganisation. The setup instructions should have its own page and more stuff (as necessary) could be added to the overview page e.g. number of roaming endusers & guest users in the organisation.
The idea behind this is to change where the admin user lands after login based on whether they have setup GovWifi & running it in their organisation or not.