### PR TITLE
Make default super admin view of organisations ordered by most recent

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -22,10 +22,10 @@ private
   end
 
   def sort_column
-    sortable_columns.include?(params[:sort]) ? params[:sort] : "name"
+    sortable_columns.include?(params[:sort]) ? params[:sort] : "created_at"
   end
 
   def sort_direction
-    %w[asc desc].include?(params[:direction]) ? params[:direction] : "asc"
+    %w[asc desc].include?(params[:direction]) ? params[:direction] : "desc"
   end
 end

--- a/spec/features/admin/sort_view_in_organisation_list_spec.rb
+++ b/spec/features/admin/sort_view_in_organisation_list_spec.rb
@@ -11,29 +11,29 @@ describe 'sorting the values in the organisation list' do
       visit root_path
     end
 
-    context 'and sorts by organisation name' do
-      it 'sorts the list from A -Z, by default' do
-        expect(page.body).to match(/Apple Cakes.*Silly Hats.*Xylophones/m)
-      end
-
-      it 'sorts the list in reverse, when Name is clicked once' do
-        click_link 'Name'
-
-        expect(page.body).to match(/Xylophones.*Silly Hats.*Apple Cakes/m)
-      end
-    end
-
     context 'and sorts by account creation date' do
+      it 'sorts the list from newest to oldest, by default' do
+        expect(page.body).to match(/Xylophones.*Apple Cakes.*Silly Hats/m)
+      end
+
       it 'sorts the list from oldest to newest, when Created on is clicked once' do
         click_link 'Created on'
 
         expect(page.body).to match(/Silly Hats.*Apple Cakes.*Xylophones/m)
       end
+    end
 
-      it 'sorts the list from newest to oldest, when Created on is clicked twice' do
-        2.times { click_link 'Created on' }
+    context 'and sorts by organisation name' do
+      it 'sorts the list from A -Z, when Name is clicked once' do
+        click_link 'Name'
 
-        expect(page.body).to match(/Xylophones.*Apple Cakes.*Silly Hats/m)
+        expect(page.body).to match(/Apple Cakes.*Silly Hats.*Xylophones/m)
+      end
+
+      it 'sorts the list in reverse alphabetical order, when Name is clicked twice' do
+        2.times { click_link 'Name' }
+
+        expect(page.body).to match(/Xylophones.*Silly Hats.*Apple Cakes/m)
       end
     end
 

--- a/spec/features/admin/view_organisation_tab_spec.rb
+++ b/spec/features/admin/view_organisation_tab_spec.rb
@@ -37,16 +37,16 @@ describe 'the visibility of the organisation depending on user' do
   end
 
   context 'comparing signed up organisations' do
-    let!(:organisation_def) { create(:organisation, name: "DEF") }
-    let!(:organisation_xyz) { create(:organisation, name: "XYZ") }
-    let!(:organisation_abc) { create(:organisation, name: "ABC") }
+    let!(:organisation_def) { create(:organisation, name: "DEF", created_at: '10 Oct 2013') }
+    let!(:organisation_xyz) { create(:organisation, name: "XYZ", created_at: '10 Nov 2013') }
+    let!(:organisation_abc) { create(:organisation, name: "ABC", created_at: '10 Jan 2014') }
     let(:user) { create(:user, email: 'me@example.gov.uk', organisation: organisation_abc, super_admin: true) }
 
-    it 'display list of organisations in alphabetical order' do
+    it 'displays list of organisations in order of most recent' do
       sign_in_user user
       visit admin_organisations_path
 
-      expect(page.body).to match(/ABC.*DEF.*XYZ/m)
+      expect(page.body).to match(/ABC.*XYZ.*DEF/m)
     end
   end
 end


### PR DESCRIPTION
**WHY:**
It was suggested that viewing organisations in the order of most recently joined was an easier view to use.

**IN THIS PR:**
Change the current setup of the associated tests to reflect the preferred change. The initial default view was by alphabetical order. 

**BEFORE:**

<img width="1440" alt="screenshot 2019-01-10 at 19 07 13" src="https://user-images.githubusercontent.com/32823756/50990852-1a34c400-150b-11e9-9593-844bce40f27f.png">

------------------------------------------------------------------------------------------------------

**AFTER:**

<img width="1440" alt="screenshot 2019-01-10 at 17 09 35" src="https://user-images.githubusercontent.com/32823756/50990934-5b2cd880-150b-11e9-8fec-749db1015abd.png">
