### PR TITLE
Fix visibility of the top navigation links on mobile view

### DIFF
--- a/app/assets/stylesheets/components/main_nav.scss
+++ b/app/assets/stylesheets/components/main_nav.scss
@@ -1,6 +1,8 @@
-.main-nav {
-  display: flex;
-  justify-content: space-between;
+@media only screen and (min-width: 1024px) {
+  .main-nav {
+    display: flex;
+    justify-content: space-between;
+  }
 }
 
 .product-name{

--- a/app/assets/stylesheets/components/main_nav.scss
+++ b/app/assets/stylesheets/components/main_nav.scss
@@ -18,9 +18,11 @@
   padding: 9px 0;
 }
 
-.govuk-header__container {
-  max-height: 40px;
-  padding-top: 11px;
+@media only screen and (min-width: 1024px) {
+  .govuk-header__container {
+    max-height: 40px;
+    padding-top: 11px;
+  }
 }
 
 .govuk-header__logotype-crown {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="govuk-template ">
+<html lang="en" class="govuk-template app-html-class">
   <head>
     <!-- test post please ignore -->
 
@@ -42,7 +42,7 @@
     <meta property="og:image" content="/assets/images/govuk-opengraph-image.png">
   </head>
 
-  <body class="govuk-template__body ">
+  <body class="govuk-template__body app-body-class">
     <!-- Google Tag Manager (noscript) -->
       <noscript>
         <iframe src="https://www.googletagmanager.com/ns.html?id=<%= SITE_CONFIG['google_tag_container_ID'] %>"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -86,6 +86,7 @@
         </div>
 
         <div class="govuk-header__content main-nav">
+          <span></span>
           <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
           <nav>
             <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <!-- test post please ignore -->
 
-  <!-- Global site tag (gtag.js) - Google Analytics -->
+    <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=<%= SITE_CONFIG['google_analytics_script_id'] %>"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -86,7 +86,7 @@
         </div>
 
         <div class="govuk-header__content main-nav">
-        <span> </span>
+          <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
           <nav>
             <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
               <li class="govuk-header__navigation-item">


### PR DESCRIPTION
**WHY:**
When viewed on a mobile device, the top navigation links: `Documentation`, `Support` & `Sign Out`(or `Sign in` depending on the user's state) disappeared from the user's view.

**PREVIOUS DISPLAY ON MOBILE:**
![screenshot 2019-01-21 at 16 09 41](https://user-images.githubusercontent.com/32823756/51485853-01dc6900-1d97-11e9-8eae-be3afb00fc0d.png)

------------------------------------------------------------------------------------------------------

**IN THIS PR:**
- Include the gov-uk styled `button` html tag within the `application.html.erb` file.
- Add gov-uk classes to the `html` and `body` tags based on the html layout of the [Customised page template](https://design-system.service.gov.uk/styles/page-template/) example.
- Add span tags to align the menu to the right of the screen.
- Add media query for desktop and iPad Pro screens. Reasoning explained below:

The custom css class involved was done in a previous PR to keep a consistent layout when comparing the main navigations of the admin portal, product page & tech docs (explained in this commit: 5ceed80).

This custom css class however, overlaid the menu (as seen below) unto the rest of the page since its max height was hard set:

![screenshot 2019-01-21 at 11 54 07](https://user-images.githubusercontent.com/32823756/51483725-ac518d80-1d91-11e9-9b2f-14014383d866.png)

The media query was added to preserve the main navigation consistency (referred to in this commit: 5ceed80) and to prevent the styling from affecting devices with a browser window less than 1024 px (i.e. mobile devices). 

------------------------------------------------------------------------------------------------------

1024 px was chosen as a result of checking the view through various screen sizes.

**iPad view- (768 x 1024)**
![screenshot 2019-01-21 at 15 38 26](https://user-images.githubusercontent.com/32823756/51484136-a7d9a480-1d92-11e9-9d8c-9bb784567072.png)

------------------------------------------------------------------------------------------------------

**iPad Pro view- (1024 x 1366)**
![screenshot 2019-01-21 at 15 38 37](https://user-images.githubusercontent.com/32823756/51484158-b627c080-1d92-11e9-8959-b31db9422afa.png)

At 1024 px, it was safe to assume that the styling that creates the menu button would no be longer active. 

------------------------------------------------------------------------------------------------------

**CURRENT DISPLAY ON MOBILE:**

**Example 1:**
![screenshot 2019-01-21 at 15 11 45](https://user-images.githubusercontent.com/32823756/51484603-e6239380-1d93-11e9-9f53-2022ea9f7077.png)

**Example 2:**
![screenshot 2019-01-21 at 15 12 00](https://user-images.githubusercontent.com/32823756/51485020-f425e400-1d94-11e9-80b9-0832c6fe52f4.png)

**Any suggestions and/or feedback would be appreciated**
