### PR TITLE
Use case to generate a signup whitelist

### DIFF
--- a/lib/use_cases/administrator/create_signup_whitelist.rb
+++ b/lib/use_cases/administrator/create_signup_whitelist.rb
@@ -1,0 +1,23 @@
+module UseCases
+  module Administrator
+    class CreateSignupWhitelist
+      NOOP_REGEX = '^$'.freeze
+
+      def execute(domains)
+        return NOOP_REGEX if domains.empty?
+
+        '^.*@' + literal_dot(domains_list(domains) + '$')
+      end
+
+    private
+
+      def domains_list(domains)
+        "(#{domains.join('|')})"
+      end
+
+      def literal_dot(whitelist)
+        whitelist.gsub('.', '\.')
+      end
+    end
+  end
+end

--- a/spec/use_cases/administrator/create_signup_whitelist_spec.rb
+++ b/spec/use_cases/administrator/create_signup_whitelist_spec.rb
@@ -1,0 +1,31 @@
+describe UseCases::Administrator::CreateSignupWhitelist do
+  let(:result) { subject.execute(authorised_domains) }
+
+  context 'given no domains' do
+    let(:authorised_domains) { [] }
+
+    it 'creates no whitelist' do
+      expect(result).to eq('^$')
+    end
+  end
+
+  context 'given one domain' do
+    let(:authorised_domains) { %w(gov.uk) }
+
+    it 'escapes the fullstops' do
+      expect(result).to include('\.')
+    end
+
+    it 'creates a whitelist with one entry' do
+      expect(result).to eq('^.*@(gov\.uk)$')
+    end
+  end
+
+  context 'given multiple domains' do
+    let(:authorised_domains) { %w(gov.uk police.uk some.domain.org.uk) }
+
+    it 'creates a whitelist with multiple entries' do
+      expect(result).to eq('^.*@(gov\.uk|police\.uk|some\.domain\.org\.uk)$')
+    end
+  end
+end


### PR DESCRIPTION
Given a list of domains, generate the PERL regular expression that will
be used to make sure someone is allowed to sign up to the admin or user
signup API.

A list of:
foo.com, bar.gov.uk

Will result in a regex like:
^.*@(foo\.com|bar\.gov\.uk)$