### PR TITLE
Add better errors to logging pages

### DIFF
--- a/app/models/logs_search.rb
+++ b/app/models/logs_search.rb
@@ -4,8 +4,7 @@ class LogsSearch
   attr_accessor :filter, :first_step
   attr_writer :term
 
-  validates :term, presence: true
-  validate :validate_term
+  validate :validate_term, :validate_presence
 
   def term
     @term&.strip
@@ -22,16 +21,24 @@ private
     end
   end
 
+  def validate_presence
+    if term.length == 0
+      self.errors.add(:search_term, 'cannot be empty')
+    end
+  end
+
   def validate_username
-    unless term.length == 5 || term.length == 6
-      self.errors.add(:term, 'must be 5 or 6 characters')
+    unless term.length == 5 || term.length == 6 || term.length == 0
+      self.errors.add(:search_term, 'must be 5 or 6 characters')
     end
   end
 
   def validate_ip
+    validate_presence if term.length == 0 && return
+
     checker = UseCases::Administrator::CheckIfValidIp.new
     unless checker.execute(self.term)[:success]
-      errors.add(:term, "must be a valid IP")
+      errors.add(:search_term, 'must be a valid IP address')
     end
   end
 end

--- a/app/models/logs_search.rb
+++ b/app/models/logs_search.rb
@@ -22,19 +22,21 @@ private
   end
 
   def validate_presence
-    if term.length == 0
-      self.errors.add(:search_term, 'cannot be empty')
-    end
+    self.errors.add(:search_term, 'cannot be empty') if term.empty?
   end
 
   def validate_username
-    unless term.length == 5 || term.length == 6 || term.length == 0
+    if term_is_present_but_incorrect_length
       self.errors.add(:search_term, 'must be 5 or 6 characters')
     end
   end
 
+  def term_is_present_but_incorrect_length
+    term.present? && term.length != 5 && term.length != 6
+  end
+
   def validate_ip
-    validate_presence if term.length == 0 && return
+    validate_presence if term.empty? && return
 
     checker = UseCases::Administrator::CheckIfValidIp.new
     unless checker.execute(self.term)[:success]

--- a/app/views/logs_searches/_error_message.html.erb
+++ b/app/views/logs_searches/_error_message.html.erb
@@ -1,0 +1,3 @@
+<% if field_error(@search, key).present? %>
+  <p class="govuk-body govuk-error-message">Please <%= message %></p>
+<% end %>

--- a/app/views/logs_searches/_error_message.html.erb
+++ b/app/views/logs_searches/_error_message.html.erb
@@ -1,3 +1,3 @@
 <% if field_error(@search, key).present? %>
-  <p class="govuk-body govuk-error-message">Please <%= message %></p>
+  <p class="govuk-body govuk-error-message"><%= message %></p>
 <% end %>

--- a/app/views/logs_searches/ip.html.erb
+++ b/app/views/logs_searches/ip.html.erb
@@ -9,8 +9,13 @@
 
   <div class='govuk-grid-column-two-thirds'>
     <%= form_for @search do |f| %>
-      <div class='govuk-form-group'>
+      <div class='govuk-form-group <%= field_error(@search, :search_term) %>'>
         <%= f.label :term, 'IP address', class: 'govuk-label' %>
+
+        <% if field_error(@search, :search_term).present? %>
+          <p class="govuk-body govuk-error-message">Please enter a valid IP address</p>
+        <% end %>
+
         <%= f.text_field :term, class: 'govuk-input govuk-input--width-10' %>
       </div>
       <%= f.hidden_field :filter %>

--- a/app/views/logs_searches/ip.html.erb
+++ b/app/views/logs_searches/ip.html.erb
@@ -11,7 +11,6 @@
     <%= form_for @search do |f| %>
       <div class='govuk-form-group <%= field_error(@search, :search_term) %>'>
         <%= f.label :term, 'IP address', class: 'govuk-label' %>
-
         <%= render 'error_message', key: :search_term, message: 'enter a valid IP address' %>
 
         <%= f.text_field :term, class: 'govuk-input govuk-input--width-10' %>

--- a/app/views/logs_searches/ip.html.erb
+++ b/app/views/logs_searches/ip.html.erb
@@ -11,7 +11,7 @@
     <%= form_for @search do |f| %>
       <div class='govuk-form-group <%= field_error(@search, :search_term) %>'>
         <%= f.label :term, 'IP address', class: 'govuk-label' %>
-        <%= render 'error_message', key: :search_term, message: 'enter a valid IP address' %>
+        <%= render 'error_message', key: :search_term, message: 'Enter a valid IP address' %>
 
         <%= f.text_field :term, class: 'govuk-input govuk-input--width-10' %>
       </div>

--- a/app/views/logs_searches/ip.html.erb
+++ b/app/views/logs_searches/ip.html.erb
@@ -12,9 +12,7 @@
       <div class='govuk-form-group <%= field_error(@search, :search_term) %>'>
         <%= f.label :term, 'IP address', class: 'govuk-label' %>
 
-        <% if field_error(@search, :search_term).present? %>
-          <p class="govuk-body govuk-error-message">Please enter a valid IP address</p>
-        <% end %>
+        <%= render 'error_message', key: :search_term, message: 'enter a valid IP address' %>
 
         <%= f.text_field :term, class: 'govuk-input govuk-input--width-10' %>
       </div>

--- a/app/views/logs_searches/new.html.erb
+++ b/app/views/logs_searches/new.html.erb
@@ -5,7 +5,7 @@
 
   <div class='govuk-grid-column-full'>
     <p class='govuk-body'>
-      We record recent requests made to the GovWifi service.
+      Logs are kept for recent authentication requests made to the GovWifi service.
     </p>
 
     <%= form_with url: logs_searches_path, method: :post do |form| %>
@@ -13,7 +13,10 @@
         <p class="govuk-body">
           How do you want to filter these logs?
         </p>
-        <div class="govuk-radios">
+        <div class="govuk-radios <%= field_error(@search, :filter) %>">
+          <% if field_error(@search, :filter).present? %>
+            <p class="govuk-body govuk-error-message">Please select an option</p>
+          <% end %>
           <div class="govuk-radios__item">
             <input class="govuk-radios__input" id="choice-location" name="logs_search[filter]" type="radio" value="location">
             <label class="govuk-label govuk-radios__label" for="choice-location">

--- a/app/views/logs_searches/new.html.erb
+++ b/app/views/logs_searches/new.html.erb
@@ -14,9 +14,8 @@
           How do you want to filter these logs?
         </p>
         <div class="govuk-radios <%= field_error(@search, :filter) %>">
-          <% if field_error(@search, :filter).present? %>
-            <p class="govuk-body govuk-error-message">Please select an option</p>
-          <% end %>
+          <%= render 'error_message', key: :filter, message: 'select an option' %>
+          
           <div class="govuk-radios__item">
             <input class="govuk-radios__input" id="choice-location" name="logs_search[filter]" type="radio" value="location">
             <label class="govuk-label govuk-radios__label" for="choice-location">

--- a/app/views/logs_searches/username.html.erb
+++ b/app/views/logs_searches/username.html.erb
@@ -14,8 +14,8 @@
         <span class='govuk-hint'>
           This is an end user's 5- or 6-character username, like 'abcdef'
         </span>
-        <%= render 'error_message', key: :search_term, message: 'enter a valid username' %>
-        
+        <%= render 'error_message', key: :search_term, message: 'Enter a valid username' %>
+
         <%= f.text_field :term, class: 'govuk-input govuk-input--width-10' %>
       </div>
       <%= f.hidden_field :filter %>

--- a/app/views/logs_searches/username.html.erb
+++ b/app/views/logs_searches/username.html.erb
@@ -15,6 +15,7 @@
           This is an end user's 5- or 6-character username, like 'abcdef'
         </span>
         <%= render 'error_message', key: :search_term, message: 'enter a valid username' %>
+        
         <%= f.text_field :term, class: 'govuk-input govuk-input--width-10' %>
       </div>
       <%= f.hidden_field :filter %>

--- a/app/views/logs_searches/username.html.erb
+++ b/app/views/logs_searches/username.html.erb
@@ -9,11 +9,15 @@
 
   <div class='govuk-grid-column-two-thirds'>
     <%= form_for @search do |f| %>
-      <div class='govuk-form-group'>
+      <div class='govuk-form-group <%= field_error(@search, :search_term) %>'>
         <%= f.label :term, 'Username', class: 'govuk-label' %>
         <span class='govuk-hint'>
           This is an end user's 5- or 6-character username, like 'abcdef'
         </span>
+
+        <% if field_error(@search, :search_term).present? %>
+          <p class="govuk-body govuk-error-message">Please enter a valid username</p>
+        <% end %>
         <%= f.text_field :term, class: 'govuk-input govuk-input--width-10' %>
       </div>
       <%= f.hidden_field :filter %>

--- a/app/views/logs_searches/username.html.erb
+++ b/app/views/logs_searches/username.html.erb
@@ -14,10 +14,7 @@
         <span class='govuk-hint'>
           This is an end user's 5- or 6-character username, like 'abcdef'
         </span>
-
-        <% if field_error(@search, :search_term).present? %>
-          <p class="govuk-body govuk-error-message">Please enter a valid username</p>
-        <% end %>
+        <%= render 'error_message', key: :search_term, message: 'enter a valid username' %>
         <%= f.text_field :term, class: 'govuk-input govuk-input--width-10' %>
       </div>
       <%= f.hidden_field :filter %>

--- a/spec/features/logging/view_auth_requests_for_a_username_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_a_username_spec.rb
@@ -97,7 +97,7 @@ describe "View authentication requests for a username" do
 
       it "should display an error summary to the user" do
         expect(page).to have_content("Search term must be 5 or 6 characters")
-        expect(page).to have_content("Please enter a valid username")
+        expect(page).to have_content("Enter a valid username")
       end
     end
   end

--- a/spec/features/logging/view_auth_requests_for_a_username_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_a_username_spec.rb
@@ -94,6 +94,11 @@ describe "View authentication requests for a username" do
       let(:search_string) { "1" }
 
       it_behaves_like "errors in form"
+
+      it "should display an error summary to the user" do
+        expect(page).to have_content("Search term must be 5 or 6 characters")
+        expect(page).to have_content("Please enter a valid username")
+      end
     end
   end
 

--- a/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
@@ -15,19 +15,49 @@ describe 'View authentication requests for an IP' do
       )
 
       create(:ip, location_id: location.id, address: ip)
-
       sign_in_user admin_user
-      visit ips_path
-
-      within('#ips-table') do
-        click_on 'View logs'
-      end
     end
 
-    context 'searching by IP address' do
+    context 'viewing logs of an IP address directly from link' do
+      before do
+        visit ips_path
+
+        within('#ips-table') do
+          click_on 'View logs'
+        end
+      end
+
       it 'displays the authentication requests' do
         expect(page).to have_content("Found 1 result for \"#{ip}\"")
         expect(page).to have_content(username)
+      end
+    end
+
+    context 'viewing logs by searching for an IP address' do
+      before do
+        visit ip_new_logs_search_path
+        fill_in "IP address", with: search_string
+        click_on "Show logs"
+      end
+
+      context "when IP is correct" do
+        let(:search_string) { ip }
+
+        it 'displays the authentication requests' do
+          expect(page).to have_content("Found 1 result for \"#{ip}\"")
+          expect(page).to have_content(username)
+        end
+      end
+
+      context "when IP is incorrect" do
+        let(:search_string) { "1" }
+
+        it_behaves_like "errors in form"
+
+        it "should display an error summary and prompt to the user" do
+          expect(page).to have_content("Search term must be a valid IP address")
+          expect(page).to have_content("Please enter a valid IP address")
+        end
       end
     end
   end

--- a/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
@@ -56,7 +56,7 @@ describe 'View authentication requests for an IP' do
 
         it "should display an error summary and prompt to the user" do
           expect(page).to have_content("Search term must be a valid IP address")
-          expect(page).to have_content("Please enter a valid IP address")
+          expect(page).to have_content("Enter a valid IP address")
         end
       end
     end

--- a/spec/models/logs_search_spec.rb
+++ b/spec/models/logs_search_spec.rb
@@ -9,7 +9,7 @@ describe LogsSearch do
 
       it 'explains it is blank' do
         subject.valid?
-        expect(subject.errors.full_messages.first).to eq "Term can't be blank"
+        expect(subject.errors.full_messages.first).to eq "Search term cannot be empty"
       end
     end
 
@@ -20,7 +20,7 @@ describe LogsSearch do
 
       it 'explains the required length' do
         subject.valid?
-        expect(subject.errors.full_messages.first).to eq 'Term must be 5 or 6 characters'
+        expect(subject.errors.full_messages.first).to eq 'Search term must be 5 or 6 characters'
       end
     end
 
@@ -43,7 +43,7 @@ describe LogsSearch do
 
       it 'explains the required length' do
         subject.valid?
-        expect(subject.errors.full_messages.first).to eq 'Term must be 5 or 6 characters'
+        expect(subject.errors.full_messages.first).to eq 'Search term must be 5 or 6 characters'
       end
     end
   end
@@ -58,7 +58,7 @@ describe LogsSearch do
 
       it 'explains it is blank' do
         subject.valid?
-        expect(subject.errors.full_messages.first).to eq "Term can't be blank"
+        expect(subject.errors.full_messages.first).to eq "Search term cannot be empty"
       end
     end
 
@@ -69,7 +69,7 @@ describe LogsSearch do
 
       it 'explains it is invalid' do
         subject.valid?
-        expect(subject.errors.full_messages.first).to eq "Term must be a valid IP"
+        expect(subject.errors.full_messages.first).to eq "Search term must be a valid IP address"
       end
     end
 
@@ -80,7 +80,7 @@ describe LogsSearch do
 
       it 'explains it is invalid' do
         subject.valid?
-        expect(subject.errors.full_messages.first).to eq "Term must be a valid IP"
+        expect(subject.errors.full_messages.first).to eq "Search term must be a valid IP address"
       end
     end
 


### PR DESCRIPTION
- Added the error highlighting class to each form field
- Added an error hint to each form field
- Improved the error messages
- Removed the duplicate error summaries when a search term was blank (it used to say "blank" and "invalid", now it just says "blank".

<img width="965" alt="screenshot 2019-01-17 at 17 03 40" src="https://user-images.githubusercontent.com/2160769/51294919-0264bf00-1a7a-11e9-84b3-7292f86c4ba9.png">
<img width="951" alt="screenshot 2019-01-17 at 17 03 04" src="https://user-images.githubusercontent.com/2160769/51294920-0264bf00-1a7a-11e9-831e-f050d853e035.png">
<img width="951" alt="screenshot 2019-01-17 at 17 03 14" src="https://user-images.githubusercontent.com/2160769/51294921-0264bf00-1a7a-11e9-8b02-0901aa2f7b7d.png">
<img width="874" alt="screenshot 2019-01-17 at 17 03 23" src="https://user-images.githubusercontent.com/2160769/51294923-02fd5580-1a7a-11e9-9c74-2e61ae34f046.png">
<img width="874" alt="screenshot 2019-01-17 at 17 03 32" src="https://user-images.githubusercontent.com/2160769/51294924-02fd5580-1a7a-11e9-954a-c807d49ed34a.png">
