### PR TITLE
Align sub-navigation on support page for consistency across the platform

### DIFF
--- a/app/assets/stylesheets/components/sub_nav.scss
+++ b/app/assets/stylesheets/components/sub_nav.scss
@@ -19,6 +19,7 @@
       padding-bottom: 5px;
       display: inline-block;
       text-decoration: none;
+      border-bottom: 5px solid white;
     }
 
     .active {

--- a/app/views/application/_subnavigation.html.erb
+++ b/app/views/application/_subnavigation.html.erb
@@ -1,29 +1,29 @@
 <div class="govuk-grid-row subnav">
   <div class="govuk-grid-column-one-third govuk-!-padding-left-0">
     <p class="govuk-body organisation-name">
-    <% unless current_user.super_admin? %>
-      <strong><%= current_organisation.name %></strong>
-    <% end %>
+      <% unless current_user.super_admin? %>
+        <strong><%= current_organisation.name %></strong>
+      <% end %>
     </p>
   </div>
 
   <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-0 govuk-!-padding-right-0 flex-end">
     <nav class="govuk-body govuk-!-margin-bottom-0 ">
-    <% if current_user.super_admin? %>
-      <%= link_to "Organisations", admin_organisations_path, class: active_tab(admin_organisations_path) %>
-      <%= link_to "MOU", admin_mou_index_path, class: active_tab(admin_mou_index_path) %>
-    <% else %>
-      <% if current_organisation.ips.present? %>
-        <%= link_to "Overview", root_path, class: active_tab(root_path) %>
+      <% if current_user.super_admin? %>
+        <%= link_to "Organisations", admin_organisations_path, class: active_tab(admin_organisations_path) %>
+        <%= link_to "MOU", admin_mou_index_path, class: active_tab(admin_mou_index_path) %>
+      <% else %>
+        <% if current_organisation.ips.present? %>
+          <%= link_to "Overview", root_path, class: active_tab(root_path) %>
+        <% end %>
+        <%= link_to "Setting Up", setup_instructions_path, class: active_tab(setup_instructions_path) %>
+        <%= link_to 'Organisation', organisation_path(current_organisation), class: active_tab("organisation") %>
+        <%= link_to "Team members", team_members_path, class: "#{active_tab("team")}" + "#{active_tab("user")}"%>
+        <%= link_to "IPs", ips_path, id:"nav-ips", class: active_tab("ips") %>
+        <% if current_organisation.ips.present? %>
+          <%= link_to 'Logs', new_logs_search_path, class: active_tab("logs") %>
+        <% end %>
       <% end %>
-      <%= link_to "Setting Up", setup_instructions_path, class: active_tab(setup_instructions_path) %>
-      <%= link_to 'Organisation', organisation_path(current_organisation), class: active_tab("organisation") %>
-      <%= link_to "Team members", team_members_path, class: "#{active_tab("team")}" + "#{active_tab("user")}"%>
-      <%= link_to "IPs", ips_path, id:"nav-ips", class: active_tab("ips") %>
-      <% if current_organisation.ips.present? %>
-        <%= link_to 'Logs', new_logs_search_path, class: active_tab("logs") %>
-      <% end %>
-    <% end %>
     </nav>
   </div>
 </div>


### PR DESCRIPTION
**WHY:**
When viewing the support page, the sub-navigation shifts downwards since none of the tabs on the sub-nav are active. 

**IN THIS PR:**
Add a "default" white border bottom to all the sub-nav tabs to keep the alignment consistent regardless of active state. When a tab is active, the appropriate CSS class will change the colour of the border from white to black.

**1. SUPPORT PAGE BEFORE:**

<img width="1082" alt="screenshot 2019-01-22 at 12 38 17" src="https://user-images.githubusercontent.com/32823756/51536609-162a6f80-1e44-11e9-9bde-0cf727b82f7b.png">

------------------------------------------------------------------------------------------------------

**2. SUPPORT PAGE AFTER:**

<img width="1101" alt="screenshot 2019-01-22 at 12 38 04" src="https://user-images.githubusercontent.com/32823756/51536624-204c6e00-1e44-11e9-8005-b7bf08c451ec.png">

------------------------------------------------------------------------------------------------------

**3. WHEN TAB IS ACTIVE:**

<img width="1050" alt="screenshot 2019-01-22 at 12 49 38" src="https://user-images.githubusercontent.com/32823756/51536682-45d97780-1e44-11e9-8d38-cdf5cf9a024c.png">

------------------------------------------------------------------------------------------------------

**Any suggestion/feedback would be appreciated.**