### PR TITLE
Lint logout user after inactivity spec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,6 @@ AllCops:
     - spec/features/super_admin/authorised_email_domain_spec.rb
     - spec/features/super_admin/sign_in_as_super_admin_spec.rb
     - spec/features/super_admin/edit_organisation_details_spec.rb
-    - spec/features/logout_user_after_inactivity_spec.rb
     - spec/features/overview/view_overview_page_spec.rb
     - spec/features/authentication/logging_in_after_signing_up_spec.rb
     - spec/features/authentication/lock_user_account_spec.rb

--- a/spec/features/logout_user_after_inactivity_spec.rb
+++ b/spec/features/logout_user_after_inactivity_spec.rb
@@ -1,6 +1,6 @@
 require 'timecop'
 
-describe 'logout users after specific period of inactivity' do
+describe 'Logout users after period of inactivity', type: :feature do
   let(:user) { create(:user) }
 
   context 'when a signed in user has been inactive for 59 minutes' do
@@ -9,6 +9,8 @@ describe 'logout users after specific period of inactivity' do
       visit root_path
       Timecop.travel(Time.now + 59.minutes) { visit root_path }
     end
+
+    after { Timecop.return }
 
     it 'and they navigate to a page' do
       visit team_members_path
@@ -23,6 +25,8 @@ describe 'logout users after specific period of inactivity' do
       visit root_path
       Timecop.travel(Time.now + 1.hour) { visit root_path }
     end
+
+    after { Timecop.return }
 
     it_behaves_like 'not signed in'
 


### PR DESCRIPTION
`spec/features/logout_user_after_inactivity_spec.rb`

Explicitly return timecop.