### PR TITLE
Format date in the unconfirmed user list in super admin

### DIFF
--- a/app/views/admin/manage_users/index.html.erb
+++ b/app/views/admin/manage_users/index.html.erb
@@ -15,7 +15,7 @@
           <%= user.email %>
         </td>
         <td class="govuk-table__cell govuk-!-width-one-third" scope="row">
-          <%= user.created_at %>
+          <%= user.created_at.strftime('%e %b %Y') %>
         </td>
       </tr>
     <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,6 +33,16 @@ user = organisation.users.create(
   )
 end
 
+2.times do
+  User.create(
+    email: Faker::Name.first_name + "@gov.uk",
+    password: "password",
+    name: Faker::Name.name,
+    confirmed_at: nil,
+    organisation: organisation
+  )
+end
+
 location_1 = Location.create!(
   address: 'Momentum Centre, London',
   postcode: 'SE10SX',


### PR DESCRIPTION
**WHY:**
Better to change the `created_at` time to a more human readable format.

**IN THIS PR:**
- Add unconfirmed users to the `seeds.rb` file
- Use `strftime` method to format the time in the `index.html.erb`.

------------------------------------------------------------------------------------------------------

**BEFORE:**

<img width="1002" alt="Screenshot 2019-03-12 at 16 31 00" src="https://user-images.githubusercontent.com/32823756/54218098-cfbccd00-44e4-11e9-9162-f893d09c2a57.png">

------------------------------------------------------------------------------------------------------

**AFTER:**

<img width="997" alt="Screenshot 2019-03-12 at 16 31 12" src="https://user-images.githubusercontent.com/32823756/54218119-d8150800-44e4-11e9-8379-67111ede5b08.png">

------------------------------------------------------------------------------------------------------

**Any suggestions/feedback would be appreciated.**