### PR TITLE
introduce an ERB Linter

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@ coverage
 **/.*
 
 # Allow hidden ruby files
+!.erb-lint.yml
 !.rspec
 !.rubocop.yml
 !.ruby-version

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ coverage
 
 # Allow hidden ruby files
 !.rspec
+!.rubocop.yml
 !.ruby-version
 
 # Ignore host node_modules

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -2,3 +2,8 @@
 linters:
   ErbSafety:
     enabled: true
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,4 @@
+---
+linters:
+  ErbSafety:
+    enabled: true

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,7 +1,12 @@
 ---
+exclude:
+  - '**/node_modules/**/*'
 linters:
   ErbSafety:
     enabled: true
+    exclude:
+      # we exclude this as it uses html_safe deliberately.
+      - '**/app/views/layouts/_form_errors.html.erb'
   Rubocop:
     enabled: true
     rubocop_config:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -7,6 +7,8 @@ linters:
     exclude:
       # we exclude this as it uses html_safe deliberately.
       - '**/app/views/layouts/_form_errors.html.erb'
+  SelfClosingTag:
+    enabled: false
   Rubocop:
     enabled: true
     rubocop_config:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -7,3 +7,17 @@ linters:
     rubocop_config:
       inherit_from:
         - .rubocop.yml
+      Layout/InitialIndentation:
+        Enabled: false
+      Layout/TrailingBlankLines:
+        Enabled: false
+      Naming/FileName:
+        Enabled: false
+      Style/FrozenStringLiteralComment:
+        Enabled: false
+      Metrics/LineLength:
+        Enabled: false
+      Lint/UselessAssignment:
+        Enabled: false
+      Rails/OutputSafety:
+        Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+inherit_gem:
+  govuk-lint: configs/rubocop/all.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM ruby:2.6.1
 ARG BUNDLE_INSTALL_CMD
 
+# required for certain linting tools that read files, such as erb-lint
+ENV LANG 'C.UTF-8'
+
 ENV RACK_ENV development
 ENV DB_USER root
 ENV DB_PASS root

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ end
 
 group :development, :test do
   gem 'byebug', '~> 11'
-  gem 'erb_lint'
+  gem 'erb_lint', require: false
   gem 'listen', '~> 3'
   gem 'pry'
   gem 'rack-mini-profiler', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ end
 
 group :development, :test do
   gem 'byebug', '~> 11'
+  gem 'erb_lint'
   gem 'listen', '~> 3'
   gem 'pry'
   gem 'rack-mini-profiler', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :test do
   gem 'capybara'
   gem 'capybara-screenshot'
   gem 'database_cleaner'
+  gem 'erb_lint', require: false
   gem 'factory_bot_rails', '~> 5.0'
   gem 'faker'
   gem 'govuk-lint', '~> 3'
@@ -39,7 +40,6 @@ end
 
 group :development, :test do
   gem 'byebug', '~> 11'
-  gem 'erb_lint', require: false
   gem 'listen', '~> 3'
   gem 'pry'
   gem 'rack-mini-profiler', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,14 @@ GEM
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.12)
+    better_html (1.0.13)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
     builder (3.2.3)
     byebug (11.0.1)
     capybara (3.14.0)
@@ -96,6 +104,13 @@ GEM
       devise (>= 4.6)
     diff-lcs (1.3)
     docile (1.3.1)
+    erb_lint (0.0.28)
+      activesupport
+      better_html (~> 1.0.7)
+      html_tokenizer
+      rainbow
+      rubocop (~> 0.51)
+      smart_properties
     erubi (1.8.0)
     factory_bot (5.0.0)
       activesupport (>= 4.2.0)
@@ -130,6 +145,7 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     hashdiff (0.3.7)
     hashie (3.6.0)
+    html_tokenizer (0.0.7)
     httparty (0.16.4)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -280,6 +296,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    smart_properties (1.13.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -325,6 +342,7 @@ DEPENDENCIES
   database_cleaner
   devise (~> 4.6.1)
   devise_invitable (~> 2.0.0)
+  erb_lint
   factory_bot_rails (~> 5.0)
   faker
   govuk-lint (~> 3)
@@ -352,4 +370,4 @@ RUBY VERSION
    ruby 2.6.1p33
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ lint-ruby: build
 	$(DOCKER_COMPOSE) run --rm app bundle exec govuk-lint-ruby app lib spec Gemfile*
 lint-sass: build
 	$(DOCKER_COMPOSE) run --rm app bundle exec govuk-lint-sass app/assets/stylesheets
-
+lint-erb: build
+	$(DOCKER_COMPOSE) run --rm app bundle exec erblint --lint-all
 
 test:
 	$(MAKE) build


### PR DESCRIPTION
running: `make lint-erb`

I've purposefully not linked it up to `make lint` yet, as the fixes should come in another PR, lest this PR be made up of 70 file changes.

I've also deliberately disabled `ErbSafety` on a file which uses `html_safe`. While this isn't ideal, it's what is needed.

This also adds a rubocop config that inherits from the GDS styling. This is so other tools (namely erblint) can utilise a common styling.
This inadvertently adds support for running `rubocop`, as well as being able to enable `rubocop` based autofixing in our editors
