### PR TITLE
Ensure IP whitelist is updated when deleting IPs

### DIFF
--- a/app/controllers/ips_controller.rb
+++ b/app/controllers/ips_controller.rb
@@ -11,7 +11,7 @@ class IpsController < ApplicationController
     @ip = Ip.new(ip_params)
 
     if @ip.save
-      Facades::Ips::AfterCreate.new.execute
+      Facades::Ips::Publish.new.execute
       redirect_to(
         ips_path,
         notice: "#{@ip.address} added, it will be active starting tomorrow"
@@ -34,6 +34,7 @@ class IpsController < ApplicationController
     redirect_to ips_path && return unless ip
 
     ip.destroy
+    Facades::Ips::Publish.new.execute
     redirect_to ips_path, notice: "Successfully removed IP address #{ip.address}"
   end
 

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -8,7 +8,7 @@ class LocationsController < ApplicationController
     @location = Location.new(location_params_without_blank_ips)
 
     if @location.save
-      Facades::Ips::AfterCreate.new.execute
+      Facades::Ips::Publish.new.execute
       redirect_to ips_path, notice: "#{@location.full_address} added"
     else
       add_blank_ips_to_location

--- a/lib/facades/ips/publish.rb
+++ b/lib/facades/ips/publish.rb
@@ -1,6 +1,6 @@
 module Facades
   module Ips
-    class AfterCreate
+    class Publish
       def execute
         publish_for_performance_platform
         publish_radius_whitelist

--- a/spec/facades/ips/publish_spec.rb
+++ b/spec/facades/ips/publish_spec.rb
@@ -1,4 +1,4 @@
-describe Facades::Ips::AfterCreate do
+describe Facades::Ips::Publish do
   before do
     expect_any_instance_of(
       UseCases::PerformancePlatform::PublishLocationsIps

--- a/spec/requests/ips/delete_spec.rb
+++ b/spec/requests/ips/delete_spec.rb
@@ -6,6 +6,8 @@ describe "DELETE /ips/:id", type: :request do
   before do
     https!
     login_as(user, scope: :user)
+    stub_request(:get, 'http://169.254.169.254/latest/meta-data/iam/security-credentials/')
+    stub_request(:put, /s3.eu-west-2/)
   end
 
   context "when the user owns the IP" do
@@ -13,6 +15,11 @@ describe "DELETE /ips/:id", type: :request do
       expect {
         delete ip_path(ip)
       }.to change { Ip.count }.by(-1)
+    end
+
+    it "Publishes the new list of IPs" do
+      expect_any_instance_of(Facades::Ips::Publish).to receive(:execute)
+      delete ip_path(ip)
     end
   end
 


### PR DESCRIPTION
We publish an IP whitelist to S3 whenever we create one, do the same
when we delete them