### PR TITLE
Add custom organisations 

### DIFF
--- a/app/models/custom_organisation_name.rb
+++ b/app/models/custom_organisation_name.rb
@@ -1,3 +1,2 @@
 class CustomOrganisationName < ApplicationRecord
-
 end

--- a/app/models/custom_organisation_name.rb
+++ b/app/models/custom_organisation_name.rb
@@ -1,0 +1,3 @@
+class CustomOrganisationName < ApplicationRecord
+
+end

--- a/db/migrate/20190207105214_create_custom_organisation_name.rb
+++ b/db/migrate/20190207105214_create_custom_organisation_name.rb
@@ -1,0 +1,9 @@
+class CreateCustomOrganisationName < ActiveRecord::Migration[5.2]
+  def change
+    create_table :custom_organisation_names do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_27_155510) do
+ActiveRecord::Schema.define(version: 2019_02_07_105214) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -31,6 +31,12 @@ ActiveRecord::Schema.define(version: 2018_11_27_155510) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "custom_organisation_names", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "ips", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/lib/gateways/govuk_organisations_register_gateway.rb
+++ b/lib/gateways/govuk_organisations_register_gateway.rb
@@ -22,5 +22,10 @@ module Gateways
         value['item'].first['official-name']
       end
     end
+
+    def custom_orgs
+      []
+    end
+
   end
 end

--- a/lib/gateways/govuk_organisations_register_gateway.rb
+++ b/lib/gateways/govuk_organisations_register_gateway.rb
@@ -24,7 +24,7 @@ module Gateways
     end
 
     def custom_orgs
-      []
+      CustomOrganisationName.all.map(&:name)
     end
 
   end

--- a/lib/gateways/govuk_organisations_register_gateway.rb
+++ b/lib/gateways/govuk_organisations_register_gateway.rb
@@ -26,6 +26,5 @@ module Gateways
     def custom_orgs
       CustomOrganisationName.all.map(&:name)
     end
-
   end
 end

--- a/lib/use_cases/organisation/fetch_organisation_register.rb
+++ b/lib/use_cases/organisation/fetch_organisation_register.rb
@@ -8,7 +8,9 @@ module UseCases
       def execute
         government_orgs = organisations_gateway.government_orgs
         local_authorities = organisations_gateway.local_authorities
-        government_orgs + local_authorities
+        custom_orgs = organisations_gateway.custom_orgs
+
+        government_orgs + local_authorities + custom_orgs
       end
 
     private

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :organisation do
     sequence :name do |n|
-      "Org #{n}"
+      "Gov Org #{n}"
     end
 
     service_email { Faker::Internet.email }

--- a/spec/features/admin/add_custom_organisation_as_super_admin_spec.rb
+++ b/spec/features/admin/add_custom_organisation_as_super_admin_spec.rb
@@ -1,9 +1,0 @@
-describe 'adding a custom organisation' do
-  let!(:admin_user) { create(:user, super_admin: true) }
-
-  context 'when visiting the organisations page' do
-    before do
-      sign_in_user admin_user
-    end
-  end
-end

--- a/spec/features/admin/add_custom_organisation_as_super_admin_spec.rb
+++ b/spec/features/admin/add_custom_organisation_as_super_admin_spec.rb
@@ -1,0 +1,9 @@
+describe 'adding a custom organisation' do
+  let!(:admin_user) { create(:user, super_admin: true) }
+
+  context 'when visiting the organisations page' do
+    before do
+      sign_in_user admin_user
+    end
+  end
+end

--- a/spec/features/admin/delete_organisation_as_super_admin_spec.rb
+++ b/spec/features/admin/delete_organisation_as_super_admin_spec.rb
@@ -1,6 +1,6 @@
 describe 'deleting an organisation' do
   let!(:admin_user) { create(:user, super_admin: true) }
-  let!(:organisation) { create(:organisation, name: 'Org 2') }
+  let!(:organisation) { create(:organisation, name: 'Gov Org 2') }
 
   context 'when visiting the organisations page' do
     before do
@@ -10,7 +10,7 @@ describe 'deleting an organisation' do
     end
 
     it 'shows the organisations page I am on' do
-      expect(page).to have_content("Org 2")
+      expect(page).to have_content("Gov Org 2")
     end
 
     it 'should show a delete organisation button on the page' do
@@ -28,7 +28,7 @@ describe 'deleting an organisation' do
 
     it 'should remove the organisation from the index list of orgs' do
       click_on 'Yes, remove this organisation'
-      expect(page).to_not have_content("Org 2")
+      expect(page).to_not have_content("Gov Org 2")
     end
   end
 end

--- a/spec/features/admin/edit_organisation_details_spec.rb
+++ b/spec/features/admin/edit_organisation_details_spec.rb
@@ -1,6 +1,6 @@
 describe 'editing an organisations details' do
   let(:admin_user1) { create(:user, organisation: organisation) }
-  let(:organisation) { create(:organisation, name: "Org 2", service_email: "testme@gov.uk") }
+  let(:organisation) { create(:organisation, name: "Gov Org 2", service_email: "testme@gov.uk") }
 
   context 'when visiting the edit organisations settings page' do
     before do

--- a/spec/features/admin/sign_in_as_super_admin_spec.rb
+++ b/spec/features/admin/sign_in_as_super_admin_spec.rb
@@ -3,13 +3,13 @@ describe 'signing in as a super admin' do
 
   context 'when visiting the home page' do
     before do
-      create(:organisation, name: "Org 2")
+      create(:organisation, name: "Gov Org 2")
       sign_in_user user
       visit root_path
     end
 
     it 'shows list of signed organisations on the home page' do
-      expect(page).to have_content("Org 2")
+      expect(page).to have_content("Gov Org 2")
     end
   end
 end

--- a/spec/features/admin/sort_view_in_organisation_list_spec.rb
+++ b/spec/features/admin/sort_view_in_organisation_list_spec.rb
@@ -3,8 +3,8 @@ describe 'sorting the values in the organisation list' do
     let!(:super_admin) { create(:user, super_admin: true) }
 
     before do
-      create(:organisation, name: "Org 2", created_at: '10 Dec 2013')
-      create(:organisation, name: "Org 3", created_at: '10 Feb 2014')
+      create(:organisation, name: "Gov Org 2", created_at: '10 Dec 2013')
+      create(:organisation, name: "Gov Org 3", created_at: '10 Feb 2014')
 
       sign_in_user super_admin
       visit root_path
@@ -12,13 +12,13 @@ describe 'sorting the values in the organisation list' do
 
     context 'and sorts by account creation date' do
       it 'sorts the list from newest to oldest, by default' do
-        expect(page.body).to match(/Org 1.*Org 3.*Org 2/m)
+        expect(page.body).to match(/Gov Org 1.*Gov Org 3.*Gov Org 2/m)
       end
 
       it 'sorts the list from oldest to newest, when Created on is clicked once' do
         click_link 'Created on'
 
-        expect(page.body).to match(/Org 2.*Org 3.*Org 1/m)
+        expect(page.body).to match(/Gov Org 2.*Gov Org 3.*Gov Org 1/m)
       end
     end
 
@@ -26,41 +26,41 @@ describe 'sorting the values in the organisation list' do
       it 'sorts the list from A -Z, when Name is clicked once' do
         click_link 'Name'
 
-        expect(page.body).to match(/Org 1.*Org 2.*Org 3/m)
+        expect(page.body).to match(/Gov Org 1.*Gov Org 2.*Gov Org 3/m)
       end
 
       it 'sorts the list in reverse alphabetical order, when Name is clicked twice' do
         2.times { click_link 'Name' }
 
-        expect(page.body).to match(/Org 3.*Org 2.*Org 1/m)
+        expect(page.body).to match(/Gov Org 3.*Gov Org 2.*Gov Org 1/m)
       end
     end
 
     context 'and sorts by signed MoU uploads' do
       before do
-        create(:organisation, name: "Org 4")
+        create(:organisation, name: "Gov Org 4")
 
-        Organisation.find_by(name: "Org 1").signed_mou.attach(
+        Organisation.find_by(name: "Gov Org 1").signed_mou.attach(
           io: File.open(Rails.root + "spec/fixtures/mou.pdf"), filename: "mou.pdf"
         )
 
-        Organisation.find_by(name: "Org 3").signed_mou.attach(
+        Organisation.find_by(name: "Gov Org 3").signed_mou.attach(
           io: File.open(Rails.root + "spec/fixtures/mou.pdf"), filename: "mou.pdf"
         )
 
-        Organisation.find_by(name: "Org 3").signed_mou_attachment.update(created_at: 3.months.from_now)
+        Organisation.find_by(name: "Gov Org 3").signed_mou_attachment.update(created_at: 3.months.from_now)
       end
 
       it 'sorts the list by oldest to most recent, when MoU signed is clicked once' do
         click_link 'MoU Signed'
 
-        expect(page.body).to match(/Org 4.*Org 1.*Org 3/m)
+        expect(page.body).to match(/Gov Org 4.*Gov Org 1.*Gov Org 3/m)
       end
 
       it 'sorts the list by most recent to oldest, when MoU signed is clicked twice' do
         2.times { click_link 'MoU Signed' }
 
-        expect(page.body).to match(/Org 3.*Org 1.*Org 4/m)
+        expect(page.body).to match(/Gov Org 3.*Gov Org 1.*Gov Org 4/m)
       end
     end
   end

--- a/spec/features/admin/view_organisation_tab_spec.rb
+++ b/spec/features/admin/view_organisation_tab_spec.rb
@@ -38,9 +38,9 @@ describe 'the visibility of the organisation depending on user' do
 
   context 'comparing signed up organisations' do
     before do
-      create(:organisation, name: "Org 3", created_at: '10 Oct 2013')
-      create(:organisation, name: "Org 1", created_at: '10 Nov 2013')
-      create(:organisation, name: "Org 2", created_at: '10 Jan 2014')
+      create(:organisation, name: "Gov Org 3", created_at: '10 Oct 2013')
+      create(:organisation, name: "Gov Org 1", created_at: '10 Nov 2013')
+      create(:organisation, name: "Gov Org 2", created_at: '10 Jan 2014')
     end
 
     let(:user) { create(:user, email: 'me@example.gov.uk', organisation: Organisation.first, super_admin: true) }
@@ -49,7 +49,7 @@ describe 'the visibility of the organisation depending on user' do
       sign_in_user user
       visit admin_organisations_path
 
-      expect(page.body).to match(/Org 2.*Org 1.*Org 3/m)
+      expect(page.body).to match(/Gov Org 2.*Gov Org 1.*Gov Org 3/m)
     end
   end
 end

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -32,7 +32,7 @@ describe 'Sign up as an organisation' do
       end
 
       it 'creates an organisation for the user' do
-        expect(User.last.organisation.name).to eq('Org 1')
+        expect(User.last.organisation.name).to eq('Gov Org 1')
       end
     end
 

--- a/spec/features/team/view_team_members_spec.rb
+++ b/spec/features/team/view_team_members_spec.rb
@@ -49,7 +49,7 @@ describe 'View team members of my organisation' do
 
     context 'when there are users outside of my organisation' do
       before do
-        other_organisation = create(:organisation, name: 'Org 2')
+        other_organisation = create(:organisation, name: 'Gov Org 2')
         create(:user, email: 'stranger@example.gov.uk', organisation: other_organisation)
       end
 

--- a/spec/fixtures/gov_orgs_payload.json
+++ b/spec/fixtures/gov_orgs_payload.json
@@ -8,7 +8,7 @@
       {
         "end-date":"2016-07-13",
         "website":"https://www.gov.uk/government/organisations/org1",
-        "name":"Org 1",
+        "name":"Gov Org 1",
         "government-organisation":"OT1067"
       }
     ]
@@ -21,7 +21,7 @@
       {
         "end-date":"2016-07-13",
         "website":"https://www.gov.uk/government/organisations/org2",
-        "name":"Org 2",
+        "name":"Gov Org 2",
         "government-organisation":"OT1099"
       }
     ]
@@ -34,7 +34,7 @@
       {
         "end-date":"2016-07-13",
         "website":"https://www.gov.uk/government/organisations/org3",
-        "name":"Org 3",
+        "name":"Gov Org 3",
         "government-organisation":"OT1068"
       }
     ]
@@ -47,7 +47,7 @@
       {
         "end-date":"2016-07-13",
         "website":"https://www.gov.uk/government/organisations/org4",
-        "name":"Org 4",
+        "name":"Gov Org 4",
         "government-organisation":"OT1069"
       }
     ]

--- a/spec/fixtures/local_auths_payload.json
+++ b/spec/fixtures/local_auths_payload.json
@@ -7,7 +7,7 @@
     "item":[
       {
         "local-authority-type":"NMD",
-        "official-name":"Org 5",
+        "official-name":"Local Auth 1",
         "local-authority-eng":"STA",
         "name":"Stafford"}
       ]
@@ -19,7 +19,7 @@
         "item":[
       {
         "local-authority-type":"COMB",
-        "official-name":"Org 6",
+        "official-name":"Local Auth 2",
         "local-authority-eng":"SCR",
         "name":"Sheffield City Region",
         "start-date":"2014-04-01"}
@@ -33,7 +33,7 @@
         "item":[
       {
         "local-authority-type":"NMD",
-        "official-name":"Org 7",
+        "official-name":"Local Auth 3",
         "local-authority-eng":"EHE",
         "name":"East Hertfordshire"}
       ]
@@ -46,7 +46,7 @@
       "item":[
         {
           "local-authority-type":"NMD",
-          "official-name":"Org 8",
+          "official-name":"Local Auth 4",
           "local-authority-eng":"EHE",
           "name":"East Hertfordshire"}
         ]

--- a/spec/gateways/govuk_organisations_register_gateway_spec.rb
+++ b/spec/gateways/govuk_organisations_register_gateway_spec.rb
@@ -22,4 +22,22 @@ describe Gateways::GovukOrganisationsRegisterGateway do
       ]
     )
   end
+
+context 'with custom oranisations' do
+
+  before do
+    CustomOrganisationName.create(name:'Org1')
+    CustomOrganisationName.create(name:'Org2')
+  end
+
+  it 'fetches the custom orgs' do
+    result = subject.custom_orgs
+    expect(result).to eq(
+      [
+       'Org1',
+       'Org2'
+      ]
+    )
+    end
+  end
 end

--- a/spec/gateways/govuk_organisations_register_gateway_spec.rb
+++ b/spec/gateways/govuk_organisations_register_gateway_spec.rb
@@ -3,10 +3,10 @@ describe Gateways::GovukOrganisationsRegisterGateway do
     result = subject.government_orgs
     expect(result).to eq(
       [
-        'Org 1',
-        'Org 2',
-        'Org 3',
-        'Org 4'
+        'Gov Org 1',
+        'Gov Org 2',
+        'Gov Org 3',
+        'Gov Org 4'
       ]
     )
   end
@@ -15,29 +15,28 @@ describe Gateways::GovukOrganisationsRegisterGateway do
     result = subject.local_authorities
     expect(result).to eq(
       [
-        'Org 5',
-        'Org 6',
-        'Org 7',
-        'Org 8'
+        'Local Auth 1',
+        'Local Auth 2',
+        'Local Auth 3',
+        'Local Auth 4'
       ]
     )
   end
 
-context 'with custom oranisations' do
+  context 'with custom organisations' do
+    before do
+      CustomOrganisationName.create(name: 'Custom Org 1')
+      CustomOrganisationName.create(name: 'Custom Org 2')
+    end
 
-  before do
-    CustomOrganisationName.create(name:'Org1')
-    CustomOrganisationName.create(name:'Org2')
-  end
-
-  it 'fetches the custom orgs' do
-    result = subject.custom_orgs
-    expect(result).to eq(
-      [
-       'Org1',
-       'Org2'
-      ]
-    )
+    it 'fetches the custom orgs' do
+      result = subject.custom_orgs
+      expect(result).to eq(
+        [
+        'Custom Org 1',
+        'Custom Org 2'
+        ]
+      )
     end
   end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -18,10 +18,10 @@ describe Organisation do
     end
 
     context 'When an organisation signs up under the same name as another organisation' do
-      before { create(:organisation, name: 'Org 1') }
+      before { create(:organisation, name: 'Gov Org 1') }
 
       it 'is not valid' do
-        organisation = build(:organisation, name: 'Org 1')
+        organisation = build(:organisation, name: 'Gov Org 1')
         expect(organisation).to_not be_valid
       end
     end
@@ -36,7 +36,7 @@ describe Organisation do
 
     context 'Given my organisation is in the GovUk register' do
       it 'is valid' do
-        organisation = build(:organisation, name: 'Org 1')
+        organisation = build(:organisation, name: 'Gov Org 1')
         expect(organisation).to be_valid
       end
     end

--- a/spec/use_cases/organisation/fetch_organisations_register_spec.rb
+++ b/spec/use_cases/organisation/fetch_organisations_register_spec.rb
@@ -1,5 +1,5 @@
 describe UseCases::Organisation::FetchOrganisationRegister do
-  let(:gateway_spy) { spy(government_orgs: [], local_authorities: []) }
+  let(:gateway_spy) { spy(government_orgs: [], local_authorities: [], custom_orgs: []) }
 
   it 'calls government_orgs on the gateway' do
     described_class.new(organisations_gateway: gateway_spy).execute
@@ -9,5 +9,19 @@ describe UseCases::Organisation::FetchOrganisationRegister do
   it 'calls local_authorities on the gateway' do
     described_class.new(organisations_gateway: gateway_spy).execute
     expect(gateway_spy).to have_received(:local_authorities)
+  end
+
+  it 'calls custom_orgs on the gateway' do
+    described_class.new(organisations_gateway: gateway_spy).execute
+    expect(gateway_spy).to have_received(:custom_orgs)
+  end
+
+  context 'get the custom orgs' do
+    let(:custom_orgs_list_gateway) { double(government_orgs: [], local_authorities: [], custom_orgs: ['Custom Org 1', 'Custom Org 2', 'Custom Org 3']) }
+
+    it 'returns the custom orgs' do
+      response = described_class.new(organisations_gateway: custom_orgs_list_gateway).execute
+      expect(response).to eq(['Custom Org 1', 'Custom Org 2', 'Custom Org 3'])
+    end
   end
 end

--- a/spec/use_cases/organisation/fetch_organisations_register_spec.rb
+++ b/spec/use_cases/organisation/fetch_organisations_register_spec.rb
@@ -18,16 +18,16 @@ describe UseCases::Organisation::FetchOrganisationRegister do
     end
   end
 
-  context 'get the custom orgs' do
+  context 'with custom organisations' do
     let(:custom_orgs_list_gateway) { double(government_orgs: [], local_authorities: [], custom_orgs: ['Custom Org 1', 'Custom Org 2', 'Custom Org 3']) }
 
-    it 'returns the custom orgs' do
+    it 'returns the custom organisations' do
       response = described_class.new(organisations_gateway: custom_orgs_list_gateway).execute
       expect(response).to eq(['Custom Org 1', 'Custom Org 2', 'Custom Org 3'])
     end
   end
 
-  context 'with gov, local and custom orgs' do
+  context 'with government, local and custom organisations' do
     before do
       CustomOrganisationName.create(name: 'Custom Org 1')
       CustomOrganisationName.create(name: 'Custom Org 2')

--- a/spec/use_cases/organisation/fetch_organisations_register_spec.rb
+++ b/spec/use_cases/organisation/fetch_organisations_register_spec.rb
@@ -1,19 +1,21 @@
 describe UseCases::Organisation::FetchOrganisationRegister do
   let(:gateway_spy) { spy(government_orgs: [], local_authorities: [], custom_orgs: []) }
 
-  it 'calls government_orgs on the gateway' do
-    described_class.new(organisations_gateway: gateway_spy).execute
-    expect(gateway_spy).to have_received(:government_orgs)
-  end
+  context 'On the gateway' do
+    it 'calls government_orgs ' do
+      described_class.new(organisations_gateway: gateway_spy).execute
+      expect(gateway_spy).to have_received(:government_orgs)
+    end
 
-  it 'calls local_authorities on the gateway' do
-    described_class.new(organisations_gateway: gateway_spy).execute
-    expect(gateway_spy).to have_received(:local_authorities)
-  end
+    it 'calls local_authorities' do
+      described_class.new(organisations_gateway: gateway_spy).execute
+      expect(gateway_spy).to have_received(:local_authorities)
+    end
 
-  it 'calls custom_orgs on the gateway' do
-    described_class.new(organisations_gateway: gateway_spy).execute
-    expect(gateway_spy).to have_received(:custom_orgs)
+    it 'calls custom_orgs' do
+      described_class.new(organisations_gateway: gateway_spy).execute
+      expect(gateway_spy).to have_received(:custom_orgs)
+    end
   end
 
   context 'get the custom orgs' do
@@ -25,17 +27,19 @@ describe UseCases::Organisation::FetchOrganisationRegister do
     end
   end
 
-  context 'appends the custom orgs to the govuk registers' do
-    let(:custom_orgs_list_gateway) { double(government_orgs: ['Custom Org 1', 'Custom Org 2', 'Custom Org 3'],
-      local_authorities: ['Custom Org 4', 'Custom Org 5', 'Custom Org 6'],
-      custom_orgs: ['Custom Org 7', 'Custom Org 8', 'Custom Org 9']) }
+  context 'with gov, local and custom orgs' do
+    before do
+      CustomOrganisationName.create(name: 'Custom Org 1')
+      CustomOrganisationName.create(name: 'Custom Org 2')
+    end
 
-    it 'returns the combined list of orgs' do
-      response = described_class.new(organisations_gateway: custom_orgs_list_gateway).execute
+    it 'returns the combined register of all orgs' do
+      response = described_class.new(organisations_gateway: Gateways::GovukOrganisationsRegisterGateway.new).execute
       expect(response).to eq([
-        'Custom Org 1', 'Custom Org 2', 'Custom Org 3',
-        'Custom Org 4', 'Custom Org 5', 'Custom Org 6',
-        'Custom Org 7', 'Custom Org 8', 'Custom Org 9', ])
+        "Gov Org 1", "Gov Org 2", "Gov Org 3", "Gov Org 4",
+        "Local Auth 1", "Local Auth 2", "Local Auth 3", "Local Auth 4",
+        'Custom Org 1', 'Custom Org 2'
+      ])
     end
   end
 end

--- a/spec/use_cases/organisation/fetch_organisations_register_spec.rb
+++ b/spec/use_cases/organisation/fetch_organisations_register_spec.rb
@@ -24,4 +24,18 @@ describe UseCases::Organisation::FetchOrganisationRegister do
       expect(response).to eq(['Custom Org 1', 'Custom Org 2', 'Custom Org 3'])
     end
   end
+
+  context 'appends the custom orgs to the govuk registers' do
+    let(:custom_orgs_list_gateway) { double(government_orgs: ['Custom Org 1', 'Custom Org 2', 'Custom Org 3'],
+      local_authorities: ['Custom Org 4', 'Custom Org 5', 'Custom Org 6'],
+      custom_orgs: ['Custom Org 7', 'Custom Org 8', 'Custom Org 9']) }
+
+    it 'returns the combined list of orgs' do
+      response = described_class.new(organisations_gateway: custom_orgs_list_gateway).execute
+      expect(response).to eq([
+        'Custom Org 1', 'Custom Org 2', 'Custom Org 3',
+        'Custom Org 4', 'Custom Org 5', 'Custom Org 6',
+        'Custom Org 7', 'Custom Org 8', 'Custom Org 9', ])
+    end
+  end
 end


### PR DESCRIPTION
Allows custom organisations to be added, as before you could only choose organisations from the register provided. However now we have the ability to append other organisations to these registers to allow us to add other organisations that may not be on the official register yet.