### PR TITLE
Stop passing the user email as a query string to the pending URL

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -6,8 +6,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
 protected
 
   # The path used after sign up for inactive accounts.
-  def after_inactive_sign_up_path_for(resource)
-    users_confirmations_pending_path(email: resource.email)
+  def after_inactive_sign_up_path_for(_resource)
+    users_confirmations_pending_path
   end
 
   def validate_email_on_whitelist

--- a/app/views/users/confirmations/pending.html.erb
+++ b/app/views/users/confirmations/pending.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <h1 class="govuk-heading-l">Check your email</h1>
-    <p class="govuk-body-l">A confirmation email has been sent to <strong><%= params[:email] %>.</strong></p>
+    <p class="govuk-body-l">A confirmation email has been sent to <strong>your email address.</strong></p>
     <p class="govuk-body">
       Click on the link in the email to continue creating your account.
     </p>

--- a/app/views/users/confirmations/pending.html.erb
+++ b/app/views/users/confirmations/pending.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <h1 class="govuk-heading-l">Check your email</h1>
-    <p class="govuk-body-l">A confirmation email has been sent to <strong>your email address.</strong></p>
+    <p class="govuk-body-l">A confirmation email has been sent to your email address.</p>
     <p class="govuk-body">
       Click on the link in the email to continue creating your account.
     </p>

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -21,7 +21,7 @@ describe 'Sign up as an organisation' do
 
     it 'instructs the user to check their confirmation email' do
       expect(page).to have_content(
-        "A confirmation email has been sent to #{email}"
+        "A confirmation email has been sent to your email address."
         )
     end
   end


### PR DESCRIPTION
**WHY:**
PII is any data that can potentially identify a particular individual. 
We currently pass the email address of a new user signing up as a query string in the pending page URL. This allowed for the confirmation message to be personalised to the specific user.
 
**INITIAL SCREENSHOT:**

![screenshot 2019-03-04 at 16 07 24](https://user-images.githubusercontent.com/32823756/53747008-441abf00-3e9a-11e9-9679-400f207bc76c.png)
**Please note:** 
**- The URL in the screenshot.**
**- The personalised message.**

**IN THIS PR:**
However, in order be more compliant with GDPR standards and be prepared to use Google Analytics more effectively _(We were advised that G.A have some policies around user-specific details being passed as query strings in URLs)_:
1. We have stopped passing params to this URL.

**RESULT 1:**

![screenshot 2019-03-04 at 16 09 02](https://user-images.githubusercontent.com/32823756/53747260-c1deca80-3e9a-11e9-8442-0e5705f03c39.png)
**Please note:** 
**- The URL in the screenshot.**
**- The lack of a personalised message.**

2. The personalised message was changed to be more generic.

**RESULT 2:**

![screenshot 2019-03-04 at 16 09 41](https://user-images.githubusercontent.com/32823756/53747357-fbafd100-3e9a-11e9-8bdf-a7ab3ff3cfcb.png)
**Please note:** 
**- The URL in the screenshot.**
**- The generic message.**

**Is there a better solution?**
So currently there is a failing test as a result of the lack of a personalised message.
- Is there a way to make the user details (ideally the user's email) available as a variable in the `pending method` in the `ConfirmationsController`?
- Is there another way to hide what we are passing to the URL? 
- Have read some stuff about changing the GET request to a POST, any insight on this?

**The failing test could be edited/deleted but wanted some feedback on this first, would be nice to keep the personalised message, if possible.**