### PR TITLE
Remove Tag manager Implementation

### DIFF
--- a/app/assets/javascripts/googletagmanager.js
+++ b/app/assets/javascripts/googletagmanager.js
@@ -1,7 +1,0 @@
-var containerID = 'GTM-TNHHHPZ';
-
-(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer', containerID);

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,8 +11,6 @@
       gtag('js', new Date());
     </script>
 
-    <%= javascript_include_tag "googletagmanager.js" %>
-
     <title>Govwifi Admin</title>
 
     <meta charset="utf-8" />
@@ -43,13 +41,6 @@
   </head>
 
   <body class="govuk-template__body app-body-class">
-    <!-- Google Tag Manager (noscript) -->
-      <noscript>
-        <iframe src="https://www.googletagmanager.com/ns.html?id=<%= SITE_CONFIG['google_tag_container_ID'] %>"
-        height="0" width="0" style="display:none;visibility:hidden">
-        </iframe>
-      </noscript>
-    <!-- End Google Tag Manager (noscript) -->
 
     <script>
         document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -7,7 +7,6 @@ Rails.application.config.assets.precompile += %w(
   govuk-logotype-crown.png
   application_ie8.css
   html5shiv.js
-  googletagmanager.js
   accessible-autocomplete.min.js
   accessible-autocomplete.min.css
   tick.svg

--- a/config/site.yml
+++ b/config/site.yml
@@ -3,7 +3,6 @@ default: &default
   end_user_troubleshooting_link: 'https://www.gov.uk/guidance/solve-problems-with-connecting-to-govwifi'
   organisation_docs_link: 'https://docs.wifi.service.gov.uk'
   product_page_link: 'https://wifi.service.gov.uk'
-  google_tag_container_ID: 'GTM-TNHHHPZ'
   organisation_register_url: 'https://government-organisation.register.gov.uk/records.json?page-size=5000'
   local_auth_register_url: 'https://local-authority-eng.register.gov.uk/records.json?page-size=5000'
 


### PR DESCRIPTION
**WHAT:** 
This removes the current installation of Google Tag Manager in the admin portal. 

**WHY:**
This was done in preparation for the current installation of Google Analytics in the admin portal to be reconfigured.
