### PR TITLE
Show total orgs/locations to super-admins

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -2,7 +2,11 @@ class Admin::OrganisationsController < AdminController
   helper_method :sort_column, :sort_direction
 
   def index
-    @organisations = Organisation.includes(:signed_mou_attachment).order("#{sort_column} #{sort_direction}").all
+    @organisations = Organisation
+      .includes(:signed_mou_attachment)
+      .order("#{sort_column} #{sort_direction}")
+
+    @location_count = Location.count
   end
 
   def show

--- a/app/views/admin/organisations/index.html.erb
+++ b/app/views/admin/organisations/index.html.erb
@@ -6,7 +6,7 @@
   </span>
    across
   <span class="govuk-!-font-weight-bold">
-    <%= pluralize(@organisations.count, 'organisation') %>.
+    <%= pluralize(@organisations.length, 'organisation') %>.
   </span>
 </h3>
 

--- a/app/views/admin/organisations/index.html.erb
+++ b/app/views/admin/organisations/index.html.erb
@@ -1,6 +1,13 @@
 <h1 class="govuk-heading-l">All organisations</h1>
-<h3 class="govuk-heading-m">
-  <%= pluralize(@organisations.count, 'organisation') %> are signed up to GovWifi
+<h3 class="govuk-body">
+  GovWifi is in
+  <span class="govuk-!-font-weight-bold">
+    <%= pluralize(@location_count, 'location') %>
+  </span>
+   across
+  <span class="govuk-!-font-weight-bold">
+    <%= pluralize(@organisations.count, 'organisation') %>.
+  </span>
 </h3>
 
 <table class="govuk-table">

--- a/spec/features/super_admin/view_organisation_list_spec.rb
+++ b/spec/features/super_admin/view_organisation_list_spec.rb
@@ -64,10 +64,20 @@ describe 'view list of signed up organisations' do
       end
     end
 
-    context 'and three organisations exist' do
+    context 'and two extra organisations (with three locations each) exist' do
       before do
-        3.times { create(:organisation) }
+        2.times do
+          organisation = create(:organisation)
+          3.times { create(:location, organisation: organisation) }
+        end
+
         visit admin_organisations_path
+      end
+
+      it 'summarises the totals' do
+        expect(page).to have_content(
+          "GovWifi is in 6 locations across 3 organisations."
+        )
       end
 
       it 'shows all three organisations' do


### PR DESCRIPTION
Steve wasn't interested in IP totals (especially now you can't add a location without an IP) - from talking/demoing to him, I believe this is what is needed.

It's possible I missed some context whilst out of the office, so feel free to challenge this!

![image](https://user-images.githubusercontent.com/429326/53495179-4beff300-3a97-11e9-9ca5-e0aad9323e87.png)
