### PR TITLE
fetch parameters from admin service for run-task

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,7 +132,10 @@ def runMigrations(deploy_environment) {
     deploy_environment = 'wifi'
   }
 
-  sh("aws ecs run-task --cluster ${deploy_environment}-admin-cluster --task-definition  admin-task-${deploy_environment} --count 1 --overrides \"{ \\\"containerOverrides\\\": [{ \\\"name\\\": \\\"admin\\\", \\\"command\\\": [\\\"bundle\\\", \\\"exec\\\", \\\"rake\\\", \\\"db:migrate\\\"] }] }\"")
+  // we need to get the network config from our main service
+  network_config = sh("aws ecs describe-services --cluster '${deploy_environment}-admin-cluster' --service 'admin-${deploy_environment}' --query 'services[0].networkConfiguration' --output json")
+
+  sh("aws ecs run-task --cluster '${deploy_environment}-admin-cluster' --task-definition  'admin-task-${deploy_environment}' --count 1 --overrides '{ \"containerOverrides\": [{ \"name\": \"admin\", \"command\": [\"bundle\", \"exec\", \"rake\", \"db:migrate\"] }] }' --launch-type FARGATE --network-configuration '${network_config}'")
 }
 
 def publishStableTag() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,9 +133,10 @@ def runMigrations(deploy_environment) {
   }
 
   // we need to get the network config from our main service
-  network_config = sh("aws ecs describe-services --cluster '${deploy_environment}-admin-cluster' --service 'admin-${deploy_environment}' --query 'services[0].networkConfiguration' --output json")
-
-  sh("aws ecs run-task --cluster '${deploy_environment}-admin-cluster' --task-definition  'admin-task-${deploy_environment}' --count 1 --overrides '{ \"containerOverrides\": [{ \"name\": \"admin\", \"command\": [\"bundle\", \"exec\", \"rake\", \"db:migrate\"] }] }' --launch-type FARGATE --network-configuration '${network_config}'")
+  aws_service_cmd = "aws ecs describe-services --cluster '${deploy_environment}-admin-cluster' --service 'admin-${deploy_environment}' --output json"
+  network_config = sh("${aws_service_cmd} --query 'services[0].networkConfiguration'")
+  launch_type = sh("${aws_service_cmd} --query 'services[0].launchType'")
+  sh("aws ecs run-task --cluster '${deploy_environment}-admin-cluster' --task-definition  'admin-task-${deploy_environment}' --count 1 --overrides '{ \"containerOverrides\": [{ \"name\": \"admin\", \"command\": [\"bundle\", \"exec\", \"rake\", \"db:migrate\"] }] }' --launch-type '${launch_type}' --network-configuration '${network_config}'")
 }
 
 def publishStableTag() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,8 +134,8 @@ def runMigrations(deploy_environment) {
 
   // we need to get the network config from our main service
   aws_service_cmd = "aws ecs describe-services --cluster '${deploy_environment}-admin-cluster' --service 'admin-${deploy_environment}' --output json"
-  network_config = sh("${aws_service_cmd} --query 'services[0].networkConfiguration'")
-  launch_type = sh("${aws_service_cmd} --query 'services[0].launchType'")
+  network_config = sh(returnStdout: true, script: "${aws_service_cmd} --query 'services[0].networkConfiguration'").trim()
+  launch_type = sh(returnStdout: true, script: "${aws_service_cmd} --query 'services[0].launchType'").trim()
   sh("aws ecs run-task --cluster '${deploy_environment}-admin-cluster' --task-definition  'admin-task-${deploy_environment}' --count 1 --overrides '{ \"containerOverrides\": [{ \"name\": \"admin\", \"command\": [\"bundle\", \"exec\", \"rake\", \"db:migrate\"] }] }' --launch-type '${launch_type}' --network-configuration '${network_config}'")
 }
 


### PR DESCRIPTION
With the move to fargate, we use awsvpc. This requires all tasks to have a network configuration.

Clone from the running service for running migrations