### PR TITLE
UI for adding custom orgs

### DIFF
--- a/app/controllers/admin/custom_organisations_controller.rb
+++ b/app/controllers/admin/custom_organisations_controller.rb
@@ -1,15 +1,26 @@
 class Admin::CustomOrganisationsController < AdminController
-
-  def index; end
+  def index
+    all_custom_organisation_names
+  end
 
   def create
-    CustomOrganisationName.create(custom_org_params)
+    all_custom_organisation_names
+    created_org = CustomOrganisationName.create(custom_org_params)
 
-    flash[:notice] = 'Successfully added a custom organisation'
-    redirect_to root_path
+    if created_org.valid?
+      flash[:notice] = 'Successfully added a custom organisation'
+      redirect_to root_path
+    else
+      flash[:alert] = "Organisation name can't be blank"
+      render :index
+    end
   end
 
 private
+
+  def all_custom_organisation_names
+    @all_orgs = CustomOrganisationName.all
+  end
 
   def custom_org_params
     params.require(:custom_organisations).permit(:name)

--- a/app/controllers/admin/custom_organisations_controller.rb
+++ b/app/controllers/admin/custom_organisations_controller.rb
@@ -1,14 +1,17 @@
 class Admin::CustomOrganisationsController < AdminController
 
-  def index
-    @number_of_custom_orgs = CustomOrganisationName.count
-  end
+  def index; end
 
   def create
-    # Add whatever is in that text field into the database
-    add_custom_organiastion = CustomOrganisationName.create(params[:name])
+    CustomOrganisationName.create(custom_org_params)
 
     flash[:notice] = 'Successfully added a custom organisation'
     redirect_to root_path
+  end
+
+private
+
+  def custom_org_params
+    params.require(:custom_organisations).permit(:name)
   end
 end

--- a/app/controllers/admin/custom_organisations_controller.rb
+++ b/app/controllers/admin/custom_organisations_controller.rb
@@ -1,26 +1,20 @@
 class Admin::CustomOrganisationsController < AdminController
   def index
-    all_custom_organisation_names
+    @all_orgs = CustomOrganisationName.all
+    @custom_organisation = CustomOrganisationName.new
   end
 
   def create
-    all_custom_organisation_names
-    created_org = CustomOrganisationName.create(custom_org_params)
+    @all_orgs = CustomOrganisationName.all
+    @custom_organisation = CustomOrganisationName.new(custom_org_params)
 
-    if created_org.valid?
-      flash[:notice] = 'Successfully added a custom organisation'
-      redirect_to root_path
-    else
-      flash[:alert] = "Organisation name can't be blank"
-      render :index
+    if @custom_organisation.save
+      flash[:notice] = "Custom organisation has been successfully added"
     end
+    render :index
   end
 
 private
-
-  def all_custom_organisation_names
-    @all_orgs = CustomOrganisationName.all
-  end
 
   def custom_org_params
     params.require(:custom_organisations).permit(:name)

--- a/app/controllers/admin/custom_organisations_controller.rb
+++ b/app/controllers/admin/custom_organisations_controller.rb
@@ -1,0 +1,14 @@
+class Admin::CustomOrganisationsController < AdminController
+
+  def index
+    @number_of_custom_orgs = CustomOrganisationName.count
+  end
+
+  def create
+    # Add whatever is in that text field into the database
+    add_custom_organiastion = CustomOrganisationName.create(params[:name])
+
+    flash[:notice] = 'Successfully added a custom organisation'
+    redirect_to root_path
+  end
+end

--- a/app/controllers/admin/custom_organisations_controller.rb
+++ b/app/controllers/admin/custom_organisations_controller.rb
@@ -1,11 +1,11 @@
 class Admin::CustomOrganisationsController < AdminController
   def index
-    @all_orgs = CustomOrganisationName.all
+    @custom_organisation_names = CustomOrganisationName.all
     @custom_organisation = CustomOrganisationName.new
   end
 
   def create
-    @all_orgs = CustomOrganisationName.all
+    @custom_organisation_names = CustomOrganisationName.all
     @custom_organisation = CustomOrganisationName.new(custom_org_params)
 
     if @custom_organisation.save

--- a/app/models/custom_organisation_name.rb
+++ b/app/models/custom_organisation_name.rb
@@ -1,2 +1,3 @@
 class CustomOrganisationName < ApplicationRecord
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
 end

--- a/app/views/admin/custom_organisations/index.html.erb
+++ b/app/views/admin/custom_organisations/index.html.erb
@@ -1,15 +1,17 @@
+<%= render "layouts/form_errors", resource: @custom_organisation %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Add Organistions to the Register</h2>
+    <h2 class="govuk-heading-l">Allow an organisation access to the admin platform</h2>
 
     <%= form_for(:custom_organisations, url: admin_custom_organisations_path, html: { novalidate: '' }) do |f| %>
-      <div class="govuk-form-group" >
-        <%= f.label :name, "Enter the custom organisation you want to add", class: "govuk-label"  %>
+      <div class='govuk-form-group'>
+        <%= f.label :name, "Enter the organisation's full name", class: "govuk-label"  %>
         <%= f.text_field :name, autofocus: true, class: "govuk-input" %>
       </div>
 
       <div class="actions">
-        <%= f.submit "Confirm", class: "govuk-button" %>
+        <%= f.submit "Allow organisation", class: "govuk-button" %>
       </div>
       <% end %>
 

--- a/app/views/admin/custom_organisations/index.html.erb
+++ b/app/views/admin/custom_organisations/index.html.erb
@@ -5,7 +5,7 @@
     <h2 class="govuk-heading-l">Allow an organisation access to the admin platform</h2>
 
     <%= form_for(:custom_organisations, url: admin_custom_organisations_path, html: { novalidate: '' }) do |f| %>
-      <div class='govuk-form-group'>
+      <div class="govuk-form-group <%= field_error(@custom_organisation, :name) %>">
         <%= f.label :name, "Enter the organisation's full name", class: "govuk-label"  %>
         <%= f.text_field :name, autofocus: true, class: "govuk-input" %>
       </div>
@@ -20,7 +20,7 @@
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">Name</th>
-          <th class="govuk-table__header" scope="col">Date Created</th>
+          <th class="govuk-table__header" scope="col">Allowed on</th>
         </tr>
       </thead>
       <tbody class="govuk-table__body">

--- a/app/views/admin/custom_organisations/index.html.erb
+++ b/app/views/admin/custom_organisations/index.html.erb
@@ -28,7 +28,7 @@
         <tbody class="govuk-table__body">
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><%= organisation.name %></td>
-          <td class="govuk-table__cell"><%= organisation.created_at.strftime('%e %b %Y') %></td>
+            <td class="govuk-table__cell"><%= organisation.created_at.strftime('%e %b %Y') %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/admin/custom_organisations/index.html.erb
+++ b/app/views/admin/custom_organisations/index.html.erb
@@ -3,7 +3,7 @@
     <h2 class="govuk-heading-l">Add Organistions to the Register</h2>
 
     <%= form_for(:custom_organisations, url: admin_custom_organisations_path, html: { novalidate: '' }) do |f| %>
-      <div class="govuk-form-group">
+      <div class="govuk-form-group" >
         <%= f.label :name, "Enter the custom organisation you want to add", class: "govuk-label"  %>
         <%= f.text_field :name, autofocus: true, class: "govuk-input" %>
       </div>
@@ -13,5 +13,23 @@
       </div>
       <% end %>
 
+    <table class="govuk-table">
+    <h2 class="govuk-heading-m">Custom Organistions</h2>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Name</th>
+          <th class="govuk-table__header" scope="col">Date Created</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @all_orgs.each do |organisation| %>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= organisation.name %></td>
+          <td class="govuk-table__cell"><%= organisation.created_at.strftime('%e %b %Y') %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
   </div>
 </div>

--- a/app/views/admin/custom_organisations/index.html.erb
+++ b/app/views/admin/custom_organisations/index.html.erb
@@ -1,0 +1,18 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l">Add Organistions to the Register</h2>
+
+    <%= form_for(:custom_organisations, url: admin_custom_organisations_path, html: { novalidate: '' }) do |f| %>
+      <div class="govuk-form-group">
+        <%= f.label :name, "Enter the custom organisation you want to add", class: "govuk-label"  %>
+        <%= f.text_field :name, autofocus: true, class: "govuk-input" %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit "Confirm", class: "govuk-button" %>
+      </div>
+      <% end %>
+
+      <h2 class="govuk-heading-m"> Number of custom organistions: <%= @number_of_custom_orgs %> </h2>
+  </div>
+</div>

--- a/app/views/admin/custom_organisations/index.html.erb
+++ b/app/views/admin/custom_organisations/index.html.erb
@@ -24,7 +24,7 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        <% @all_orgs.each do |organisation| %>
+        <% @custom_organisation_names.each do |organisation| %>
         <tbody class="govuk-table__body">
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><%= organisation.name %></td>

--- a/app/views/admin/custom_organisations/index.html.erb
+++ b/app/views/admin/custom_organisations/index.html.erb
@@ -13,6 +13,5 @@
       </div>
       <% end %>
 
-      <h2 class="govuk-heading-m"> Number of custom organistions: <%= @number_of_custom_orgs %> </h2>
   </div>
 </div>

--- a/app/views/application/_subnavigation.html.erb
+++ b/app/views/application/_subnavigation.html.erb
@@ -11,7 +11,7 @@
     <nav class='govuk-body govuk-!-margin-bottom-0 '>
       <% if current_user.super_admin? %>
         <%= link_to 'Organisations', admin_organisations_path, class: active_tab(admin_organisations_path) %>
-        <%= link_to 'Custom Organisations', admin_custom_organisations_path, class: active_tab(admin_custom_organisations_path) %>
+        <%= link_to 'Allow Organisations', admin_custom_organisations_path, class: active_tab(admin_custom_organisations_path) %>
         <%= link_to 'MOU', admin_mou_index_path, class: active_tab(admin_mou_index_path) %>
       <% else %>
         <% if current_organisation.ips.present? %>

--- a/app/views/application/_subnavigation.html.erb
+++ b/app/views/application/_subnavigation.html.erb
@@ -11,6 +11,7 @@
     <nav class='govuk-body govuk-!-margin-bottom-0 '>
       <% if current_user.super_admin? %>
         <%= link_to 'Organisations', admin_organisations_path, class: active_tab(admin_organisations_path) %>
+        <%= link_to 'Custom Organisations', admin_custom_organisations_path, class: active_tab(admin_custom_organisations_path) %>
         <%= link_to 'MOU', admin_mou_index_path, class: active_tab(admin_mou_index_path) %>
       <% else %>
         <% if current_organisation.ips.present? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :mou, only: %i[index update create]
     resources :organisations, only: %i[index show destroy]
+    resources :custom_organisations, only: %i[index create]
   end
 
   %w( 404 422 500 ).each do |code|

--- a/lib/use_cases/administrator/send_confirmation_email.rb
+++ b/lib/use_cases/administrator/send_confirmation_email.rb
@@ -15,7 +15,6 @@ module UseCases
           reference: REFERENCE,
           email_reply_to_id: nil
         }
-        pp confirmation_url
         notifications_gateway.send(opts)
       end
 

--- a/lib/use_cases/administrator/send_confirmation_email.rb
+++ b/lib/use_cases/administrator/send_confirmation_email.rb
@@ -15,6 +15,7 @@ module UseCases
           reference: REFERENCE,
           email_reply_to_id: nil
         }
+        pp confirmation_url
         notifications_gateway.send(opts)
       end
 

--- a/spec/features/admin/add_custom_organisation_spec.rb
+++ b/spec/features/admin/add_custom_organisation_spec.rb
@@ -14,7 +14,18 @@ describe 'adding a custom organisation name', focus: true do
     it 'will redirect you to organiastions page once a custom org is added' do
       fill_in 'custom_organisations[name]', with: 'Custom Org name'
       click_on 'Confirm'
-      expect(page.body).to have_content('Successfully added a custom organisation')
+      expect(page).to have_content('Successfully added a custom organisation')
+    end
+
+    context 'signout and find custom org' do
+      it 'will redirect you to organiastions page once a custom org is added' do
+        fill_in 'custom_organisations[name]', with: 'Custom Org name'
+        click_on 'Confirm'
+        sign_out
+        visit confirmation_email_link
+        select 'Custom Org name', from: 'Organisation name'
+        expect(page).to have_content('Custom Org name')
+      end
     end
   end
 end

--- a/spec/features/admin/add_custom_organisation_spec.rb
+++ b/spec/features/admin/add_custom_organisation_spec.rb
@@ -16,19 +16,20 @@ describe 'adding a custom organisation name' do
     end
 
     it 'will redirect you to organiastions page once a custom org is added' do
-      fill_in 'custom_organisations[name]', with: 'Custom Org name'
+      fill_in "Enter the organisation's full name", with: 'Custom Org name'
       click_on 'Allow organisation'
       expect(page).to have_content('Custom organisation has been successfully added')
     end
 
     context 'sign out and find custom organisation' do
       before do
-        fill_in 'custom_organisations[name]', with: 'Custom Org name'
+        fill_in "Enter the organisation's full name", with: 'Custom Org name'
         click_on 'Allow organisation'
         sign_out
         sign_up_for_account(email: 'default@gov.uk')
         visit confirmation_email_link
       end
+
       it 'the custom organisation will appear when creating an account' do
         select 'Custom Org name', from: 'Organisation name'
         fill_in 'Service email', with: 'bob@gov.uk'
@@ -46,6 +47,7 @@ describe 'adding a custom organisation name' do
         expect(page).to have_content("Name can't be blank")
       end
     end
+
     context 'after addding a custom organisation' do
       let!(:org1) { CustomOrganisationName.create(name: 'Custom Org 1') }
       let!(:org2) { CustomOrganisationName.create(name: 'Custom Org 2') }

--- a/spec/features/admin/add_custom_organisation_spec.rb
+++ b/spec/features/admin/add_custom_organisation_spec.rb
@@ -1,6 +1,6 @@
 require 'support/confirmation_use_case'
 
-describe 'adding a custom organisation name', focus: true do
+describe 'adding a custom organisation name' do
   include_examples 'confirmation use case spy'
 
   let!(:admin_user) { create(:user, super_admin: true) }
@@ -21,13 +21,15 @@ describe 'adding a custom organisation name', focus: true do
       expect(page).to have_content('Successfully added a custom organisation')
     end
 
-    context 'signout and find custom org' do
-      it 'will redirect you to organiastions page once a custom org is added' do
+    context 'signout and find custom organisation' do
+      before do
         fill_in 'custom_organisations[name]', with: 'Custom Org name'
         click_on 'Confirm'
         sign_out
         sign_up_for_account(email: 'default@gov.uk')
         visit confirmation_email_link
+      end
+      it 'the custom organisation will appear when creating an account' do
         select 'Custom Org name', from: 'Organisation name'
         fill_in 'Service email', with: 'bob@gov.uk'
         fill_in 'Your name', with: 'bob'

--- a/spec/features/admin/add_custom_organisation_spec.rb
+++ b/spec/features/admin/add_custom_organisation_spec.rb
@@ -12,19 +12,19 @@ describe 'adding a custom organisation name' do
     end
 
     it 'will show the add custom organisations page' do
-      expect(page.body).to have_content('Add Organistions to the Register')
+      expect(page.body).to have_content('Allow an organisation access to the admin platform')
     end
 
     it 'will redirect you to organiastions page once a custom org is added' do
       fill_in 'custom_organisations[name]', with: 'Custom Org name'
-      click_on 'Confirm'
-      expect(page).to have_content('Successfully added a custom organisation')
+      click_on 'Allow organisation'
+      expect(page).to have_content('Custom organisation has been successfully added')
     end
 
     context 'sign out and find custom organisation' do
       before do
         fill_in 'custom_organisations[name]', with: 'Custom Org name'
-        click_on 'Confirm'
+        click_on 'Allow organisation'
         sign_out
         sign_up_for_account(email: 'default@gov.uk')
         visit confirmation_email_link
@@ -42,8 +42,8 @@ describe 'adding a custom organisation name' do
     context 'if the organisation name is blank' do
       it 'will error with the reason' do
         fill_in 'custom_organisations[name]', with: ' '
-        click_on 'Confirm'
-        expect(page).to have_content("Organisation name can't be blank")
+        click_on 'Allow organisation'
+        expect(page).to have_content("Name can't be blank")
       end
     end
     context 'after addding a custom organisation' do

--- a/spec/features/admin/add_custom_organisation_spec.rb
+++ b/spec/features/admin/add_custom_organisation_spec.rb
@@ -21,7 +21,7 @@ describe 'adding a custom organisation name' do
       expect(page).to have_content('Successfully added a custom organisation')
     end
 
-    context 'signout and find custom organisation' do
+    context 'sign out and find custom organisation' do
       before do
         fill_in 'custom_organisations[name]', with: 'Custom Org name'
         click_on 'Confirm'
@@ -36,6 +36,27 @@ describe 'adding a custom organisation name' do
         fill_in 'Password', with: 'bobpassword'
         click_on 'Create my account'
         expect(page).to have_content('Custom Org name')
+      end
+    end
+
+    context 'if the organisation name is blank' do
+      it 'will error with the reason' do
+        fill_in 'custom_organisations[name]', with: ' '
+        click_on 'Confirm'
+        expect(page).to have_content("Organisation name can't be blank")
+      end
+    end
+    context 'after addding a custom organisation' do
+      let!(:org1) { CustomOrganisationName.create(name: 'Custom Org 1') }
+      let!(:org2) { CustomOrganisationName.create(name: 'Custom Org 2') }
+      before do
+        sign_in_user admin_user
+        visit admin_custom_organisations_path
+      end
+
+      it 'lists all of the custom organisation names' do
+        expect(page).to have_content('Custom Org 1')
+        expect(page).to have_content('Custom Org 2')
       end
     end
   end

--- a/spec/features/admin/add_custom_organisation_spec.rb
+++ b/spec/features/admin/add_custom_organisation_spec.rb
@@ -1,0 +1,20 @@
+describe 'adding a custom organisation name', focus: true do
+  let!(:admin_user) { create(:user, super_admin: true) }
+
+  context 'when visiting the custom organisations page' do
+    before do
+      sign_in_user admin_user
+      visit admin_custom_organisations_path
+    end
+
+    it 'will show the add custom organisations page' do
+      expect(page.body).to have_content('Add Organistions to the Register')
+    end
+
+    it 'will redirect you to organiastions page once a custom org is added' do
+      fill_in 'custom_organisations[name]', with: 'Custom Org name'
+      click_on 'Confirm'
+      expect(page.body).to have_content('Successfully added a custom organisation')
+    end
+  end
+end

--- a/spec/features/admin/add_custom_organisation_spec.rb
+++ b/spec/features/admin/add_custom_organisation_spec.rb
@@ -23,24 +23,6 @@ describe 'adding a custom organisation name' do
       end
     end
 
-    context 'sign out and find custom organisations' do
-      before do
-        sign_out
-        CustomOrganisationName.create(name: 'Custom Org name')
-        sign_up_for_account(email: 'default@gov.uk')
-        visit confirmation_email_link
-      end
-
-      it 'displays the custom organisation name in the list` would be better for instance' do
-        select 'Custom Org name', from: 'Organisation name'
-        fill_in 'Service email', with: 'bob@gov.uk'
-        fill_in 'Your name', with: 'bob'
-        fill_in 'Password', with: 'bobpassword'
-        click_on 'Create my account'
-        expect(page).to have_content('Custom Org name')
-      end
-    end
-
     context 'when the organisation name is blank' do
       it 'will error with the reason' do
         fill_in 'custom_organisations[name]', with: ' '
@@ -48,19 +30,37 @@ describe 'adding a custom organisation name' do
         expect(page).to have_content("Name can't be blank")
       end
     end
+  end
 
-    context 'after addding a custom organisation' do
-      let!(:org1) { CustomOrganisationName.create(name: 'Custom Org 1') }
-      let!(:org2) { CustomOrganisationName.create(name: 'Custom Org 2') }
-      before do
-        sign_in_user admin_user
-        visit admin_custom_organisations_path
-      end
+  context 'sign out and find custom organisations' do
+    before do
+      CustomOrganisationName.create(name: 'Custom Org name')
+      sign_up_for_account(email: 'default@gov.uk')
+      visit confirmation_email_link
+    end
 
-      it 'lists all of the custom organisation names' do
-        expect(page).to have_content('Custom Org 1')
-        expect(page).to have_content('Custom Org 2')
-      end
+    it 'displays the custom organisation name in the list' do
+      CustomOrganisationName.create(name: 'Custom Org name')
+      select 'Custom Org name', from: 'Organisation name'
+      fill_in 'Service email', with: 'bob@gov.uk'
+      fill_in 'Your name', with: 'bob'
+      fill_in 'Password', with: 'bobpassword'
+      click_on 'Create my account'
+      expect(page).to have_content('Custom Org name')
+    end
+  end
+
+  context 'after addding a custom organisation' do
+    let!(:org1) { CustomOrganisationName.create(name: 'Custom Org 1') }
+    let!(:org2) { CustomOrganisationName.create(name: 'Custom Org 2') }
+    before do
+      sign_in_user admin_user
+      visit admin_custom_organisations_path
+    end
+
+    it 'lists all of the custom organisation names' do
+      expect(page).to have_content('Custom Org 1')
+      expect(page).to have_content('Custom Org 2')
     end
   end
 end

--- a/spec/features/admin/add_custom_organisation_spec.rb
+++ b/spec/features/admin/add_custom_organisation_spec.rb
@@ -1,4 +1,8 @@
+require 'support/confirmation_use_case'
+
 describe 'adding a custom organisation name', focus: true do
+  include_examples 'confirmation use case spy'
+
   let!(:admin_user) { create(:user, super_admin: true) }
 
   context 'when visiting the custom organisations page' do
@@ -22,8 +26,13 @@ describe 'adding a custom organisation name', focus: true do
         fill_in 'custom_organisations[name]', with: 'Custom Org name'
         click_on 'Confirm'
         sign_out
+        sign_up_for_account(email: 'default@gov.uk')
         visit confirmation_email_link
         select 'Custom Org name', from: 'Organisation name'
+        fill_in 'Service email', with: 'bob@gov.uk'
+        fill_in 'Your name', with: 'bob'
+        fill_in 'Password', with: 'bobpassword'
+        click_on 'Create my account'
         expect(page).to have_content('Custom Org name')
       end
     end

--- a/spec/features/admin/add_custom_organisation_spec.rb
+++ b/spec/features/admin/add_custom_organisation_spec.rb
@@ -17,10 +17,9 @@ describe 'adding a custom organisation name' do
 
     it 'will redirect you to organisations page once a custom org is added' do
       fill_in "Enter the organisation's full name", with: 'Custom Org name'
-      expect do
+      expect {
         click_on 'Allow organisation'
-        .to change { CustomOrganisationName.count }.by(1)
-      end
+      }.to change { CustomOrganisationName.count }.by(1)
     end
 
     context 'when the organisation name is blank' do

--- a/spec/features/admin/add_custom_organisation_spec.rb
+++ b/spec/features/admin/add_custom_organisation_spec.rb
@@ -25,8 +25,8 @@ describe 'adding a custom organisation name' do
 
     context 'sign out and find custom organisations' do
       before do
-        CustomOrganisationName.create(name: 'Custom Org name')
         sign_out
+        CustomOrganisationName.create(name: 'Custom Org name')
         sign_up_for_account(email: 'default@gov.uk')
         visit confirmation_email_link
       end

--- a/spec/features/admin/add_custom_organisation_spec.rb
+++ b/spec/features/admin/add_custom_organisation_spec.rb
@@ -15,22 +15,23 @@ describe 'adding a custom organisation name' do
       expect(page.body).to have_content('Allow an organisation access to the admin platform')
     end
 
-    it 'will redirect you to organiastions page once a custom org is added' do
+    it 'will redirect you to organisations page once a custom org is added' do
       fill_in "Enter the organisation's full name", with: 'Custom Org name'
-      click_on 'Allow organisation'
-      expect(page).to have_content('Custom organisation has been successfully added')
+      expect do
+        click_on 'Allow organisation'
+        .to change { CustomOrganisationName.count }.by(1)
+      end
     end
 
-    context 'sign out and find custom organisation' do
+    context 'sign out and find custom organisations' do
       before do
-        fill_in "Enter the organisation's full name", with: 'Custom Org name'
-        click_on 'Allow organisation'
+        CustomOrganisationName.create(name: 'Custom Org name')
         sign_out
         sign_up_for_account(email: 'default@gov.uk')
         visit confirmation_email_link
       end
 
-      it 'the custom organisation will appear when creating an account' do
+      it 'displays the custom organisation name in the list` would be better for instance' do
         select 'Custom Org name', from: 'Organisation name'
         fill_in 'Service email', with: 'bob@gov.uk'
         fill_in 'Your name', with: 'bob'
@@ -40,7 +41,7 @@ describe 'adding a custom organisation name' do
       end
     end
 
-    context 'if the organisation name is blank' do
+    context 'when the organisation name is blank' do
       it 'will error with the reason' do
         fill_in 'custom_organisations[name]', with: ' '
         click_on 'Allow organisation'


### PR DESCRIPTION
**This PR provides the user with a UI to add custom organisations to the combined registers list, so that the organisation added can then sign up to GovWifi through the normal signup journey.**

![screenshot 2019-02-08 at 10 00 03](https://user-images.githubusercontent.com/40758489/52471239-5437cb00-2b88-11e9-846e-47ddde1fab14.png)
