### PR TITLE
Validate shape of the data being whitelisted

### DIFF
--- a/app/models/authorised_email_domain.rb
+++ b/app/models/authorised_email_domain.rb
@@ -1,3 +1,4 @@
 class AuthorisedEmailDomain < ApplicationRecord
   validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates_format_of :name, with: /\A[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/, on: :create
 end

--- a/spec/models/authorised_email_domain_spec.rb
+++ b/spec/models/authorised_email_domain_spec.rb
@@ -2,5 +2,27 @@ describe AuthorisedEmailDomain do
   context 'validations' do
     it { should validate_presence_of(:name) }
     it { should validate_uniqueness_of(:name).case_insensitive }
+
+    it 'validates the domain is in the correct shape' do
+      invalid_examples = %i(
+        justarandomstring
+        i_contain_an_at_sign@gov.uk
+        999999
+      )
+
+      invalid_examples.each do |invalid_example|
+        expect(described_class.new(name: invalid_example).valid?).to eq(false)
+      end
+
+      valid_examples = %i(
+        foo.com
+        nhs.net
+        123abc.foo.com
+      )
+
+      valid_examples.each do |valid_example|
+        expect(described_class.new(name: valid_example).valid?).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
There is a danger that malformed data entered here could produce a
corrupt whitelist regular expression.

Validate that only domains / subdomains are allowed to be saved.