### PR TITLE
Various quick wins for docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,4 @@ node_modules
 public/assets
 storage
 tmp
+log

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,18 @@
 coverage
+
+# Ignore all hidden files
+.*
+**/.*
+
+# Allow hidden ruby files
+!.rspec
+!.ruby-version
+
+# Ignore host node_modules
+node_modules
+
+# ignore rails files
+
+public/assets
+storage
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ ENV PATH "$PATH:/root/.yarn/bin:/root/.config/yarn/global/node_modules/.bin"
 COPY Gemfile Gemfile.lock .ruby-version ./
 RUN ${BUNDLE_INSTALL_CMD}
 
+COPY package.json yarn.lock ./
+RUN yarn
+
 COPY . .
 
 ARG RUN_PRECOMPILATION=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,5 @@ RUN ${BUNDLE_INSTALL_CMD}
 COPY . .
 
 RUN ASSET_PRECOMPILATION_ONLY=true RAILS_ENV=production bundle exec rails assets:precompile
-RUN cp -R /usr/src/app/node_modules /usr/src/.node_modules
 
 CMD ["bundle", "exec", "rails", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN ${BUNDLE_INSTALL_CMD}
 
 COPY . .
 
-RUN ASSET_PRECOMPILATION_ONLY=true RAILS_ENV=production bundle exec rails assets:precompile
-
+ARG RUN_PRECOMPILATION=true
+RUN if [ ${RUN_PRECOMPILATION} = 'true' ]; then \
+  ASSET_PRECOMPILATION_ONLY=true RAILS_ENV=production bundle exec rails assets:precompile; \
+  fi
 CMD ["bundle", "exec", "rails", "server"]

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,7 @@ build:
 	$(DOCKER_BUILD_CMD)
 
 serve: build
-	$(DOCKER_COMPOSE) up -d govuk-fake-registers
-	$(DOCKER_COMPOSE) up -d db
-	$(DOCKER_COMPOSE) up -d rr_db
+	$(DOCKER_COMPOSE) up -d govuk-fake-registers db rr_db
 	./mysql/bin/wait_for_mysql
 	./mysql/bin/wait_for_rr_db
 	$(DOCKER_COMPOSE) run --rm app ./bin/rails db:create db:schema:load db:seed
@@ -30,8 +28,7 @@ lint:
 
 test:
 	$(MAKE) build
-	$(DOCKER_COMPOSE) up -d db
-	$(DOCKER_COMPOSE) up -d rr_db
+	$(DOCKER_COMPOSE) up -d db rr_db
 	./mysql/bin/wait_for_mysql
 	./mysql/bin/wait_for_rr_db
 	$(DOCKER_COMPOSE) run -e RACK_ENV=test --rm app ./bin/rails db:create db:schema:load db:migrate

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ shell:
 	$(DOCKER_COMPOSE) exec app bash || ($(MAKE) build && $(DOCKER_COMPOSE) run --service-ports --rm app bash)
 
 stop:
-	$(DOCKER_COMPOSE) kill
-	$(DOCKER_COMPOSE) rm -f
+	$(DOCKER_COMPOSE) down -v
 
 .PHONY: build lint serve shell stop test

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,7 @@ serve: build
 	$(DOCKER_COMPOSE) up -d rr_db
 	./mysql/bin/wait_for_mysql
 	./mysql/bin/wait_for_rr_db
-	$(DOCKER_COMPOSE) run --rm app rm -f tmp/pids/server.pid
 	$(DOCKER_COMPOSE) run --rm app ./bin/rails db:create db:schema:load db:seed
-	$(DOCKER_COMPOSE) run --rm app cp -R --remove-destination /usr/src/.node_modules ./node_modules
 	$(DOCKER_COMPOSE) up -d app
 
 lint:
@@ -37,7 +35,6 @@ test:
 	./mysql/bin/wait_for_mysql
 	./mysql/bin/wait_for_rr_db
 	$(DOCKER_COMPOSE) run -e RACK_ENV=test --rm app ./bin/rails db:create db:schema:load db:migrate
-	$(DOCKER_COMPOSE) run --rm app cp -R --remove-destination /usr/src/.node_modules ./node_modules
 	$(DOCKER_COMPOSE) run --rm app bundle exec rspec
 
 shell:

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -7,3 +7,11 @@ services:
         RUN_PRECOMPILATION: 'false'
     volumes:
       - ".:/usr/src/app"
+      - "tmp:/usr/src/app/tmp"
+      - "storage:/usr/src/app/storage"
+      - "node_modules:/usr/src/app/node_modules"
+
+volumes:
+  tmp:
+  storage:
+  node_modules:

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -2,5 +2,8 @@ version: '3.4'
 
 services:
   app:
+    build:
+      args:
+        RUN_PRECOMPILATION: 'false'
     volumes:
-    - ".:/usr/src/app"
+      - ".:/usr/src/app"


### PR DESCRIPTION
### Ignore generated files for the docker context
This avoids stale cache making it in, as well as `node_modules`, which can cause complications if compiled packages are used.
We also avoid putting implicit hidden files going in, such as the git directory.

### Spin up services at the same time, instead of one by one
Docker can do this in parallel, so let's do it in parallel.

### Use volumes instead of bind mounts
Bind mounts are expensive, and we don't need them. Use volumes for cache, storage, and node modules
**note**, storage will now be discarded. Given the database is discarded, I assume this doesn't matter for our usecase.

### Avoid precompiling the assets at build time
This takes time, so defer it for when they're actually required.
**note** they'll still precompile on Jenkins