### PR TITLE
Add read method to s3 gateway

### DIFF
--- a/lib/gateways/s3.rb
+++ b/lib/gateways/s3.rb
@@ -3,10 +3,10 @@ module Gateways
     def initialize(bucket:, key:)
       @bucket = bucket
       @key = key
+      @client = Aws::S3::Client.new(config)
     end
 
     def upload(data:)
-      client = Aws::S3::Client.new(config)
       client.put_object(
         body: data,
         bucket: bucket,
@@ -16,11 +16,15 @@ module Gateways
       {}
     end
 
+    def read
+      client.get_object(bucket: bucket, key: key).body.read
+    end
+
   private
 
     DEFAULT_REGION = 'eu-west-2'.freeze
 
-    attr_reader :bucket, :key
+    attr_reader :bucket, :key, :client
 
     def config
       { region: DEFAULT_REGION }.merge(Rails.application.config.s3_aws_config)

--- a/spec/gateways/s3_spec.rb
+++ b/spec/gateways/s3_spec.rb
@@ -22,10 +22,6 @@ describe Gateways::S3 do
       }
     end
 
-    after do
-      Rails.application.config.s3_aws_config = { stub_responses: true }
-    end
-
     it 'returns the contents' do
       expect(subject.read).to eq('some data')
     end

--- a/spec/gateways/s3_spec.rb
+++ b/spec/gateways/s3_spec.rb
@@ -8,4 +8,26 @@ describe Gateways::S3 do
   it 'uploads the data' do
     expect(subject.upload(data: data)).to eq({})
   end
+
+  context 'given we read from the S3 file' do
+    before do
+      Rails.application.config.s3_aws_config = {
+        stub_responses: {
+          get_object: ->(context) {
+            if context.params.fetch(:bucket) == bucket && context.params.fetch(:key) == key
+              { body: 'some data' }
+            end
+          }
+        }
+      }
+    end
+
+    after do
+      Rails.application.config.s3_aws_config = { stub_responses: true }
+    end
+
+    it 'returns the contents' do
+      expect(subject.read).to eq('some data')
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,5 +28,14 @@ RSpec.configure do |config|
     to_return(status: 200, body: File.read("#{Rails.root}/spec/fixtures/local_auths_payload.json"))
   end
 
+  config.around do |example|
+    original_s3_aws_config = Rails.application.config.s3_aws_config
+    begin
+      example.run
+    ensure
+      Rails.application.config.s3_aws_config = original_s3_aws_config
+    end
+  end
+
   ENV['AUTHORISED_EMAIL_DOMAINS_REGEX'] = '.*gov\.uk'
 end


### PR DESCRIPTION
NB: In a later change, will rename the upload method to write to maintain consistency.

**IN THIS PR:**
- Add read method to s3 gateway.
- This will be used to fetch the user sign up whitelist regex from the s3 bucket. 
- This read method is currently unused at this point.