### PR TITLE
Fix the colour of the overview links in unique browser scenarios

### DIFF
--- a/app/assets/stylesheets/components/overview.scss
+++ b/app/assets/stylesheets/components/overview.scss
@@ -13,7 +13,3 @@
 .summary-link-colour:hover {
   color: govuk-colour("white")
 }
-
-.summary-link-colour:active {
-  color: govuk-colour("white")
-}

--- a/app/assets/stylesheets/components/overview.scss
+++ b/app/assets/stylesheets/components/overview.scss
@@ -2,6 +2,18 @@
   background: govuk-colour("light-blue");
 }
 
+.summary-link-colour:link {
+  color: govuk-colour("white")
+}
+
 .summary-link-colour:visited {
+  color: govuk-colour("white")
+}
+
+.summary-link-colour:hover {
+  color: govuk-colour("white")
+}
+
+.summary-link-colour:active {
   color: govuk-colour("white")
 }


### PR DESCRIPTION
**WHY:**
In certain instances, the link styles for the links in the overview would be a different colour and/or disappear when the mouse hovers over it. One such instance is the incognito mode in Google Chrome.

**IN THIS PR:**
More CSS pseudo-classes were added to the `summary-link-colour` CSS class to work around the limitations some browsers may put on changing the colour of links, especially visited links.

**BEFORE:**

<img width="1440" alt="screenshot 2019-01-10 at 11 29 06" src="https://user-images.githubusercontent.com/32823756/50966269-5563d280-14cc-11e9-99ee-97f8092c815d.png">

**Google Chrome's Incognito Mode**

------------------------------------------------------------------------------------------------------

<img width="1440" alt="screenshot 2019-01-10 at 11 29 09" src="https://user-images.githubusercontent.com/32823756/50966285-644a8500-14cc-11e9-9bae-7cb812b53f04.png">

**Hovering over a link in this state (note: IPs has disappeared**

------------------------------------------------------------------------------------------------------

**AFTER:**

<img width="1440" alt="screenshot 2019-01-10 at 11 41 18" src="https://user-images.githubusercontent.com/32823756/50966396-b095c500-14cc-11e9-9555-0ad8c41cbed7.png">
