### PR TITLE
Replace support email with contact us link

### DIFF
--- a/app/views/layouts/_form_errors.html.erb
+++ b/app/views/layouts/_form_errors.html.erb
@@ -1,11 +1,11 @@
 <% if defined? resource %>
   <% if resource&.errors&.any? %>
-    <div class="govuk-error-summary">
+    <div class="govuk-error-summary" id="error-summary">
       <h2 class="govuk-error-summary__title">There is a problem</h2>
       <div class="govuk-error-summary__body">
         <ul class="govuk-list govuk-error-summary__list">
           <% resource.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
+            <li><%= message.html_safe %></li>
           <% end %>
         </ul>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,6 @@ en:
           attributes:
             name:
               taken: " is already registered. If you wish to administer an \n
-              existing GovWifi installation, you must be invited to the \n
-              account. <a class='govuk-link' href='/help/new'>Contact us</a> \n
+              existing GovWifi installation, you must be invited to that \n
+              organisation's team. <a class='govuk-link' href='/help/new'>Contact us</a> \n
               if you need help."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,5 +13,5 @@ en:
             name:
               taken: " is already registered. If you wish to administer an \n
               existing GovWifi installation, you must be invited to the \n
-              account. Please contact govwifi-support@digital.cabinet-office.gov.uk \n
+              account. Please <a href='/help/new'>contact us</a> \n
               if you need help."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,5 +13,5 @@ en:
             name:
               taken: " is already registered. If you wish to administer an \n
               existing GovWifi installation, you must be invited to the \n
-              account. Please <a href='/help/new'>contact us</a> \n
+              account. <a class='govuk-link' href='/help/new'>Contact us</a> \n
               if you need help."

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -155,4 +155,23 @@ describe 'Sign up as an organisation' do
       expect(page).to have_content 'Email was already confirmed'
     end
   end
+
+  context 'Given an organisation is already registered' do
+    let(:existing_org_name) { 'Gov Org 1' }
+
+    before do
+      sign_up_for_account
+      create(:organisation, name: existing_org_name)
+      update_user_details(organisation_name: existing_org_name)
+    end
+
+    it_behaves_like 'errors in form'
+
+    it 'shows the user an error message' do
+      within('div#error-summary')do
+        expect(page).to have_content('Organisation name is already registered')
+        expect(page).to have_link('contact us', href: new_help_path)
+      end
+    end
+  end
 end

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -170,7 +170,7 @@ describe 'Sign up as an organisation' do
     it 'shows the user an error message' do
       within('div#error-summary')do
         expect(page).to have_content('Organisation name is already registered')
-        expect(page).to have_link('contact us', href: new_help_path)
+        expect(page).to have_link('Contact us', href: new_help_path)
       end
     end
   end


### PR DESCRIPTION
**WHY:**
When a user signs up to create an account for an existing organisation. The error message includes the support email. 

It would be better to change this to a link to the offline support form with the app.

**IN THIS PR:**
Add a link within the message in the `en.yml` file.

**BEFORE:**

![](https://trello-attachments.s3.amazonaws.com/5c765bcb1eb8d43c4da83fa9/5c7fc751a3e80d5eab2eb969/1123x297/e300f3fd758c76a5af89de6ea259e044/Screenshot_2019-03-04_at_15.57.34.png)

------------------------------------------------------------------------------------------------------

**AFTER:**
![screenshot 2019-03-07 at 10 46 55](https://user-images.githubusercontent.com/32823756/53951475-74df3c00-40c6-11e9-971b-811c633adcf9.png)

------------------------------------------------------------------------------------------------------

**Any suggestions/feedback would be appreciated.**