### PR TITLE
Fix make serve to reflect public IP validation

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,11 +46,11 @@ location_2 = Location.create!(
 )
 
 20.times do
-  Ip.create!(address: Faker::Internet.unique.ip_v4_address, location: location_1)
+  Ip.create!(address: Faker::Internet.unique.public_ip_v4_address, location: location_1)
 end
 
 20.times do
-  Ip.create!(address: Faker::Internet.unique.ip_v4_address, location: location_2)
+  Ip.create!(address: Faker::Internet.unique.public_ip_v4_address, location: location_2)
 end
 
 location_2.ips.each_with_index do |ip, index|


### PR DESCRIPTION
We've changed the validation to only allowed private IPs, but generated seeds can still be private IPs, which causes `make serve` to fail.

This PR changes the seed generation to only use public IPs (there's a Faker method for it out of the box).

Follow-up to https://github.com/alphagov/govwifi-admin/pull/428.