### PR TITLE
Better error messaging on signup 

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -27,7 +27,7 @@ protected
 
   def set_user_object_with_errors
     @user = User.new(sign_up_params)
-    @user.errors.add(:email, 'must be from a government domain')
+    @user.errors.add(:email, "must be from a government domain. If you're having trouble signing up, <a href='/help/new'>contact us</a>.")
   end
 
   def return_user_to_registration_page

--- a/app/views/layouts/_form_errors.html.erb
+++ b/app/views/layouts/_form_errors.html.erb
@@ -5,7 +5,7 @@
       <div class="govuk-error-summary__body">
         <ul class="govuk-list govuk-error-summary__list">
           <% resource.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
+            <li><%= message.html_safe %></li>
           <% end %>
         </ul>
       </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,13 +1,4 @@
-<% if resource.errors.any? %>
-  <div class="govuk-error-summary">
-    <h2 class="govuk-error-summary__title">There is a problem</h2>
-    <div class="govuk-error-summary__body">
-      <ul class="govuk-list">
-        <li>Only government organisations can sign up to GovWifi. If you're having trouble signing up, <%= link_to "contact us", signing_up_new_help_path, class: 'govuk-link' %>.</li>
-      </ul>
-    </div>
-  </div>
-<% end %>
+<%= render "layouts/form_errors", resource: resource %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,8 +5,7 @@ en:
         user:
           attributes:
             email:
-              taken: " is already invited, or already registered with \n
-              another organisation."
+              taken: " is already associated with an account. If you can't sign in, <a href='/users/password/new'>reset your password</a>."
               invalid: " must be a valid email address"
         organisation:
           attributes:

--- a/spec/features/invite_existing_user_spec.rb
+++ b/spec/features/invite_existing_user_spec.rb
@@ -21,7 +21,7 @@ describe 'inviting a user that has already signed up' do
         click_on "Send invitation email"
       }.to change { User.count }.by(0)
       expect(InviteUseCaseSpy.invite_count).to eq(0)
-      expect(page).to have_content("Email is already invited, or already registered with another organisation")
+      expect(page).to have_content("Email is already associated with an account. If you can't sign in, reset your password")
     end
 
     context 'when betty signs into their account after the confirmed user tried to invite them' do
@@ -67,7 +67,7 @@ describe 'inviting a user that has already signed up' do
 
       it "does not send an invitation to an existing user" do
         expect(InviteUseCaseSpy.invite_count).to eq(0)
-        expect(page).to have_content("Email is already invited, or already registered with another organisation")
+        expect(page).to have_content("Email is already associated with an account. If you can't sign in, reset your password")
       end
 
       context 'when claire visits the confirmation link after the confirmed user tried to invite them' do

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -56,7 +56,7 @@ describe 'Sign up as an organisation' do
       let(:email) { 'someone@google.com' }
 
       it 'tells me my email is not valid' do
-        expect(page).to have_content("Only government organisations can sign up to GovWifi. If you're having trouble signing up, contact us.")
+        expect(page).to have_content("Email must be from a government domain. If you're having trouble signing up, contact us.")
       end
 
       it 'provides a link to a support form' do
@@ -71,7 +71,7 @@ describe 'Sign up as an organisation' do
       let(:email) { '' }
 
       it 'tells me my email is not valid' do
-        expect(page).to have_content("Only government organisations can sign up to GovWifi. If you're having trouble signing up, contact us.")
+        expect(page).to have_content("Email must be from a government domain. If you're having trouble signing up, contact us.")
       end
     end
 
@@ -153,6 +153,16 @@ describe 'Sign up as an organisation' do
 
     it 'tells the user the email is already confirmed' do
       expect(page).to have_content 'Email was already confirmed'
+    end
+  end
+
+  context 'with an already registered email' do
+    let(:email) { 'george@gov.uk' }
+    before { sign_up_for_account(email: email) }
+
+    it 'will tell the user the email is already in use' do
+      sign_up_for_account(email: email)
+      expect(page).to have_content("Email is already associated with an account. If you can't sign in, reset your password")
     end
   end
 end

--- a/spec/features/team/invite_a_team_member_spec.rb
+++ b/spec/features/team/invite_a_team_member_spec.rb
@@ -71,7 +71,7 @@ describe "Invite a team member" do
             click_on "Send invitation email"
           }.to change { User.count }.by(0)
           expect(InviteUseCaseSpy.invite_count).to eq(0)
-          expect(page).to have_content("Email is already invited, or already registered with another organisation")
+          expect(page).to have_content("Email is already associated with an account. If you can't sign in, reset your password")
         end
       end
 


### PR DESCRIPTION
Empty or invalid email domain:
<img width="863" alt="screenshot 2019-03-07 at 12 19 17" src="https://user-images.githubusercontent.com/40758489/53956335-43b93880-40d3-11e9-97cc-9bae8f63cdc4.png">

Already existing email:
<img width="895" alt="screenshot 2019-03-07 at 12 19 23" src="https://user-images.githubusercontent.com/40758489/53956339-461b9280-40d3-11e9-9982-3fc3e7f4f4df.png">