### PR TITLE
Hide logs link if org has no locations

### DIFF
--- a/app/views/help/signed_in.html.erb
+++ b/app/views/help/signed_in.html.erb
@@ -11,9 +11,11 @@
       <li>
         Direct them to <%= link_to 'our guidance on common issues', SITE_CONFIG['end_user_troubleshooting_link'], class: "govuk-link" %>.
       </li>
-      <li>
-        <%= link_to 'Search our logs', username_new_logs_search_path, class: "govuk-link" %> to confirm they are reaching our service
-      </li>
+      <% unless current_organisation.locations.empty? %>
+        <li>
+          <%= link_to 'Search our logs', username_new_logs_search_path, class: "govuk-link" %> to confirm they are reaching our service
+        </li>
+      <% end %>
       <li>
         <p class="govuk-body">
           Check if there are any problems with the <%= link_to 'GovWifi service', status_index_path, class: "govuk-link" %>.
@@ -30,9 +32,11 @@
       <li>
         Check your <%= link_to 'IPs and RADIUS secret keys', ips_path, class: "govuk-link" %> match your local configuration
       </li>
-      <li>
-        <%= link_to 'Search our logs', location_new_logs_search_path, class: "govuk-link" %> to confirm traffic from you is reaching our service
-      </li>
+      <% unless current_organisation.locations.empty? %>
+        <li>
+          <%= link_to 'Search our logs', location_new_logs_search_path, class: "govuk-link" %> to confirm traffic from you is reaching our service
+        </li>
+      <% end %>
       <li>
         Search <%= link_to 'our technical documentation', SITE_CONFIG['organisation_docs_link'], class: "govuk-link" %>
       </li>


### PR DESCRIPTION
**WHY:**
- When an organisation has no locations and they click on the `search logs by location` link it takes them to the "hidden from navigation" `logs/search` page with no locations in the drop-down.

<img width="707" alt="screenshot 2019-01-25 at 12 00 40" src="https://user-images.githubusercontent.com/32823756/51744880-1cfdf000-2099-11e9-8f4d-2fcb9f6e550b.png">

- The `logs` sub navigation link is hidden when an organisation has no locations(PR #404).
The thinking behind this was that there would be no logs if the organisation has not set up an IP to receive traffic with. Setting up an IP is not standalone but depends on there being a location added to the organisation's profile.

- Since the navigation to `logs` is hidden from view when an organisation has no locations, the remaining routes to that part of the app were the `search logs by location` & `search logs by username` links in the signed in support page.

**IN THIS PR:**
- The two bullet points were also made hidden from view in the same manner as the `logs` sub navigation link.

------------------------------------------------------------------------------------------------------

_**CURRENT VIEW FOR NO LOCATIONS ADDED:**_

<img width="617" alt="screenshot 2019-01-25 at 12 08 02" src="https://user-images.githubusercontent.com/32823756/51745146-e379b480-2099-11e9-85ba-c62f976e23b8.png">

------------------------------------------------------------------------------------------------------

_**POSSIBLE VIEW FOR NO LOCATIONS ADDED:**_

<img width="662" alt="screenshot 2019-01-25 at 12 00 23" src="https://user-images.githubusercontent.com/32823756/51744833-f50e8c80-2098-11e9-875a-32da78abc0eb.png">

**Any suggestions/feedback would be appreciated**