### PR TITLE
Improve signed-in support page

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -35,6 +35,10 @@ class HelpController < ApplicationController
   def create
     @support_form = SupportForm.new(support_form_params)
 
+    if @support_form.email.blank?
+      @support_form.email = current_user&.email
+    end
+
     if @support_form.valid?
       template_id = GOV_NOTIFY_CONFIG['help_email']['template_id']
 

--- a/app/views/help/signed_in.html.erb
+++ b/app/views/help/signed_in.html.erb
@@ -2,32 +2,53 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= link_to 'Back', root_path, class: "govuk-back-link" %>
     <h2 class="govuk-heading-l">Get support</h2>
-    <div class="govuk-details">
-      <h2 class="govuk-heading-s">
-        End user connection issues
-      </h2>
-      <p class="govuk-body">
-        If an end user is having trouble with GovWifi, we recommend directing them to
-        <%= link_to 'our guidance on common issues', SITE_CONFIG['end_user_troubleshooting_link'], class: "govuk-link" %>.
-      </p>
-    </div>
 
-    <h2 class="govuk-heading-s">Before you contact us</h2>
+    <p class="govuk-body">
+      If an <strong>individual user</strong> is having trouble connecting to GovWifi:
+    </p>
     <ul class="govuk-list govuk-list--bullet">
-      <li><%= link_to 'Check the GovWifi service status', status_index_path, class: "govuk-link" %></li>
-      <li>Check your <%= link_to 'configured IP addresses', ips_path, class: "govuk-link" %> match your authenticator IPs </li>
-      <li>Check your authenticators have the right RADIUS secret keys</li>
-      <li>Try logging in as an end user, then <%= link_to 'search our logs', new_logs_search_path, class: "govuk-link" %></li>
-      <li><%= link_to 'Browse the technical documentation', SITE_CONFIG['organisation_docs_link'], class: "govuk-link" %></li>
+      <li>
+        Direct them to <%= link_to 'our guidance on common issues', SITE_CONFIG['end_user_troubleshooting_link'], class: "govuk-link" %>.
+      </li>
+      <li>
+        <%= link_to 'Search our logs', username_new_logs_search_path, class: "govuk-link" %> to confirm they are reaching our service
+      </li>
+      <li>
+        <p class="govuk-body">
+          Check if there are any problems with the <%= link_to 'GovWifi service', status_index_path, class: "govuk-link" %>.
+        </p>
+      </li>
     </ul>
 
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <p class="govuk-body">
+      If your <strong>entire organisation</strong> is having trouble connecting to GovWifi:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        Check your <%= link_to 'IPs and RADIUS secret keys', ips_path, class: "govuk-link" %> match your local configuration
+      </li>
+      <li>
+        <%= link_to 'Search our logs', location_new_logs_search_path, class: "govuk-link" %> to confirm traffic from you is reaching our service
+      </li>
+      <li>
+        Search <%= link_to 'our technical documentation', SITE_CONFIG['organisation_docs_link'], class: "govuk-link" %>
+      </li>
+      <li>
+        <p class="govuk-body">
+          Check if there are any problems with the <%= link_to 'GovWifi service', status_index_path, class: "govuk-link" %>.
+        </p>
+      </li>
+    </ul>
+
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <p class="govuk-body">
+      If you <strong> can't resolve your issue</strong>, send us a support request.
+    </p>
     <%= form_for @support_form, url: {action: "create"}  do |f| %>
-      <div class="govuk-form-group <%= field_error(@support_form, :email) %>">
-        <%= f.label :email, "Your email address", class: "govuk-label" %>
-        <%= f.text_field :email, class: "govuk-input" %>
-      </div>
       <div class="govuk-form-group <%= field_error(@support_form, :details) %>">
         <%= f.label :details, "Tell us about your issue", class: "govuk-label" %>
         <%= f.text_area :details, class: "govuk-textarea", size: "30x10"  %>
@@ -36,7 +57,7 @@
         <%= f.hidden_field :choice %>
       </div>
       <div class="govuk-inset-text">
-        Support tickets are checked daily, you will receive a reply within the next few working days.
+        Support tickets are checked daily. You should receive a reply within the next few working days.
       </div>
       <%= f.submit 'Send support request', class: 'govuk-button' %>
     <% end %>

--- a/app/views/setup_instructions/index.html.erb
+++ b/app/views/setup_instructions/index.html.erb
@@ -73,4 +73,4 @@
     <hr class="govuk-section-break--l govuk-section-break--visible">
   </div>
 </div>
-<p class="govuk-body">If you have trouble setting up GovWifi, <%= link_to "contact us", signed_in_new_help_path, class: 'govuk-link govuk-body' %>.</p>
+<p class="govuk-body">If you are having trouble setting up GovWifi, go to our <%= link_to "support page", signed_in_new_help_path, class: 'govuk-link govuk-body' %>.</p>

--- a/spec/features/admin/view_organisation_list_spec.rb
+++ b/spec/features/admin/view_organisation_list_spec.rb
@@ -14,7 +14,7 @@ describe 'view list of signed up organisations' do
 
     it 'redirects me to the landing guidance' do
       expect(page).to have_content 'Get GovWifi'
-      expect(page).to have_content 'If you have trouble setting up GovWifi'
+      expect(page).to have_content 'If you are having trouble setting up GovWifi'
     end
   end
 

--- a/spec/features/contact_us_when_signed_in_spec.rb
+++ b/spec/features/contact_us_when_signed_in_spec.rb
@@ -2,16 +2,16 @@ describe 'Contact us when signed in' do
   include_context 'with a mocked notifications client'
 
   let(:organisation) { create :organisation }
+  let(:user) { create(:user, organisation: organisation) }
 
   before do
-    sign_in_user create(:user, organisation: organisation)
+    sign_in_user user
     visit signed_in_new_help_path
   end
 
   context 'with details filled in' do
     before do
       fill_in 'Tell us about your issue', with: 'Help me barry.. im a duck too'
-      fill_in 'Your email address', with: 'barry@gov.uk'
       click_on 'Send support request'
     end
 
@@ -31,6 +31,10 @@ describe 'Contact us when signed in' do
     it 'records the organisation' do
       expect(last_notification_personalisation[:organisation])
         .to eq organisation.name
+    end
+
+    it 'records the sender' do
+      expect(last_notification_personalisation[:sender_email]).to eq user.email
     end
   end
 

--- a/spec/features/guidance_after_sign_in_spec.rb
+++ b/spec/features/guidance_after_sign_in_spec.rb
@@ -18,7 +18,7 @@ describe 'guidance after sign in' do
 
     it 'shows me the landing guidance' do
       expect(page).to have_content 'Get GovWifi'
-      expect(page).to have_content 'If you have trouble setting up GovWifi'
+      expect(page).to have_content 'If you are having trouble setting up GovWifi'
     end
 
     context 'and an IP, clicking on that IP' do


### PR DESCRIPTION
### This PR:
- Uses account email instead of asking a user to enter it
- Gives clearer direction to other ways of resolving problems
- Cuts out superfluous text
- Removes back link (there are multiple ways to get here and plenty of escape routes, "back" is more likely to confuse than help)

### OLD

![image](https://user-images.githubusercontent.com/429326/51324950-d4748000-1a63-11e9-880b-73caeb141e2b.png)

### NEW

![image](https://user-images.githubusercontent.com/429326/51324974-e35b3280-1a63-11e9-81c1-8751cdee7194.png)

This page is serving multiple needs, I would expect to split it out in the near future, but think this is an improvement already.