### PR TITLE
Improve deletion confirmation by printing domain

### DIFF
--- a/app/views/admin/authorised_email_domains/_confirm_remove_email_domain.html.erb
+++ b/app/views/admin/authorised_email_domains/_confirm_remove_email_domain.html.erb
@@ -3,6 +3,6 @@
      Are you sure you want to remove this email domain?
    </h2>
 		<div class="govuk-error-summary__body">
-     <%= button_to 'Yes, remove this email domain', admin_authorised_email_domain_path(params[:id]), method: :delete, class: "govuk-button red-button" %>
+      <%= button_to "Yes, remove #{params[:domain_to_remove]} from the whitelist", admin_authorised_email_domain_path(params[:id]), method: :delete, class: "govuk-button red-button" %>
    </div>
  </div>

--- a/app/views/admin/authorised_email_domains/_confirm_remove_email_domain.html.erb
+++ b/app/views/admin/authorised_email_domains/_confirm_remove_email_domain.html.erb
@@ -1,8 +1,8 @@
 <div class="govuk-error-summary">
-   <h2 class="govuk-error-summary__title">
-     Are you sure you want to remove this email domain?
-   </h2>
-		<div class="govuk-error-summary__body">
-      <%= button_to "Yes, remove #{params[:domain_to_remove]} from the whitelist", admin_authorised_email_domain_path(params[:id]), method: :delete, class: "govuk-button red-button" %>
-   </div>
- </div>
+  <h2 class="govuk-error-summary__title">
+    Are you sure you want to remove this email domain?
+  </h2>
+  <div class="govuk-error-summary__body">
+    <%= button_to "Yes, remove #{params[:domain_to_remove]} from the whitelist", admin_authorised_email_domain_path(params[:id]), method: :delete, class: "govuk-button red-button" %>
+  </div>
+</div>

--- a/app/views/admin/authorised_email_domains/_table.html.erb
+++ b/app/views/admin/authorised_email_domains/_table.html.erb
@@ -4,7 +4,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-third"><%= domain.name %></td>
         <td class="govuk-table__cell text-right">
-          <%= link_to 'Remove', admin_authorised_email_domains_path(id: domain.id, remove_email_domain: true), class: "govuk-link" %>
+          <%= link_to 'Remove', admin_authorised_email_domains_path(id: domain.id, domain_to_remove: domain.name), class: "govuk-link" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/authorised_email_domains/index.html.erb
+++ b/app/views/admin/authorised_email_domains/index.html.erb
@@ -1,5 +1,5 @@
 
-<%= render "confirm_remove_email_domain" if params[:remove_email_domain] %>
+<%= render "confirm_remove_email_domain" if params[:domain_to_remove] %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/features/super_admin/authorised_email_domain_spec.rb
+++ b/spec/features/super_admin/authorised_email_domain_spec.rb
@@ -43,7 +43,7 @@ describe 'Authorised Email Domains' do
             click_on 'Save'
             click_on 'Remove'
 
-            expect { click_on 'Yes, remove this email domain' }.to change { AuthorisedEmailDomain.count }.by(-1)
+            expect { click_on "Yes, remove #{some_domain} from the whitelist" }.to change { AuthorisedEmailDomain.count }.by(-1)
             expect(page).to have_content("#{some_domain} has been deleted")
           end
 
@@ -52,7 +52,7 @@ describe 'Authorised Email Domains' do
             click_on 'Remove'
 
             expect_any_instance_of(Gateways::S3).to receive(:write).with(data: '^$')
-            click_on 'Yes, remove this email domain'
+            expect { click_on "Yes, remove #{some_domain} from the whitelist" }.to change { AuthorisedEmailDomain.count }.by(-1)
           end
         end
       end


### PR DESCRIPTION
When removing a domain from the signup whitelist, print that domain for
extra protection