### PR TITLE
Fix documentation link in the footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -136,9 +136,7 @@
                 <% end %>
               </li>
               <li class="govuk-footer__list-item">
-                <a class="govuk-footer__link" href="#2">
-                  Documentation
-                </a>
+                <%= link_to 'Documentation', SITE_CONFIG['organisation_docs_link'], class: "govuk-footer__link" %>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
**WHY:**
Documentation link in the footer didn't go anywhere when clicked. It had no URL assigned to it.

**IN THIS PR:**
Assigned the [tech docs](https://docs.wifi.service.gov.uk/#requirements) URL to it.