### PR TITLE
Prevent bad emails being submitted to Zendesk

### DIFF
--- a/app/models/support_form.rb
+++ b/app/models/support_form.rb
@@ -3,5 +3,6 @@ class SupportForm
 
   attr_accessor :name, :details, :email, :organisation, :phone, :subject, :choice
 
-  validates :details, :email, presence: true
+  validates :details, presence: true
+  validates :email, presence: true, format: { with: Devise.email_regexp, message: "Email is not a valid email address" }
 end

--- a/app/models/support_form.rb
+++ b/app/models/support_form.rb
@@ -4,5 +4,5 @@ class SupportForm
   attr_accessor :name, :details, :email, :organisation, :phone, :subject, :choice
 
   validates :details, presence: true
-  validates :email, presence: true, format: { with: Devise.email_regexp, message: "Email is not a valid email address" }
+  validates :email, presence: true, format: { with: Devise.email_regexp, message: " is not a valid email address" }
 end

--- a/spec/features/contact_us_when_not_signed_in_spec.rb
+++ b/spec/features/contact_us_when_not_signed_in_spec.rb
@@ -98,7 +98,7 @@ describe 'Contact us when not signed in' do
       visit signing_up_new_help_path
       fill_in 'Your email address', with: email
       fill_in 'Tell us a bit more about your issue', with: details
-      click_on('Submit')
+      expect { click_on('Submit') }.to_not change { support_tickets.count }
     end
 
     context 'with blank details' do
@@ -122,7 +122,7 @@ describe 'Contact us when not signed in' do
         let(:email) { 'test@' }
 
         it 'does not submit the form' do
-          expect(page).to have_content 'Email is incorrect'
+          expect(page).to have_content 'Email is not a valid email address'
         end
       end
 
@@ -130,7 +130,7 @@ describe 'Contact us when not signed in' do
         let(:email) { 'test@ gov .uk' }
 
         it 'does not submit the form' do
-          expect(page).to have_content 'Email is incorrect'
+          expect(page).to have_content 'Email is not a valid email address'
         end
       end
 
@@ -138,7 +138,7 @@ describe 'Contact us when not signed in' do
         let(:email) { 'testgov.uk' }
 
         it 'does not submit the form' do
-          expect(page).to have_content 'Email is incorrect'
+          expect(page).to have_content 'Email is not a valid email address'
         end
       end
     end

--- a/spec/features/contact_us_when_not_signed_in_spec.rb
+++ b/spec/features/contact_us_when_not_signed_in_spec.rb
@@ -98,7 +98,7 @@ describe 'Contact us when not signed in' do
       visit signing_up_new_help_path
       fill_in 'Your email address', with: email
       fill_in 'Tell us a bit more about your issue', with: details
-      expect { click_on('Submit') }.to_not change { support_tickets.count }
+      expect { click_on('Submit') }.to_not change(support_tickets, :count)
     end
 
     context 'with blank details' do

--- a/spec/features/contact_us_when_not_signed_in_spec.rb
+++ b/spec/features/contact_us_when_not_signed_in_spec.rb
@@ -1,137 +1,162 @@
 describe 'Contact us when not signed in' do
   include_context 'with a mocked support tickets client'
 
+  let(:email) { 'george@gov.uk' }
+  let(:name) { 'George' }
+  let(:details) { 'I have an issue' }
+
+  before do
+    ENV['ZENDESK_API_ENDPOINT'] = 'https://example-company.zendesk.com/api/v2/'
+    ENV['ZENDESK_API_USER'] = 'zd-api-user@example-company.co.uk'
+    ENV['ZENDESK_API_TOKEN'] = 'abcdefggfedcba'
+    visit new_help_path
+  end
+
   context 'navigating via links' do
-    let(:email) { 'george@gov.uk' }
-    let(:name) { 'George' }
-    let(:details) { 'I have an issue' }
-
-    before do
-      ENV['ZENDESK_API_ENDPOINT'] = 'https://example-company.zendesk.com/api/v2/'
-      ENV['ZENDESK_API_USER'] = 'zd-api-user@example-company.co.uk'
-      ENV['ZENDESK_API_TOKEN'] = 'abcdefggfedcba'
-      visit new_help_path
-    end
-
     it 'shows the user the not signed in support page' do
       expect(page).to have_content 'How can we help?'
     end
+  end
 
-    context 'submits a support ticket' do
-      it 'when having trouble signing up' do
-        choose 'I\'m having trouble signing up'
-        click_on('Continue')
-        fill_in 'Your email address', with: email
-        fill_in 'Tell us a bit more about your issue', with: details
-        click_on('Submit')
-        expect(page).to have_content 'Your support request has been submitted.'
-      end
-
-      it 'when something is wrong with their admin account' do
-        choose 'Something\'s wrong with my admin account'
-        click_on('Continue')
-        expect(page).to have_content 'Something’s wrong with my admin account'
-        fill_in 'Your email address', with: email
-        fill_in 'Tell us a bit more about your issue', with: details
-        click_on('Submit')
-        expect(page).to have_content 'Your support request has been submitted.'
-      end
-
-      it 'when there is a question or feedback' do
-        choose 'Ask a question or leave feedback'
-        click_on('Continue')
-        fill_in 'Your message', with: details
-        fill_in 'Your email address', with: email
-        click_on('Submit')
-        expect(page).to have_content 'Your support request has been submitted.'
-      end
+  context 'submits a support ticket' do
+    it 'when having trouble signing up' do
+      choose 'I\'m having trouble signing up'
+      click_on('Continue')
+      fill_in 'Your email address', with: email
+      fill_in 'Tell us a bit more about your issue', with: details
+      click_on('Submit')
+      expect(page).to have_content 'Your support request has been submitted.'
     end
 
-    context 'checks the email is actually sent' do
-      it 'signing up email sent' do
-        expect {
-          visit signing_up_new_help_path
-          fill_in 'Your email address', with: email
-          fill_in 'Tell us a bit more about your issue', with: details
-          click_on 'Submit'
-        }.to change {
-          support_tickets.count
-        }.by(1)
-      end
+    it 'when something is wrong with their admin account' do
+      choose 'Something\'s wrong with my admin account'
+      click_on('Continue')
+      expect(page).to have_content 'Something’s wrong with my admin account'
+      fill_in 'Your email address', with: email
+      fill_in 'Tell us a bit more about your issue', with: details
+      click_on('Submit')
+      expect(page).to have_content 'Your support request has been submitted.'
+    end
 
-      it 'existing account email sent' do
-        expect {
-          visit signing_up_new_help_path
-          fill_in 'Your email address', with: email
-          fill_in 'Tell us a bit more about your issue', with: details
-          click_on 'Submit'
-        }.to change {
-          support_tickets.count
-        }.by(1)
-      end
+    it 'when there is a question or feedback' do
+      choose 'Ask a question or leave feedback'
+      click_on('Continue')
+      fill_in 'Your message', with: details
+      fill_in 'Your email address', with: email
+      click_on('Submit')
+      expect(page).to have_content 'Your support request has been submitted.'
+    end
+  end
 
-      it 'feedback email sent' do
-        expect {
-          visit feedback_new_help_path
-          fill_in 'Your email address', with: email
-          fill_in 'Your message', with: details
-          click_on 'Submit'
-        }.to change {
-          support_tickets.count
-        }.by(1)
-      end
-
-      it 'records the email' do
+  context 'checks the email is actually sent' do
+    it 'signing up email sent' do
+      expect {
         visit signing_up_new_help_path
         fill_in 'Your email address', with: email
         fill_in 'Tell us a bit more about your issue', with: details
         click_on 'Submit'
-
-        expect(support_tickets.last[:requester][:email])
-          .to eq email
-      end
-
-      it 'does not send an email if the details and or email is blank' do
-        visit signing_up_new_help_path
-        click_on 'Submit'
-        expect(support_tickets).to be_empty
-      end
+      }.to change {
+        support_tickets.count
+      }.by(1)
     end
 
-    context 'when a user leaves the details field blank' do
-      it 'having trouble signing up' do
+    it 'existing account email sent' do
+      expect {
         visit signing_up_new_help_path
-        click_on('Submit')
-        expect(page).to have_content 'Details can\'t be blank'
-      end
+        fill_in 'Your email address', with: email
+        fill_in 'Tell us a bit more about your issue', with: details
+        click_on 'Submit'
+      }.to change {
+        support_tickets.count
+      }.by(1)
+    end
 
-      it 'something wrong with their admin account' do
-        visit existing_account_new_help_path
-        click_on('Submit')
-        expect(page).to have_content 'Details can\'t be blank'
-      end
-
-      it 'leaving feedback' do
+    it 'feedback email sent' do
+      expect {
         visit feedback_new_help_path
-        click_on('Submit')
+        fill_in 'Your email address', with: email
+        fill_in 'Your message', with: details
+        click_on 'Submit'
+      }.to change {
+        support_tickets.count
+      }.by(1)
+    end
+
+    it 'records the email' do
+      visit signing_up_new_help_path
+      fill_in 'Your email address', with: email
+      fill_in 'Tell us a bit more about your issue', with: details
+      click_on 'Submit'
+
+      expect(support_tickets.last[:requester][:email])
+        .to eq email
+    end
+  end
+
+  context 'incorrectly filled out form' do
+    before do
+      visit signing_up_new_help_path
+      fill_in 'Your email address', with: email
+      fill_in 'Tell us a bit more about your issue', with: details
+      click_on('Submit')
+    end
+
+    context 'with blank details' do
+      let(:details) { '' }
+
+      it 'does not submit the form' do
         expect(page).to have_content 'Details can\'t be blank'
       end
     end
-  end
 
-  context 'navigating directly to root/help path' do
-    before { visit '/help' }
+    context 'with blank email' do
+      let(:email) { '' }
 
-    it 'shows the user the not signed in support page' do
-      expect(page).to have_content 'How can we help?'
+      it 'does not submit the form' do
+        expect(page).to have_content 'Email can\'t be blank'
+      end
+    end
+
+    context 'with incorrect email formats' do
+      context 'without a subdomain' do
+        let(:email) { 'test@' }
+
+        it 'does not submit the form' do
+          expect(page).to have_content 'Email is incorrect'
+        end
+      end
+
+      context 'with random whitespace' do
+        let(:email) { 'test@ gov .uk' }
+
+        it 'does not submit the form' do
+          expect(page).to have_content 'Email is incorrect'
+        end
+      end
+
+      context 'without an @ symbol' do
+        let(:email) { 'testgov.uk' }
+
+        it 'does not submit the form' do
+          expect(page).to have_content 'Email is incorrect'
+        end
+      end
     end
   end
+end
 
-  context 'navigating directly to signed-in help path' do
-    before { visit '/help/new/signed_in' }
+context 'navigating directly to root/help path' do
+  before { visit '/help' }
 
-    it 'shows the user the not signed in support page' do
-      expect(page).to have_content 'How can we help?'
-    end
+  it 'shows the user the not signed in support page' do
+    expect(page).to have_content 'How can we help?'
+  end
+end
+
+context 'navigating directly to signed-in help path' do
+  before { visit '/help/new/signed_in' }
+
+  it 'shows the user the not signed in support page' do
+    expect(page).to have_content 'How can we help?'
   end
 end


### PR DESCRIPTION
A Sentry error was being raised due to bad emails being submitted via the offline support form. Eg `test@gov. uk`.

https://sentry.io/organizations/government-digital-services/issues/937104856/?project=1259357&referrer=slack&statsPeriod=14d

This solution uses Devises email validator that we already use on the User model by virtue of it being a Devise model.

Had to refactor the spec slightly so its a bit hard to see the new specs in the diff. I left a comment to help find the new specs.

![Screenshot 2019-03-18 at 14 43 06](https://user-images.githubusercontent.com/2160769/54538494-439b2180-498c-11e9-97ca-8e8972c88e57.png)
