### PR TITLE
Allow any subdomain for signup whitelist

### DIFF
--- a/lib/use_cases/administrator/create_signup_whitelist.rb
+++ b/lib/use_cases/administrator/create_signup_whitelist.rb
@@ -6,7 +6,7 @@ module UseCases
       def execute(domains)
         return NOOP_REGEX if domains.empty?
 
-        '^.*@([a-zA-Z0-9.-]+)?' + literal_dot(domains_list(domains) + '$')
+        '^[a-zA-Z0-9\.-]+@([a-zA-Z0-9\.-]+)?' + literal_dot(domains_list(domains) + '$')
       end
 
     private

--- a/lib/use_cases/administrator/create_signup_whitelist.rb
+++ b/lib/use_cases/administrator/create_signup_whitelist.rb
@@ -6,7 +6,7 @@ module UseCases
       def execute(domains)
         return NOOP_REGEX if domains.empty?
 
-        '^.*@' + literal_dot(domains_list(domains) + '$')
+        '^.*@([a-zA-Z0-9.-]+)?' + literal_dot(domains_list(domains) + '$')
       end
 
     private

--- a/lib/use_cases/administrator/create_signup_whitelist.rb
+++ b/lib/use_cases/administrator/create_signup_whitelist.rb
@@ -6,7 +6,7 @@ module UseCases
       def execute(domains)
         return NOOP_REGEX if domains.empty?
 
-        '^[a-zA-Z0-9\.-]+@([a-zA-Z0-9\.-]+)?' + literal_dot(domains_list(domains) + '$')
+        '^[a-zA-Z0-9\.-]+@([a-zA-Z0-9-]+\.)*' + literal_dot(domains_list(domains) + '$')
       end
 
     private

--- a/spec/features/super_admin/authorised_email_domain_spec.rb
+++ b/spec/features/super_admin/authorised_email_domain_spec.rb
@@ -22,7 +22,7 @@ describe 'Authorised Email Domains' do
           end
 
           it 'publishes the authorised domains to S3' do
-            expect_any_instance_of(Gateways::S3).to receive(:upload).with(data: '^.*@([a-zA-Z0-9.-]+)?(gov\.uk)$')
+            expect_any_instance_of(Gateways::S3).to receive(:upload).with(data: '^[a-zA-Z0-9\.-]+@([a-zA-Z0-9\.-]+)?(gov\.uk)$')
             click_on 'Save'
           end
         end

--- a/spec/features/super_admin/authorised_email_domain_spec.rb
+++ b/spec/features/super_admin/authorised_email_domain_spec.rb
@@ -22,7 +22,7 @@ describe 'Authorised Email Domains' do
           end
 
           it 'publishes the authorised domains to S3' do
-            expect_any_instance_of(Gateways::S3).to receive(:upload).with(data: '^.*@(gov\.uk)$')
+            expect_any_instance_of(Gateways::S3).to receive(:upload).with(data: '^.*@([a-zA-Z0-9.-]+)?(gov\.uk)$')
             click_on 'Save'
           end
         end

--- a/spec/features/super_admin/authorised_email_domain_spec.rb
+++ b/spec/features/super_admin/authorised_email_domain_spec.rb
@@ -22,7 +22,7 @@ describe 'Authorised Email Domains' do
           end
 
           it 'publishes the authorised domains to S3' do
-            expect_any_instance_of(Gateways::S3).to receive(:upload).with(data: '^[a-zA-Z0-9\.-]+@([a-zA-Z0-9\.-]+)?(gov\.uk)$')
+            expect_any_instance_of(Gateways::S3).to receive(:upload).with(data: '^[a-zA-Z0-9\.-]+@([a-zA-Z0-9-]+\.)*(gov\.uk)$')
             click_on 'Save'
           end
         end

--- a/spec/use_cases/administrator/create_signup_whitelist_spec.rb
+++ b/spec/use_cases/administrator/create_signup_whitelist_spec.rb
@@ -17,7 +17,7 @@ describe UseCases::Administrator::CreateSignupWhitelist do
     end
 
     it 'creates a whitelist with one entry' do
-      expect(result).to eq('^[a-zA-Z0-9\.-]+@([a-zA-Z0-9\.-]+)?(gov\.uk)$')
+      expect(result).to eq('^[a-zA-Z0-9\.-]+@([a-zA-Z0-9-]+\.)*(gov\.uk)$')
     end
   end
 
@@ -25,7 +25,7 @@ describe UseCases::Administrator::CreateSignupWhitelist do
     let(:authorised_domains) { %w(gov.uk police.uk some.domain.org.uk) }
 
     it 'creates a whitelist with multiple entries' do
-      expect(result).to eq('^[a-zA-Z0-9\.-]+@([a-zA-Z0-9\.-]+)?(gov\.uk|police\.uk|some\.domain\.org\.uk)$')
+      expect(result).to eq('^[a-zA-Z0-9\.-]+@([a-zA-Z0-9-]+\.)*(gov\.uk|police\.uk|some\.domain\.org\.uk)$')
     end
   end
 end

--- a/spec/use_cases/administrator/create_signup_whitelist_spec.rb
+++ b/spec/use_cases/administrator/create_signup_whitelist_spec.rb
@@ -17,7 +17,7 @@ describe UseCases::Administrator::CreateSignupWhitelist do
     end
 
     it 'creates a whitelist with one entry' do
-      expect(result).to eq('^.*@(gov\.uk)$')
+      expect(result).to eq('^.*@([a-zA-Z0-9.-]+)?(gov\.uk)$')
     end
   end
 
@@ -25,7 +25,7 @@ describe UseCases::Administrator::CreateSignupWhitelist do
     let(:authorised_domains) { %w(gov.uk police.uk some.domain.org.uk) }
 
     it 'creates a whitelist with multiple entries' do
-      expect(result).to eq('^.*@(gov\.uk|police\.uk|some\.domain\.org\.uk)$')
+      expect(result).to eq('^.*@([a-zA-Z0-9.-]+)?(gov\.uk|police\.uk|some\.domain\.org\.uk)$')
     end
   end
 end

--- a/spec/use_cases/administrator/create_signup_whitelist_spec.rb
+++ b/spec/use_cases/administrator/create_signup_whitelist_spec.rb
@@ -17,7 +17,7 @@ describe UseCases::Administrator::CreateSignupWhitelist do
     end
 
     it 'creates a whitelist with one entry' do
-      expect(result).to eq('^.*@([a-zA-Z0-9.-]+)?(gov\.uk)$')
+      expect(result).to eq('^[a-zA-Z0-9\.-]+@([a-zA-Z0-9\.-]+)?(gov\.uk)$')
     end
   end
 
@@ -25,7 +25,7 @@ describe UseCases::Administrator::CreateSignupWhitelist do
     let(:authorised_domains) { %w(gov.uk police.uk some.domain.org.uk) }
 
     it 'creates a whitelist with multiple entries' do
-      expect(result).to eq('^.*@([a-zA-Z0-9.-]+)?(gov\.uk|police\.uk|some\.domain\.org\.uk)$')
+      expect(result).to eq('^[a-zA-Z0-9\.-]+@([a-zA-Z0-9\.-]+)?(gov\.uk|police\.uk|some\.domain\.org\.uk)$')
     end
   end
 end


### PR DESCRIPTION
We need this regex to be more lenient and to allow any subdomains of trusted TLDs.
This won't cause an issue and should remain largely the same.