### PR TITLE
Remove getting help link at bottom of overview page.

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -33,4 +33,3 @@
     </div>
   </div>
 </div>
-<%= link_to "Getting help", help_index_path, class: 'govuk-link' %>


### PR DESCRIPTION
**WHY:**
It was suggested that the bottom link looked out of place on this page since its contents is light.
There is also the non-scrollable link in the top nav bar for getting support should the user require it.

**IN THIS PR:**
Remove the associated code within the `index.html` file for the `HomeController`.

**BEFORE:**

![image](https://user-images.githubusercontent.com/32823756/50828453-59abb680-1339-11e9-8c42-fb91790fcfa4.png)

**AFTER:**

<img width="1001" alt="screenshot 2019-01-08 at 11 37 19" src="https://user-images.githubusercontent.com/32823756/50828711-08e88d80-133a-11e9-9c5e-6481f2f064ae.png">
