### PR TITLE
only bind ports in development

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -10,6 +10,8 @@ services:
       - "tmp:/usr/src/app/tmp"
       - "storage:/usr/src/app/storage"
       - "node_modules:/usr/src/app/node_modules"
+    ports:
+      - "8080:3000"
 
 volumes:
   tmp:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: root
-    ports:
-      - "13306:3306"
+    expose:
+      - "3306"
 
   rr_db:
     build: ./mysql
@@ -15,21 +15,21 @@ services:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: root
       MYSQL_DATABASE: rr_govwifi
-    ports:
-      - "13307:3306"
+    expose:
+      - "3306"
 
   govuk-fake-registers:
     build:
       context: govuk_fake_register
-    ports:
-      - "7000:7000"
+    expose:
+      - "7000"
 
   app:
     build: .
     links:
       - db
       - rr_db
-    ports:
-    - "8080:3000"
+    expose:
+    - "3000"
     depends_on:
       - 'govuk-fake-registers'


### PR DESCRIPTION
We only want to bind ports while in development, to avoid doing it for in jenkins.

This will allow us to run the tests in parallel