### PR TITLE
Validate only on service email

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -30,6 +30,6 @@ private
   end
 
   def organisation_params
-    params.require(:organisation).permit(:name, :service_email)
+    params.require(:organisation).permit(:service_email)
   end
 end


### PR DESCRIPTION
Due to the register implementation whenever we updated the organisation settings, the org name was also being updated, due to some orgs not being in our register it caused a validation error. This fix allows the user to ONLY update their service email and stop the validation error.