### PR TITLE
Upload whitelist after deleting an entry

### DIFF
--- a/app/controllers/admin/authorised_email_domains_controller.rb
+++ b/app/controllers/admin/authorised_email_domains_controller.rb
@@ -26,6 +26,13 @@ class Admin::AuthorisedEmailDomainsController < AdminController
     end
   end
 
+  def destroy
+    authorised_email_domain = AuthorisedEmailDomain.find_by(id: params.fetch(:id))
+    authorised_email_domain.destroy
+
+    redirect_to admin_authorised_email_domains_path, notice: "#{authorised_email_domain.name} has been removed"
+  end
+
 private
 
   def authorised_email_params

--- a/app/controllers/admin/authorised_email_domains_controller.rb
+++ b/app/controllers/admin/authorised_email_domains_controller.rb
@@ -27,8 +27,17 @@ class Admin::AuthorisedEmailDomainsController < AdminController
   end
 
   def destroy
-    authorised_email_domain = AuthorisedEmailDomain.find_by(id: params.fetch(:id))
+    authorised_email_domain = AuthorisedEmailDomain.find_by(id: authorised_email_params.fetch(:id))
+
     authorised_email_domain.destroy
+    # UseCases::Administrator::PublishSignupWhitelist.new(
+    #     destination_gateway: Gateways::S3.new(
+    #       bucket: ENV.fetch('S3_SIGNUP_WHITELIST_BUCKET'),
+    #       key: ENV.fetch('S3_SIGNUP_WHITELIST_OBJECT_KEY')
+    #     ),
+    #     source_gateway: Gateways::AuthorisedEmailDomains.new,
+    #     presenter: UseCases::Administrator::CreateSignupWhitelist.new
+    #   ).execute
 
     redirect_to admin_authorised_email_domains_path, notice: "#{authorised_email_domain.name} has been removed"
   end

--- a/app/controllers/admin/authorised_email_domains_controller.rb
+++ b/app/controllers/admin/authorised_email_domains_controller.rb
@@ -27,7 +27,7 @@ class Admin::AuthorisedEmailDomainsController < AdminController
   end
 
   def destroy
-    authorised_email_domain = AuthorisedEmailDomain.find_by(id: authorised_email_params.fetch(:id))
+    authorised_email_domain = AuthorisedEmailDomain.find_by(id: params.fetch(:id))
 
     authorised_email_domain.destroy
     # UseCases::Administrator::PublishSignupWhitelist.new(

--- a/app/controllers/admin/authorised_email_domains_controller.rb
+++ b/app/controllers/admin/authorised_email_domains_controller.rb
@@ -30,16 +30,16 @@ class Admin::AuthorisedEmailDomainsController < AdminController
     authorised_email_domain = AuthorisedEmailDomain.find_by(id: params.fetch(:id))
 
     authorised_email_domain.destroy
-    # UseCases::Administrator::PublishSignupWhitelist.new(
-    #     destination_gateway: Gateways::S3.new(
-    #       bucket: ENV.fetch('S3_SIGNUP_WHITELIST_BUCKET'),
-    #       key: ENV.fetch('S3_SIGNUP_WHITELIST_OBJECT_KEY')
-    #     ),
-    #     source_gateway: Gateways::AuthorisedEmailDomains.new,
-    #     presenter: UseCases::Administrator::CreateSignupWhitelist.new
-    #   ).execute
+    UseCases::Administrator::PublishSignupWhitelist.new(
+      destination_gateway: Gateways::S3.new(
+        bucket: ENV.fetch('S3_SIGNUP_WHITELIST_BUCKET'),
+        key: ENV.fetch('S3_SIGNUP_WHITELIST_OBJECT_KEY')
+      ),
+      source_gateway: Gateways::AuthorisedEmailDomains.new,
+      presenter: UseCases::Administrator::CreateSignupWhitelist.new
+    ).execute
 
-    redirect_to admin_authorised_email_domains_path, notice: "#{authorised_email_domain.name} has been removed"
+    # redirect_to admin_authorised_email_domains_path, notice: "#{authorised_email_domain.name} has been removed"
   end
 
 private

--- a/app/controllers/admin/authorised_email_domains_controller.rb
+++ b/app/controllers/admin/authorised_email_domains_controller.rb
@@ -39,7 +39,7 @@ class Admin::AuthorisedEmailDomainsController < AdminController
       presenter: UseCases::Administrator::CreateSignupWhitelist.new
     ).execute
 
-    # redirect_to admin_authorised_email_domains_path, notice: "#{authorised_email_domain.name} has been removed"
+    redirect_to admin_authorised_email_domains_path, notice: "#{authorised_email_domain.name} has been deleted"
   end
 
 private

--- a/app/views/admin/authorised_email_domains/_confirm_remove_email_domain.html.erb
+++ b/app/views/admin/authorised_email_domains/_confirm_remove_email_domain.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-error-summary">
+   <h2 class="govuk-error-summary__title">
+     Are you sure you want to remove this email domain?
+   </h2>
+		<div class="govuk-error-summary__body">
+     <%= button_to 'Yes, remove this email domain', admin_authorised_email_domain_path(params[:id]), method: :delete, class: "govuk-button red-button" %>
+   </div>
+ </div>

--- a/app/views/admin/authorised_email_domains/_table.html.erb
+++ b/app/views/admin/authorised_email_domains/_table.html.erb
@@ -1,9 +1,10 @@
 <table class="govuk-table govuk-!-margin-bottom-8">
-  <tbody class="govuk-table__body" id="ips-table">
+  <tbody class="govuk-table__body" id="domains-table">
     <% domains.each do |domain| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-third"><%= domain.name %></td>
         <td class="govuk-table__cell text-right">
+          <%= link_to 'Remove', admin_authorised_email_domains_path(id: domain.id, remove_email_domain: true), class: "govuk-link" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/authorised_email_domains/index.html.erb
+++ b/app/views/admin/authorised_email_domains/index.html.erb
@@ -1,3 +1,6 @@
+
+<%= render "confirm_remove_email_domain" if params[:remove_email_domain] %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Whitelisted Signup Domains</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
     resources :mou, only: %i[index update create]
     resources :organisations, only: %i[index show destroy]
     resources :custom_organisations, only: %i[index create destroy]
-    resources :authorised_email_domains, only: %i[index new create]
+    resources :authorised_email_domains, only: %i[index new create destroy]
   end
 
   %w( 404 422 500 ).each do |code|

--- a/spec/features/super_admin/authorised_email_domain_spec.rb
+++ b/spec/features/super_admin/authorised_email_domain_spec.rb
@@ -35,23 +35,27 @@ describe 'Authorised Email Domains' do
             expect(page).to have_content("Name can't be blank")
           end
         end
+
+        context 'deleting a whitelisted domain' do
+          let(:some_domain) { 'police.uk' }
+
+          it 'removes a domain' do
+            click_on 'Save'
+            click_on 'Remove'
+
+            expect { click_on 'Yes, remove this email domain' }.to change { AuthorisedEmailDomain.count }.by(-1)
+            expect(page).to have_content("#{some_domain} has been deleted")
+          end
+
+          # it 'publishes an updated list of authorised domains to S3' do
+          #   click_on 'Save'
+          #   click_on 'Remove'
+
+          #   expect_any_instance_of(Gateways::S3).to receive(:upload).with(data: '^$')
+          #   click_on 'Yes, remove this email domain'
+          # end
+        end
       end
-
-      # context 'given I want to delete a whitelisted domain' do
-        # let!(:authorised_email_domain) { create(:authorised_email_domain, name: 'police.uk') }
-
-        # it 'removes a domain' do
-        #   visit admin_authorised_email_domains_path
-
-        #   expect { click_on 'Delete' }.to change { AuthorisedEmailDomain.count }.by(-1)
-        #   expect(page).to have_content("#{authorised_email_domain.name} has been deleted")
-        # end
-
-        # it 'publishes an updated list of authorised domains to S3' do
-        #   expect_any_instance_of(Gateways::S3).to receive(:upload).with(data: '^.*@(gov\.uk)$')
-        #   click_on 'Remove'
-        # end
-      # end
 
       context 'viewing a list of domains' do
         it 'displays a list of domains' do

--- a/spec/features/super_admin/authorised_email_domain_spec.rb
+++ b/spec/features/super_admin/authorised_email_domain_spec.rb
@@ -47,13 +47,13 @@ describe 'Authorised Email Domains' do
             expect(page).to have_content("#{some_domain} has been deleted")
           end
 
-          # it 'publishes an updated list of authorised domains to S3' do
-          #   click_on 'Save'
-          #   click_on 'Remove'
+          it 'publishes an updated list of authorised domains to S3' do
+            click_on 'Save'
+            click_on 'Remove'
 
-          #   expect_any_instance_of(Gateways::S3).to receive(:upload).with(data: '^$')
-          #   click_on 'Yes, remove this email domain'
-          # end
+            expect_any_instance_of(Gateways::S3).to receive(:upload).with(data: '^$')
+            click_on 'Yes, remove this email domain'
+          end
         end
       end
 

--- a/spec/features/super_admin/authorised_email_domain_spec.rb
+++ b/spec/features/super_admin/authorised_email_domain_spec.rb
@@ -37,6 +37,21 @@ describe 'Authorised Email Domains' do
         end
       end
 
+      # context 'given I want to delete a whitelisted domain' do
+      #   it 'removes a domain' do
+      #     create(:authorised_email_domain, name: 'police.uk')
+      #     visit admin_authorised_email_domains_path
+
+      #     expect { click_on 'Delete' }.to change { AuthorisedEmailDomain.count }.by(-1)
+      #     expect(page).to have_content("#{authorised_email_domain.name} has been deleted")
+      #   end
+
+      #   it 'publishes an updated list of authorised domains to S3' do
+      #     expect_any_instance_of(Gateways::S3).to receive(:upload).with(data: '^.*@(gov\.uk)$')
+      #     click_on 'Remove'
+      #   end
+      # end
+
       context 'viewing a list of domains' do
         it 'displays a list of domains' do
           create(:authorised_email_domain, name: 'gov.some.test.uk')
@@ -45,6 +60,7 @@ describe 'Authorised Email Domains' do
           expect(page).to have_content('gov.some.test.uk')
         end
       end
+
     end
 
     context 'as a normal administrator' do

--- a/spec/features/super_admin/authorised_email_domain_spec.rb
+++ b/spec/features/super_admin/authorised_email_domain_spec.rb
@@ -61,7 +61,6 @@ describe 'Authorised Email Domains' do
           expect(page).to have_content('gov.some.test.uk')
         end
       end
-
     end
 
     context 'as a normal administrator' do

--- a/spec/features/super_admin/authorised_email_domain_spec.rb
+++ b/spec/features/super_admin/authorised_email_domain_spec.rb
@@ -38,18 +38,19 @@ describe 'Authorised Email Domains' do
       end
 
       # context 'given I want to delete a whitelisted domain' do
-      #   it 'removes a domain' do
-      #     create(:authorised_email_domain, name: 'police.uk')
-      #     visit admin_authorised_email_domains_path
+        # let!(:authorised_email_domain) { create(:authorised_email_domain, name: 'police.uk') }
 
-      #     expect { click_on 'Delete' }.to change { AuthorisedEmailDomain.count }.by(-1)
-      #     expect(page).to have_content("#{authorised_email_domain.name} has been deleted")
-      #   end
+        # it 'removes a domain' do
+        #   visit admin_authorised_email_domains_path
 
-      #   it 'publishes an updated list of authorised domains to S3' do
-      #     expect_any_instance_of(Gateways::S3).to receive(:upload).with(data: '^.*@(gov\.uk)$')
-      #     click_on 'Remove'
-      #   end
+        #   expect { click_on 'Delete' }.to change { AuthorisedEmailDomain.count }.by(-1)
+        #   expect(page).to have_content("#{authorised_email_domain.name} has been deleted")
+        # end
+
+        # it 'publishes an updated list of authorised domains to S3' do
+        #   expect_any_instance_of(Gateways::S3).to receive(:upload).with(data: '^.*@(gov\.uk)$')
+        #   click_on 'Remove'
+        # end
       # end
 
       context 'viewing a list of domains' do

--- a/spec/requests/email_domain/delete_spec.rb
+++ b/spec/requests/email_domain/delete_spec.rb
@@ -1,36 +1,33 @@
 describe "DELETE /authorised_email_domains/:id", type: :request do
-  let(:admin_user) { create(:user, super_admin: true) }
-  let(:normal_user) { create(:user, super_admin: false) }
-  let!(:email_domain_1) { create(:authorised_email_domain, name: 'some.domain.org.uk') }
-  let!(:email_domain_2) { create(:authorised_email_domain, name: 'police.uk') }
+  let!(:email_domain) { create(:authorised_email_domain, name: 'some.domain.org.uk') }
 
   context "when the user is a super admin" do
     before do
       https!
-      login_as(admin_user, scope: :user)
+      sign_in_user(create(:user, super_admin: true))
     end
 
     it "deletes the email domain" do
       expect {
-        delete admin_authorised_email_domain_path(email_domain_1)
+        delete admin_authorised_email_domain_path(email_domain)
       }.to change { AuthorisedEmailDomain.count }.by(-1)
     end
 
     it 'publishes the authorised domains to S3' do
       expect_any_instance_of(Gateways::S3).to receive(:upload)
-      delete admin_authorised_email_domain_path(email_domain_1)
+      delete admin_authorised_email_domain_path(email_domain)
     end
   end
 
   context "when the user is not super admin" do
     before do
       https!
-      login_as(normal_user, scope: :user)
+      sign_in_user(create(:user, super_admin: false))
     end
 
     it "does not delete the email domain" do
       expect {
-        delete admin_authorised_email_domain_path(email_domain_2)
+        delete admin_authorised_email_domain_path(email_domain)
       }.to change { AuthorisedEmailDomain.count }.by(0)
     end
   end

--- a/spec/requests/email_domain/delete_spec.rb
+++ b/spec/requests/email_domain/delete_spec.rb
@@ -1,17 +1,37 @@
 describe "DELETE /authorised_email_domains/:id", type: :request do
   let(:admin_user) { create(:user, super_admin: true) }
-  let!(:authorised_email_domain) { create(:authorised_email_domain, name: 'some.domain.org.uk') }
-
-  before do
-    https!
-    login_as(admin_user, scope: :user)
-  end
+  let(:normal_user) { create(:user, super_admin: false) }
+  let!(:email_domain_1) { create(:authorised_email_domain, name: 'some.domain.org.uk') }
+  let!(:email_domain_2) { create(:authorised_email_domain, name: 'police.uk') }
 
   context "when the user is a super admin" do
+    before do
+      https!
+      login_as(admin_user, scope: :user)
+    end
+
     it "deletes the email domain" do
       expect {
-        delete admin_authorised_email_domain_path(authorised_email_domain)
+        delete admin_authorised_email_domain_path(email_domain_1)
       }.to change { AuthorisedEmailDomain.count }.by(-1)
+    end
+
+    it 'publishes the authorised domains to S3' do
+      expect_any_instance_of(Gateways::S3).to receive(:upload)
+      delete admin_authorised_email_domain_path(email_domain_1)
+    end
+  end
+
+  context "when the user is not super admin" do
+    before do
+      https!
+      login_as(normal_user, scope: :user)
+    end
+
+    it "does not delete the email domain" do
+      expect {
+        delete admin_authorised_email_domain_path(email_domain_2)
+      }.to change { AuthorisedEmailDomain.count }.by(0)
     end
   end
 end

--- a/spec/requests/email_domain/delete_spec.rb
+++ b/spec/requests/email_domain/delete_spec.rb
@@ -1,10 +1,10 @@
 describe "DELETE /authorised_email_domains/:id", type: :request do
   let(:admin_user) { create(:user, super_admin: true) }
+  let!(:authorised_email_domain) { create(:authorised_email_domain, name: 'some.domain.org.uk') }
 
   before do
     https!
     login_as(admin_user, scope: :user)
-    create(:authorised_email_domain, name: 'some.domain.org.uk')
   end
 
   context "when the user is a super admin" do

--- a/spec/requests/email_domain/delete_spec.rb
+++ b/spec/requests/email_domain/delete_spec.rb
@@ -1,0 +1,17 @@
+describe "DELETE /authorised_email_domains/:id", type: :request do
+  let(:admin_user) { create(:user, super_admin: true) }
+
+  before do
+    https!
+    login_as(admin_user, scope: :user)
+    create(:authorised_email_domain, name: 'some.domain.org.uk')
+  end
+
+  context "when the user is a super admin" do
+    it "deletes the email domain" do
+      expect {
+        delete admin_authorised_email_domains_path(authorised_email_domain)
+      }.to change { AuthorisedEmailDomain.count }.by(-1)
+    end
+  end
+end

--- a/spec/requests/email_domain/delete_spec.rb
+++ b/spec/requests/email_domain/delete_spec.rb
@@ -10,7 +10,7 @@ describe "DELETE /authorised_email_domains/:id", type: :request do
   context "when the user is a super admin" do
     it "deletes the email domain" do
       expect {
-        delete admin_authorised_email_domains_path(authorised_email_domain)
+        delete admin_authorised_email_domain_path(authorised_email_domain)
       }.to change { AuthorisedEmailDomain.count }.by(-1)
     end
   end


### PR DESCRIPTION
**WHY:**
As part of the upcoming functionality to delete an email domain. This makes sure that a new whitelist is uploaded after a deletion occurs.

**IN THIS PR:**
- Add a test to describe the function in the feature.
- Add a test to describe the DELETE request.
- Add remove button in the whitelisted email domains table.

**STEP ONE:**

<img width="994" alt="screenshot 2019-02-22 at 12 43 01" src="https://user-images.githubusercontent.com/32823756/53243368-858fbb00-369f-11e9-8f71-5954a9054c04.png">

**STEP TWO:**

<img width="1019" alt="screenshot 2019-02-22 at 12 44 12" src="https://user-images.githubusercontent.com/32823756/53243931-4bbfb400-36a1-11e9-87f9-532c301cee06.png">

**STEP THREE:**

<img width="1006" alt="screenshot 2019-02-22 at 12 57 08" src="https://user-images.githubusercontent.com/32823756/53243962-62fea180-36a1-11e9-94de-3016df56accd.png">

**Any feedback/suggestions would be appreciated.**