### PR TITLE
Allow requests to /help

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   end
 
   resources :help, only: %i[create new] do
+    get '/', on: :collection, to: 'help#new'
     get 'signed_in', on: :new
     get 'signing_up', on: :new
     get 'existing_account', on: :new

--- a/spec/features/contact_us_when_not_signed_in_spec.rb
+++ b/spec/features/contact_us_when_not_signed_in_spec.rb
@@ -111,4 +111,12 @@ describe 'Contact us when not signed in' do
       end
     end
   end
+
+  context 'from root/help path' do
+    before { visit '/help' }
+
+    it 'shows the user the not signed in support page' do
+      expect(page).to have_content 'How can we help?'
+    end
+  end
 end

--- a/spec/features/contact_us_when_signed_in_spec.rb
+++ b/spec/features/contact_us_when_signed_in_spec.rb
@@ -43,4 +43,12 @@ describe 'Contact us when signed in' do
       expect(notifications).to be_empty
     end
   end
+
+  context 'from root/help path' do
+    before { visit '/help' }
+
+    it 'shows the user the not signed in support page' do
+      expect(page).to have_content 'How can we help?'
+    end
+  end
 end


### PR DESCRIPTION
The links from product page and tech docs were broken with the introduction of the new help pages. 

Could fix this here or on those apps, I'm easy. Here being permissive seems good.