### PR TITLE
Prevent loopback IP addresses from being used

### DIFF
--- a/lib/use_cases/administrator/check_if_valid_ip.rb
+++ b/lib/use_cases/administrator/check_if_valid_ip.rb
@@ -13,7 +13,9 @@ module UseCases
       def valid_address?
         address.present? &&
           address_is_ipv4? &&
-          !(address_is_subnet? || address_allows_all?)
+          !address_is_subnet? &&
+          !address_allows_all? &&
+          !address_is_loopback?
       end
 
       def address_allows_all?
@@ -30,6 +32,10 @@ module UseCases
         rescue IPAddr::InvalidAddressError
           false
         end
+      end
+
+      def address_is_loopback?
+        IPAddr.new(address).loopback?
       end
     end
   end

--- a/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
@@ -1,6 +1,6 @@
 describe 'View authentication requests for an IP' do
   context 'with results' do
-    let(:ip) { '127.0.0.1' }
+    let(:ip) { '1.2.3.4' }
     let(:username) { 'ABCDEF' }
     let(:organisation) { create(:organisation) }
     let(:admin_user) { create(:user, organisation_id: organisation.id) }
@@ -10,7 +10,7 @@ describe 'View authentication requests for an IP' do
       Session.create!(
         start: 3.days.ago,
         username: username,
-        siteIP: '127.0.0.1',
+        siteIP: ip,
         success: true
       )
 

--- a/spec/gateways/ips_spec.rb
+++ b/spec/gateways/ips_spec.rb
@@ -4,7 +4,7 @@ describe Gateways::Ips do
   let(:result) do
     [
       {
-        ip: "127.0.0.1",
+        ip: "186.3.1.2",
         location_id: location_1.id
       }, {
         ip: "186.3.1.1",
@@ -14,7 +14,7 @@ describe Gateways::Ips do
   end
 
   before do
-    create(:ip, address: "127.0.0.1", location: location_1)
+    create(:ip, address: "186.3.1.2", location: location_1)
     create(:ip, address: "186.3.1.1", location: location_2)
   end
 

--- a/spec/use_cases/administrator/check_if_valid_ip_spec.rb
+++ b/spec/use_cases/administrator/check_if_valid_ip_spec.rb
@@ -55,6 +55,15 @@ describe UseCases::Administrator::CheckIfValidIp do
         expect(result).to eq(success: false)
       end
     end
+
+    context 'with a loopback IP address' do
+      let(:address) { '127.0.0.1' }
+
+      it 'returns false' do
+        result = subject.execute(address)
+        expect(result).to eq(success: false)
+      end
+    end
   end
 
   context 'not IPv4' do

--- a/spec/use_cases/administrator/validate_log_search_query_spec.rb
+++ b/spec/use_cases/administrator/validate_log_search_query_spec.rb
@@ -7,7 +7,7 @@ describe UseCases::Administrator::ValidateLogSearchQuery do
         valid_params = [
           { username: 'ABCDE', ip: nil },
           { username: 'ABCDEF', ip: nil },
-          { username: nil, ip: '127.0.0.1' }
+          { username: nil, ip: '1.2.3.4' }
         ]
 
         valid_params.each do |valid_param|


### PR DESCRIPTION
This is useful for 2 things:
- It prevents an admin entering an IP address that will never work for them
- It prevents an admin accidentally/maliciously trying to conflict with any internal clients we use for healtchecks