### PR TITLE
Allow super admin to delete an unconfirmed user

### DIFF
--- a/app/controllers/admin/manage_users_controller.rb
+++ b/app/controllers/admin/manage_users_controller.rb
@@ -2,4 +2,9 @@ class Admin::ManageUsersController < AdminController
   def index
     @all_unconfirmed_users = User.where(confirmed_at: nil)
   end
+
+  def destroy
+    user = User.find_by(id: params.fetch(:id))
+    user.destroy
+  end
 end

--- a/app/controllers/admin/manage_users_controller.rb
+++ b/app/controllers/admin/manage_users_controller.rb
@@ -6,5 +6,6 @@ class Admin::ManageUsersController < AdminController
   def destroy
     user = User.find_by(id: params.fetch(:id))
     user.destroy
+    redirect_to admin_manage_users_path, notice: "Unconfirmed user has been removed"
   end
 end

--- a/app/views/admin/manage_users/_confirm_remove_unconfirmed_user.html.erb
+++ b/app/views/admin/manage_users/_confirm_remove_unconfirmed_user.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-error-summary">
+  <h2 class="govuk-error-summary__title">
+    Are you sure you want to delete this unconfirmed user?
+  </h2>
+  <div class="govuk-error-summary__body">
+    <%= button_to "Yes, remove the user", admin_manage_user_path(params[:id]), method: :delete, class: "govuk-button red-button" %>
+  </div>
+</div>

--- a/app/views/admin/manage_users/index.html.erb
+++ b/app/views/admin/manage_users/index.html.erb
@@ -1,3 +1,5 @@
+<%= render "confirm_remove_unconfirmed_user" if params[:user_to_remove] %>
+
 <h1 class="govuk-heading-l">Manage Users</h1>
 
 <table class="govuk-table">
@@ -6,6 +8,7 @@
       <tr class="govuk-table__row">
         <th class="govuk-table__header govuk-!-width-one-third">Email</th>
         <th class="govuk-table__header govuk-!-width-one-third">Created at</th>
+        <th class="govuk-table__header govuk-!-width-one-third"></th>
       </tr>
     </thead>
   <tbody class="govuk-table__body">
@@ -16,6 +19,9 @@
         </td>
         <td class="govuk-table__cell govuk-!-width-one-third" scope="row">
           <%= user.created_at.strftime('%e %b %Y') %>
+        </td>
+        <td class="govuk-table__cell govuk-!-width-one-third" scope="row">
+          <%= link_to 'Remove user', admin_manage_users_path(id: user.id, user_to_remove: true), class: "govuk-link" %>
         </td>
       </tr>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,7 @@ Rails.application.routes.draw do
     resources :organisations, only: %i[index show destroy]
     resources :custom_organisations, only: %i[index create destroy]
     resources :authorised_email_domains, only: %i[index new create destroy]
-    resources :manage_users, only: %i[index]
+    resources :manage_users, only: %i[index destroy]
   end
 
   %w( 404 422 500 ).each do |code|

--- a/spec/features/super_admin/delete_an_unconfirmed_user_spec.rb
+++ b/spec/features/super_admin/delete_an_unconfirmed_user_spec.rb
@@ -1,0 +1,25 @@
+require 'support/notifications_service'
+
+describe 'deleting an unconfirmed user' do
+  include_examples 'notifications service'
+
+  let!(:admin_user) { create(:user, super_admin: true) }
+  let!(:unconfirmed_user) { create(:user, confirmed_at: nil) }
+
+  context 'when visiting the manage users page' do
+    before do
+      sign_in_user admin_user
+      visit admin_manage_users_path
+      click_on "Remove user"
+    end
+
+    it 'prompts with a flash message to remove the user' do
+      expect(page).to have_content("Are you sure you want to delete this unconfirmed user")
+      expect(page).to have_button("Yes, remove the user")
+    end
+
+    it "deletes the user" do
+      expect { click_on "Yes, remove the user" }.to change { User.count }.by(-1)
+    end
+  end
+end

--- a/spec/requests/unconfirmed_users/delete_spec.rb
+++ b/spec/requests/unconfirmed_users/delete_spec.rb
@@ -1,0 +1,34 @@
+describe "DELETE /admin_manage_users/:id", type: :request do
+  before do
+    stub_request(:post, "https://api.notifications.service.gov.uk/v2/notifications/email").
+    to_return(status: 200, body: "{}", headers: {})
+  end
+
+  let!(:unconfirmed_user) { create(:user, confirmed_at: nil) }
+
+  context "when the user is a super admin" do
+    before do
+      https!
+      sign_in_user(create(:user, super_admin: true))
+    end
+
+    it "deletes the unconfirmed user" do
+      expect {
+        delete admin_manage_user_path(unconfirmed_user)
+      }.to change { User.count }.by(-1)
+    end
+  end
+
+  context "when the user is not super admin" do
+    before do
+      https!
+      sign_in_user(create(:user, super_admin: false))
+    end
+
+    it "does not delete the email domain" do
+      expect {
+        delete admin_manage_user_path(unconfirmed_user)
+      }.to change { User.count }.by(0)
+    end
+  end
+end


### PR DESCRIPTION
**WHY:**
We've encountered a frequent problem:
- A user begins the sign up for the admin portal and realises that their organisation already has an account.
- They ask their network engineers to invite them to the organisation's account.
- Their network engineers login to the account and try invite to  their colleague.
-  However, their colleague is already in the database (as an unconfirmed user) and so cannot be invited to the admin platform. This shows as an error message to the network engineers.
- They then email support.
- A way to correct this is to delete the unconfirmed user directly from the database, and then email them explaining that they can now be invited.

There is a need for this to be solved by a non-technical person with no direct access to the database.

------------------------------------------------------------------------------------------------------

**IN THIS PR:**
- Add a delete functionality to the manage users page.

#### **EXAMPLE: Deleting test user: `travis@gov.uk`**
**STEP ONE:**

![Screenshot 2019-03-15 at 11 43 07](https://user-images.githubusercontent.com/32823756/54429626-f82d0d00-4718-11e9-8aad-56263418d09f.png)

------------------------------------------------------------------------------------------------------

**STEP TWO:**

![Screenshot 2019-03-15 at 11 43 32](https://user-images.githubusercontent.com/32823756/54429642-05e29280-4719-11e9-9cc4-546bdc98ce93.png)

------------------------------------------------------------------------------------------------------

**STEP THREE:**

![Screenshot 2019-03-15 at 11 43 42](https://user-images.githubusercontent.com/32823756/54429669-10049100-4719-11e9-8a22-4c85e9a12e55.png)

------------------------------------------------------------------------------------------------------

**STILL TO DO:**
- Make the flash message more descriptive.

![Screenshot 2019-03-15 at 11 43 32](https://user-images.githubusercontent.com/32823756/54429791-683b9300-4719-11e9-8b9a-cfa5f7568082.png)

The flash message doesn't make it clear which user is about to be deleted. 
Although the message can be altered to be more descriptive by passing the user's email as params in the URL, this is regarded as exposing PII which is not allowed in this project.

**Any suggestions/feedback on this would be appreciated.**