### PR TITLE
Add feedback link into footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -138,6 +138,9 @@
               <li class="govuk-footer__list-item">
                 <%= link_to 'Documentation', SITE_CONFIG['organisation_docs_link'], class: "govuk-footer__link" %>
               </li>
+              <li class="govuk-footer__list-item">
+                <%= link_to 'Feedback', feedback_new_help_path, class: "govuk-footer__link" %>
+              </li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
**WHY:**
Design suggestion to move the feedback link to the footer.

**IN THIS PR:**
Add feedback as list-item in the footer and make it link to the feedback form at `/help/new/feedback`.

**BEFORE:**
![screenshot 2019-02-11 at 14 46 25](https://user-images.githubusercontent.com/32823756/52570821-39758880-2e0c-11e9-8e24-083876d3fcc5.png)

**AFTER:**
![screenshot 2019-02-11 at 14 46 17](https://user-images.githubusercontent.com/32823756/52570850-41352d00-2e0c-11e9-8db1-a9677ac2ed7a.png)

**_Suggestions and/or feedback welcome._**