### PR TITLE
ensure we bind the IP address when serving in development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,4 @@ ARG RUN_PRECOMPILATION=true
 RUN if [ ${RUN_PRECOMPILATION} = 'true' ]; then \
   ASSET_PRECOMPILATION_ONLY=true RAILS_ENV=production bundle exec rails assets:precompile; \
   fi
-CMD ["bundle", "exec", "rails", "server"]
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]


### PR DESCRIPTION
a recent change to puma means the default bind is 'localhost' instead of '0.0.0.0' for development.
This breaks when running rails inside docker.

move to using '0.0.0.0' as default. This does not affect hosted environments, which already defaults to '0.0.0.0'