### PR TITLE
Log unsuccessful signup attempts

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -17,6 +17,11 @@ protected
     )
     checker = UseCases::Administrator::CheckIfWhitelistedEmail.new(gateway: gateway)
     whitelisted = checker.execute(sign_up_params[:email])[:success]
+
+    if whitelisted == false
+      logger.info("Unsuccessful signup attempt: #{sign_up_params[:email]}")
+    end
+
     set_user_object_with_errors && return_user_to_registration_page unless whitelisted
   end
 


### PR DESCRIPTION
We're using our new whitelist functionality and want to know
if someone was denied from signing up a new account in the admin.