### PR TITLE
Add responsive breakpoints to subnavigation

### DIFF
--- a/app/assets/stylesheets/components/sub_nav.scss
+++ b/app/assets/stylesheets/components/sub_nav.scss
@@ -43,15 +43,11 @@
       display: inline-block;
       text-decoration: none;
       font-size: 16px;
-    }
 
-    .active {
-      border-bottom: 5px solid black;
-      margin-bottom: 0px !important;
+      &.active {
+        border-bottom: 5px solid black;
+        margin-bottom: 0px;
+      }
     }
   }
-}
-
-.text-decoration-none {
-  text-decoration: none;
 }

--- a/app/assets/stylesheets/components/sub_nav.scss
+++ b/app/assets/stylesheets/components/sub_nav.scss
@@ -1,5 +1,4 @@
 .subnav {
-  display: flex;
   margin-left: 0px;
   margin-right: 0px;
   border-bottom: 1px solid black;
@@ -10,21 +9,36 @@
     padding-bottom: 10px;
   }
 
+  .nav-links {
+    display: flex;
+    justify-content: space-around;
+
+    @media (min-width: 640px) {
+      justify-content: flex-end;
+    }
+  }
+
   nav {
     text-align: right;
+    margin-top: 4px;
+
+    > :first-child {
+      margin-left: 0px;
+    }
 
     a {
       margin-left: 15px;
+      margin-bottom: 5px;
       padding-top: 10px;
       padding-bottom: 5px;
       display: inline-block;
       text-decoration: none;
-      border-bottom: 5px solid white;
       font-size: 16px;
     }
 
     .active {
       border-bottom: 5px solid black;
+      margin-bottom: 0px !important;
     }
   }
 }

--- a/app/assets/stylesheets/components/sub_nav.scss
+++ b/app/assets/stylesheets/components/sub_nav.scss
@@ -33,6 +33,8 @@
 
   nav {
     text-align: right;
+    // This margin is required to keep the left and right columns the same height.
+    // Flexbox cannot be used on mobile as it breaks the design system styles.
     margin-top: 4px;
 
     // Margin that separates subnav links is not required on first link

--- a/app/assets/stylesheets/components/sub_nav.scss
+++ b/app/assets/stylesheets/components/sub_nav.scss
@@ -1,14 +1,18 @@
 .subnav {
   border-bottom: 1px solid black;
 
+  // Flexbox used at desktop widths to keep the subnav links anchored to the
+  // bottom of their div.
   @media (min-width: 640px) {
     display: flex;
   }
 
   .organisation-name {
+    // Organisation name centred on mobile
     text-align: center;
     margin-top: 14px;
 
+    // Organisation name aligned left on desktop and top margin reduced.
     @media (min-width: 640px) {
       text-align: left;
       margin: 10px 0px;
@@ -16,9 +20,11 @@
   }
 
   .nav-links {
+    // Subnav links centred on mobile
     display: flex;
     justify-content: space-around;
 
+    // Subnav links aligned right on desktop
     @media (min-width: 640px) {
       justify-content: flex-end;
       align-self: flex-end;
@@ -29,17 +35,24 @@
     text-align: right;
     margin-top: 4px;
 
+    // Margin that separates subnav links is not required on first link
     > :first-child {
       margin-left: 0px;
     }
 
     a {
-      margin: 0px 0px 5px 15px;
-      padding: 10px 0px 5px 0px;
+      // Margin bottom replaced by bottom border when active
+      margin-bottom: 5px;
+      // Spacing between subnav links
+      margin-left: 15px;
+      padding-top: 10px;
+      padding-bottom: 5px;
       display: inline-block;
       text-decoration: none;
       font-size: 16px;
 
+      // Active state conveys the current page to the user. Bottom margin is
+      // replaced with a thick black bottom border
       &.active {
         border-bottom: 5px solid black;
         margin-bottom: 0px;

--- a/app/assets/stylesheets/components/sub_nav.scss
+++ b/app/assets/stylesheets/components/sub_nav.scss
@@ -3,10 +3,18 @@
   margin-right: 0px;
   border-bottom: 1px solid black;
 
+  @media (min-width: 640px) {
+    display: flex;
+  }
+
   .organisation-name {
-    margin-bottom: 0px;
-    padding-top: 10px;
-    padding-bottom: 10px;
+    text-align: center;
+    margin-top: 14px;
+
+    @media (min-width: 640px) {
+      text-align: left;
+      margin: 10px 0px;
+    }
   }
 
   .nav-links {
@@ -15,6 +23,7 @@
 
     @media (min-width: 640px) {
       justify-content: flex-end;
+      align-self: flex-end;
     }
   }
 

--- a/app/assets/stylesheets/components/sub_nav.scss
+++ b/app/assets/stylesheets/components/sub_nav.scss
@@ -1,6 +1,4 @@
 .subnav {
-  margin-left: 0px;
-  margin-right: 0px;
   border-bottom: 1px solid black;
 
   @media (min-width: 640px) {
@@ -36,10 +34,8 @@
     }
 
     a {
-      margin-left: 15px;
-      margin-bottom: 5px;
-      padding-top: 10px;
-      padding-bottom: 5px;
+      margin: 0px 0px 5px 15px;
+      padding: 10px 0px 5px 0px;
       display: inline-block;
       text-decoration: none;
       font-size: 16px;

--- a/app/views/application/_subnavigation.html.erb
+++ b/app/views/application/_subnavigation.html.erb
@@ -1,5 +1,5 @@
 <div class='govuk-grid-row subnav'>
-  <div class='govuk-grid-column-one-quarter govuk-grid-column-one-third-from-desktop govuk-!-padding-left-0 organisation-name'>
+  <div class='govuk-grid-column-one-quarter govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-0 govuk-!-padding-0 organisation-name'>
     <p class='govuk-body govuk-!-margin-0 govuk-!-padding-0'>
       <% if current_user.super_admin? %>
         <strong>GovWifi Super Admin</strong>

--- a/app/views/application/_subnavigation.html.erb
+++ b/app/views/application/_subnavigation.html.erb
@@ -1,14 +1,16 @@
 <div class='govuk-grid-row subnav'>
-  <div class='govuk-grid-column-one-quarter govuk-grid-column-one-third-from-desktop govuk-!-padding-left-0'>
-    <p class='govuk-body organisation-name'>
-      <% unless current_user.super_admin? %>
+  <div class='govuk-grid-column-one-quarter govuk-grid-column-one-third-from-desktop govuk-!-padding-left-0 organisation-name'>
+    <p class='govuk-body govuk-!-margin-0 govuk-!-padding-0'>
+      <% if current_user.super_admin? %>
+        <strong>GovWifi Super Admin</strong>
+      <% else %>
         <strong><%= current_organisation.name %></strong>
       <% end %>
     </p>
   </div>
 
   <div class='govuk-grid-column-three-quarters govuk-grid-column-two-thirds-from-desktop govuk-!-margin-bottom-0 govuk-!-padding-0 nav-links'>
-    <nav class='govuk-body govuk-!-margin-bottom-0 '>
+    <nav class='govuk-body govuk-!-margin-bottom-0'>
       <% if current_user.super_admin? %>
         <%= link_to 'Organisations', admin_organisations_path, class: active_tab(admin_organisations_path) %>
         <%= link_to 'Allow Organisations', admin_custom_organisations_path, class: active_tab(admin_custom_organisations_path) %>

--- a/app/views/application/_subnavigation.html.erb
+++ b/app/views/application/_subnavigation.html.erb
@@ -1,5 +1,5 @@
 <div class='govuk-grid-row subnav'>
-  <div class='govuk-grid-column-one-third govuk-!-padding-left-0'>
+  <div class='govuk-grid-column-one-quarter govuk-grid-column-one-third-from-desktop govuk-!-padding-left-0'>
     <p class='govuk-body organisation-name'>
       <% unless current_user.super_admin? %>
         <strong><%= current_organisation.name %></strong>
@@ -7,7 +7,7 @@
     </p>
   </div>
 
-  <div class='govuk-grid-column-two-thirds govuk-!-margin-bottom-0 govuk-!-padding-right-0 flex-end'>
+  <div class='govuk-grid-column-three-quarters govuk-grid-column-two-thirds-from-desktop govuk-!-margin-bottom-0 govuk-!-padding-0 nav-links'>
     <nav class='govuk-body govuk-!-margin-bottom-0 '>
       <% if current_user.super_admin? %>
         <%= link_to 'Organisations', admin_organisations_path, class: active_tab(admin_organisations_path) %>

--- a/app/views/application/_subnavigation.html.erb
+++ b/app/views/application/_subnavigation.html.erb
@@ -1,5 +1,5 @@
-<div class='govuk-grid-row subnav'>
-  <div class='govuk-grid-column-one-quarter govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-0 govuk-!-padding-0 organisation-name'>
+<div class='govuk-grid-row subnav govuk-!-margin-0'>
+  <div class='govuk-grid-column-one-quarter govuk-grid-column-one-third-from-desktop govuk-!-padding-left-0 organisation-name'>
     <p class='govuk-body govuk-!-margin-0 govuk-!-padding-0'>
       <% if current_user.super_admin? %>
         <strong>GovWifi Super Admin</strong>
@@ -9,7 +9,7 @@
     </p>
   </div>
 
-  <div class='govuk-grid-column-three-quarters govuk-grid-column-two-thirds-from-desktop govuk-!-margin-bottom-0 govuk-!-padding-0 nav-links'>
+  <div class='govuk-grid-column-three-quarters govuk-grid-column-two-thirds-from-desktop govuk-!-padding-0 nav-links'>
     <nav class='govuk-body govuk-!-margin-bottom-0'>
       <% if current_user.super_admin? %>
         <%= link_to 'Organisations', admin_organisations_path, class: active_tab(admin_organisations_path) %>


### PR DESCRIPTION
- Adds the gov.uk design system breakpoints to the subnav.
- On mobile the subnav and org name go to a new line and are centred.
- On desktop the subnav is inline and right aligned.

Mobile:
![screenshot 2019-02-18 at 12 09 55](https://user-images.githubusercontent.com/2160769/52950178-3f241e80-3376-11e9-96fe-a5e258205f42.png)

Tablet & Desktop:
![screenshot 2019-02-18 at 11 33 07](https://user-images.githubusercontent.com/2160769/52948305-05044e00-3371-11e9-8bbd-44514235813b.png)

![screenshot 2019-02-18 at 12 10 25](https://user-images.githubusercontent.com/2160769/52950181-43503c00-3376-11e9-968a-5c94cfe0e7a8.png)


