### PR TITLE
Fix confusion when an organisation is adding IPs for the first time with no existing locations

### DIFF
--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -6,7 +6,11 @@
   </div>
   <div class="govuk-grid-column-one-third text-right">
     <% if current_user.can_manage_locations? %>
-      <%= link_to 'Add IP address', new_ip_path, class: "govuk-button" %>
+      <% if current_organisation.locations.empty? %>
+        <%= link_to 'Add IP address', new_location_path, class: "govuk-button" %>
+      <% else %>
+        <%= link_to 'Add IP address', new_ip_path, class: "govuk-button" %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/ips/new.html.erb
+++ b/app/views/ips/new.html.erb
@@ -8,30 +8,26 @@
 
     <%= render "activation_notice" %>
 
-    <% if current_organisation.locations.empty? %>
-      <p class="govuk-body"><strong>You have no locations to add a new IP address to, click here to <%= link_to "add a new location", new_location_path, class: "govuk-link" %>.</strong></p>
-    <% else %>
-      <%= form_with model: @ip do |form| %>
-        <div class="govuk-form-group <%= field_error(@ip, :location_id) %>">
-          <%= form.label :location, "Select an existing location", class: "govuk-label" %>
-          <%= collection_select :ip, :location_id, @locations, :id, :full_address, {}, { class: "govuk-select" } %>
-        </div>
+    <%= form_with model: @ip do |form| %>
+      <div class="govuk-form-group <%= field_error(@ip, :location_id) %>">
+        <%= form.label :location, "Select an existing location", class: "govuk-label" %>
+        <%= collection_select :ip, :location_id, @locations, :id, :full_address, {}, { class: "govuk-select" } %>
+      </div>
 
-        <div class="govuk-form-group <%= field_error(@ip, :address) %>">
-          <%= form.label :ip, "Enter IP address (IPv4 only)", class: "govuk-label" %>
-          <%= form.text_field :address, id: :address, autocomplete: "off", class: "govuk-input govuk-input--width-10" %>
-        </div>
+      <div class="govuk-form-group <%= field_error(@ip, :address) %>">
+        <%= form.label :ip, "Enter IP address (IPv4 only)", class: "govuk-label" %>
+        <%= form.text_field :address, id: :address, autocomplete: "off", class: "govuk-input govuk-input--width-10" %>
+      </div>
 
-        <div class="actions">
-          <%= form.submit "Add new IP address", class: "govuk-button" %>
-        </div>
+      <div class="actions">
+        <%= form.submit "Add new IP address", class: "govuk-button" %>
+      </div>
 
-        <p class="govuk-body"><strong>OR</strong></p>
+      <p class="govuk-body"><strong>OR</strong></p>
 
-        <p class='govuk-body'>
-          <%= link_to "Add a new location", new_location_path, class: "govuk-link" %>
-        </p>
-      <% end %>
+      <p class='govuk-body'>
+        <%= link_to "Add a new location", new_location_path, class: "govuk-link" %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/ips/new.html.erb
+++ b/app/views/ips/new.html.erb
@@ -8,27 +8,30 @@
 
     <%= render "activation_notice" %>
 
-    <%= form_with model: @ip do |form| %>
-      <div class="govuk-form-group <%= field_error(@ip, :location_id) %>">
-        <%= form.label :location, "Select an existing location", class: "govuk-label" %>
-        <%= collection_select :ip, :location_id, @locations, :id, :full_address, {}, { class: "govuk-select" } %>
-      </div>
+    <% if current_organisation.locations.empty? %>
+      <p class="govuk-body"><strong>You have no locations to add a new IP address to, click here to <%= link_to "add a new location", new_location_path, class: "govuk-link" %>.</strong></p>
+    <% else %>
+      <%= form_with model: @ip do |form| %>
+        <div class="govuk-form-group <%= field_error(@ip, :location_id) %>">
+          <%= form.label :location, "Select an existing location", class: "govuk-label" %>
+          <%= collection_select :ip, :location_id, @locations, :id, :full_address, {}, { class: "govuk-select" } %>
+        </div>
 
-      <div class="govuk-form-group <%= field_error(@ip, :address) %>">
-        <%= form.label :ip, "Enter IP address (IPv4 only)", class: "govuk-label" %>
-        <%= form.text_field :address, id: :address, autocomplete: "off", class: "govuk-input govuk-input--width-10" %>
-      </div>
+        <div class="govuk-form-group <%= field_error(@ip, :address) %>">
+          <%= form.label :ip, "Enter IP address (IPv4 only)", class: "govuk-label" %>
+          <%= form.text_field :address, id: :address, autocomplete: "off", class: "govuk-input govuk-input--width-10" %>
+        </div>
 
-      <div class="actions">
-        <%= form.submit "Add new IP address", class: "govuk-button" %>
-      </div>
+        <div class="actions">
+          <%= form.submit "Add new IP address", class: "govuk-button" %>
+        </div>
 
-      <p class="govuk-body"><strong>OR</strong></p>
+        <p class="govuk-body"><strong>OR</strong></p>
 
-      <p class='govuk-body'>
-        <%= link_to "Add a new location", new_location_path, class: "govuk-link" %>
-      </p>
-
+        <p class='govuk-body'>
+          <%= link_to "Add a new location", new_location_path, class: "govuk-link" %>
+        </p>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/locations/new.erb
+++ b/app/views/locations/new.erb
@@ -19,7 +19,7 @@
     <%= link_to 'Back to list', ips_path, class: 'govuk-back-link' %>
 
     <% if current_organisation.locations.empty? %>
-      <h2 class='govuk-heading-l'>Add your first location and IP address(es)</h2>
+      <h2 class='govuk-heading-l'>Add your first location and IP addresses</h2>
     <% else %>
       <h2 class='govuk-heading-l'>Add a new location</h2>
     <% end %>

--- a/app/views/locations/new.erb
+++ b/app/views/locations/new.erb
@@ -15,18 +15,16 @@
 <% end %>
 
 <div class='govuk-grid-row'>
-  <div class='govuk-grid-column-two-thirds'>
+  <div class='govuk-grid-column-full'>
     <%= link_to 'Back to list', ips_path, class: 'govuk-back-link' %>
 
     <% if current_organisation.locations.empty? %>
-      <h2 class='govuk-heading-l'>Add a new location</h2>
-      <div class="govuk-inset-text">
-        <strong>You have no existing locations to add a new IP address to.</strong>
-      </div>
+      <h2 class='govuk-heading-l'>Add your first location and IP address(es)</h2>
     <% else %>
       <h2 class='govuk-heading-l'>Add a new location</h2>
     <% end %>
-
+  </div>
+  <div class='govuk-grid-column-two-thirds'>
     <%= form_for @location, html: { autocomplete: "off" } do |f| %>
       <div class="govuk-form-group">
         <%= f.label :address, class: 'govuk-label' %>

--- a/app/views/locations/new.erb
+++ b/app/views/locations/new.erb
@@ -18,7 +18,14 @@
   <div class='govuk-grid-column-two-thirds'>
     <%= link_to 'Back to list', ips_path, class: 'govuk-back-link' %>
 
-    <h2 class='govuk-heading-l'>Add a new location</h2>
+    <% if current_organisation.locations.empty? %>
+      <h2 class='govuk-heading-l'>Add a new location</h2>
+      <div class="govuk-inset-text">
+        <strong>You have no existing locations to add a new IP address to.</strong>
+      </div>
+    <% else %>
+      <h2 class='govuk-heading-l'>Add a new location</h2>
+    <% end %>
 
     <%= form_for @location, html: { autocomplete: "off" } do |f| %>
       <div class="govuk-form-group">

--- a/app/views/setup_instructions/index.html.erb
+++ b/app/views/setup_instructions/index.html.erb
@@ -3,7 +3,13 @@
   <div class="govuk-grid-column-two-thirds">
     <div>
       <h3 class="govuk-heading-m"> 1. Add IPs </h3>
-      <% if @ips.empty? %>
+      <% if @locations.empty? %>
+        <% if current_user.can_manage_locations? %>
+          <p class="govuk-body">
+            You need to <%= link_to "add the IPs", new_location_path, class: "govuk-link" %> of your authenticator(s).
+          </p>
+        <% end %>
+      <% elsif @ips.empty? %>
         <% if current_user.can_manage_locations? %>
           <p class="govuk-body">
             You need to <%= link_to "add the IPs", new_ip_path, class: "govuk-link" %> of your authenticator(s).

--- a/spec/features/locations/add_new_location_spec.rb
+++ b/spec/features/locations/add_new_location_spec.rb
@@ -12,8 +12,8 @@ describe 'Add new location' do
       click_on 'Add IP address'
     end
 
-    it 'explains that a location needs to be added first' do
-      expect(page).to have_content('You have no existing locations')
+    it 'displays an instruction to add the first location' do
+      expect(page).to have_content('Add your first location')
     end
 
     context 'and adding the first location' do

--- a/spec/features/locations/add_new_location_spec.rb
+++ b/spec/features/locations/add_new_location_spec.rb
@@ -13,12 +13,10 @@ describe 'Add new location' do
     end
 
     it 'explains that a location needs to be added first' do
-      expect(page).to have_content('You have no locations')
+      expect(page).to have_content('You have no existing locations')
     end
 
-    context 'and adding a new location' do
-      before { click_on 'add a new location' }
-
+    context 'and adding the first location' do
       context 'and that IP is valid' do
         before do
           fill_in 'Address', with: '30 Square'

--- a/spec/features/locations/add_new_location_spec.rb
+++ b/spec/features/locations/add_new_location_spec.rb
@@ -10,79 +10,86 @@ describe 'Add new location' do
       sign_in_user user
       visit ips_path
       click_on 'Add IP address'
-      click_on 'Add a new location'
     end
 
-    context 'and that IP is valid' do
-      before do
-        fill_in 'Address', with: '30 Square'
-        fill_in 'Postcode', with: 'CC DDD'
-        fill_in ip_input, with: '10.0.0.1'
-        click_on 'Add new location'
-      end
-
-      it 'shows me the location was added' do
-        expect(page).to have_content('30 Square, CC DDD added')
-      end
-
-      it 'adds the location and IPs' do
-        expect(Ip.last.location.address).to eq('30 Square')
-        expect(Ip.last.location.postcode).to eq('CC DDD')
-      end
+    it 'explains that a location needs to be added first' do
+      expect(page).to have_content('You have no locations')
     end
 
-    context 'and that IP is invalid' do
-      before do
-        fill_in 'Address', with: '30 Square'
-        fill_in 'Postcode', with: 'CC DDD'
-        fill_in ip_input, with: '10.wrong.0.1'
-        fill_in second_ip_input, with: '10.0.0.3'
-        click_on 'Add new location'
-      end
+    context 'and adding a new location' do
+      before { click_on 'add a new location' }
 
-      it 'asks me to re-enter IPs' do
-        expect(page).to have_content('enter up to five IP addresses')
-      end
+      context 'and that IP is valid' do
+        before do
+          fill_in 'Address', with: '30 Square'
+          fill_in 'Postcode', with: 'CC DDD'
+          fill_in ip_input, with: '10.0.0.1'
+          click_on 'Add new location'
+        end
 
-      it 'tells me an IP is invalid' do
-        expect(page).to have_content(
-          "One or more IPs are incorrect"
-        )
-      end
+        it 'shows me the location was added' do
+          expect(page).to have_content('30 Square, CC DDD added')
+        end
 
-      context 'when looking back at the list' do
-        before { visit ips_path }
-
-        it 'has not added the invalid IP' do
-          expect(page).to_not have_content('10.wrong.0.1')
+        it 'adds the location and IPs' do
+          expect(Ip.last.location.address).to eq('30 Square')
+          expect(Ip.last.location.postcode).to eq('CC DDD')
         end
       end
-    end
 
-    context 'and that IP is blank' do
-      before do
-        fill_in 'Address', with: '30 Square'
-        fill_in 'Postcode', with: 'CC DDD'
-        click_on 'Add new location'
-      end
+      context 'and that IP is invalid' do
+        before do
+          fill_in 'Address', with: '30 Square'
+          fill_in 'Postcode', with: 'CC DDD'
+          fill_in ip_input, with: '10.wrong.0.1'
+          fill_in second_ip_input, with: '10.0.0.3'
+          click_on 'Add new location'
+        end
 
-      context 'when looking back at the list' do
-        before { visit ips_path }
+        it 'asks me to re-enter IPs' do
+          expect(page).to have_content('enter up to five IP addresses')
+        end
 
-        it 'has added the location' do
-          expect(page).to have_content('30 Square')
+        it 'tells me an IP is invalid' do
+          expect(page).to have_content(
+            "One or more IPs are incorrect"
+          )
+        end
+
+        context 'when looking back at the list' do
+          before { visit ips_path }
+
+          it 'has not added the invalid IP' do
+            expect(page).to_not have_content('10.wrong.0.1')
+          end
         end
       end
-    end
 
-    context 'and the address is blank' do
-      before do
-        fill_in 'Postcode', with: 'CC DDD'
-        fill_in ip_input, with: '10.wrong.0.1'
-        click_on 'Add new location'
+      context 'and that IP is blank' do
+        before do
+          fill_in 'Address', with: '30 Square'
+          fill_in 'Postcode', with: 'CC DDD'
+          click_on 'Add new location'
+        end
+
+        context 'when looking back at the list' do
+          before { visit ips_path }
+
+          it 'has added the location' do
+            expect(page).to have_content('30 Square')
+          end
+        end
       end
 
-      it_behaves_like "errors in form"
+      context 'and the address is blank' do
+        before do
+          fill_in 'Postcode', with: 'CC DDD'
+          fill_in ip_input, with: '10.wrong.0.1'
+          click_on 'Add new location'
+        end
+
+        it_behaves_like "errors in form"
+      end
     end
   end
 


### PR DESCRIPTION
**WHY:**
When a user's organisation has no locations and the user wants to add an IP, they get an empty drop-down selector in the "Add IP address" flow. A link to `Add a new location` is present but may cause confusion for a user whose desire is to **add a new IP address** since it is not stated that a location is required first before adding an IP address.

**Current Display for organisations without any locations:**
<img width="826" alt="screenshot 2019-01-17 at 12 17 25" src="https://user-images.githubusercontent.com/32823756/51318341-fe24ab80-1a51-11e9-9403-c8d2c96e8971.png">

**Current Display for organisations with at least one location:**
<img width="833" alt="screenshot 2019-01-17 at 12 21 48" src="https://user-images.githubusercontent.com/32823756/51318520-7d19e400-1a52-11e9-8684-9a18350ebe9c.png">

------------------------------------------------------------------------------------------------------

**IN THIS PR:**
- A working suggestion is to redirect the user to the `new_location_path` when they click on the `add an IP address` button, if their organisation has not added any locations. 
- When they land on the page, a message is displayed to explain to the user that their organisation has no locations to add an IP address to. This message will only been shown if the user's organisation has no locations.

**Step 1:**
<img width="1045" alt="screenshot 2019-01-17 at 11 58 22" src="https://user-images.githubusercontent.com/32823756/51318427-36c48500-1a52-11e9-9085-097511e58111.png">

**Step 2:**
<img width="732" alt="screenshot 2019-01-17 at 11 57 20" src="https://user-images.githubusercontent.com/32823756/51318574-a5a1de00-1a52-11e9-9792-eaa9d5ad63ba.png">

------------------------------------------------------------------------------------------------------

**Suggestions/feedback would be appreciated.**