### PR TITLE
Super admin logs copy

### DIFF
--- a/app/views/logs/_back_link.html.erb
+++ b/app/views/logs/_back_link.html.erb
@@ -1,0 +1,7 @@
+<% if params[:username].present? %>
+  <%= link_to "Search by a different username", username_new_logs_search_path, class: "govuk-back-link" %>
+<% elsif params[:ip].present? %>
+  <%= link_to "Search by a different IP", ip_new_logs_search_path, class: "govuk-back-link" %>
+<% else %>
+  <%= link_to "Search by a different location", location_new_logs_search_path, class: "govuk-back-link" %>
+<% end %>

--- a/app/views/logs/_filtered_results_explanation.html.erb
+++ b/app/views/logs/_filtered_results_explanation.html.erb
@@ -1,0 +1,25 @@
+<div class="govuk-grid-column-two-thirds">
+  <div class="govuk-inset-text govuk-!-margin-top-0">
+    <h4 class="govuk-heading-s">Filtered results</h4>
+
+    <% if !current_user.super_admin? %>
+      <p class="govuk-body">
+        Only logs from your organisation's IPs are shown.
+      </p>
+    <% end %>
+
+    <p class="govuk-body">
+      Both successful and failed authentication logs are shown.
+    </p>
+
+    <% if logs.count >= Gateways::Sessions::MAXIMUM_RESULTS_COUNT %>
+      <p class="govuk-body">
+        Only the 500 most recent logs are shown.
+      </p>
+    <% elsif logs.present? %>
+      <p class="govuk-body">
+        Logs older than two weeks are not shown. If you need more logs, <%= link_to "contact us", signed_in_new_help_path, class: "govuk-link" %>.
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/logs/_filtered_results_explanation.html.erb
+++ b/app/views/logs/_filtered_results_explanation.html.erb
@@ -18,7 +18,13 @@
       </p>
     <% elsif logs.present? %>
       <p class="govuk-body">
-        Logs older than two weeks are not shown. If you need more logs, <%= link_to "contact us", signed_in_new_help_path, class: "govuk-link" %>.
+        Logs older than two weeks are not shown.
+      </p>
+    <% end %>
+
+    <% if logs.present? && !current_user.super_admin? %>
+      <p class="govuk-body">
+        If you need more logs, <%= link_to "contact us", signed_in_new_help_path, class: "govuk-link" %>.
       </p>
     <% end %>
   </div>

--- a/app/views/logs/_filtered_results_explanation.html.erb
+++ b/app/views/logs/_filtered_results_explanation.html.erb
@@ -12,13 +12,13 @@
       Both successful and failed authentication logs are shown.
     </p>
 
+    <p class="govuk-body">
+      Logs older than two weeks are not shown.
+    </p>
+
     <% if logs.count >= Gateways::Sessions::MAXIMUM_RESULTS_COUNT %>
       <p class="govuk-body">
         Only the 500 most recent logs are shown.
-      </p>
-    <% elsif logs.present? %>
-      <p class="govuk-body">
-        Logs older than two weeks are not shown.
       </p>
     <% end %>
 

--- a/app/views/logs/_no_logs_explanation.html.erb
+++ b/app/views/logs/_no_logs_explanation.html.erb
@@ -1,0 +1,26 @@
+<div class="govuk-grid-column-two-thirds">
+  <% if current_user.super_admin? %>
+    <h3 class="govuk-body">
+      If you were expecting to see results, we recommend asking the organisation:
+    </h3>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>If the IPs they entered into the admin portal match their access point IPs exactly?</li>
+      <li>If their access points have the correct RADIUS secret keys?</li>
+      <li>If they have <%= link_to 'browsed the technical documentation?', SITE_CONFIG['organisation_docs_link'], class: "govuk-link" %></li>
+    </ul>
+
+  <% else %>
+    <h3 class="govuk-body">
+      If you were expecting to see results, we recommend:
+    </h3>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>Checking your <%= link_to 'configured IP addresses', ips_path, class: "govuk-link" %> match your authenticator IPs </li>
+      <li>Checking your authenticators have the right RADIUS secret keys</li>
+      <li><%= link_to 'Browsing the technical documentation', SITE_CONFIG['organisation_docs_link'], class: "govuk-link" %></li>
+    </ul>
+
+    <p class="govuk-body"> If you still need help, <%= link_to "contact us", signed_in_new_help_path, class: "govuk-link" %></p>
+  <% end %>
+</div>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,31 +1,11 @@
-<% if params[:username].present? %>
-  <%= link_to "Search by a different username", username_new_logs_search_path, class: "govuk-back-link" %>
-<% elsif params[:ip].present? %>
-  <%= link_to "Search by a different IP", ip_new_logs_search_path, class: "govuk-back-link" %>
-<% else %>
-  <%= link_to "Search by a different location", location_new_logs_search_path, class: "govuk-back-link" %>
-<% end %>
+
+<%= render "logs/back_link", params: params %>
 
 <% if @logs.present? %>
   <h1 class="govuk-heading-l">Found <%= pluralize(@logs.count, "result") %> for "<%= params[:username] || params[:ip] || @location_address %>"</h1>
 
-  <div class="govuk-inset-text">
-    <h4 class="govuk-heading-s">Filtered results</h4>
-    <p class="govuk-body">
-      Only requests from your organisation's IPs are shown.
+  <%= render 'logs/filtered_results_explanation', logs: @logs %>
 
-    <p class="govuk-body">
-      <% if @logs.count >= Gateways::Sessions::MAXIMUM_RESULTS_COUNT %>
-        Only the 500 most recent logs are shown.
-      <% else %>
-        Results older than two weeks are not shown.
-      <% end %>
-    </p>
-
-    <p class="govuk-body">
-      If you need more logs, <%= link_to "contact us", signed_in_new_help_path, class: "govuk-link" %>.
-    </p>
-  </div>
   <table class="govuk-table">
     <caption class="govuk-table__caption"></caption>
     <thead class="govuk-table__head">
@@ -63,22 +43,7 @@
       <% end %>
     </h1>
 
-    <div class="govuk-grid-column-two-thirds">
-      <div class="govuk-inset-text govuk-!-margin-top-0">
-        <h4 class="govuk-heading-s">Filtered results</h4>
-        <p class="govuk-body">
-          Only requests from your organisation's IPs are shown.
-        </p>
-
-        <p class="govuk-body">
-          Both successful and failed authentications are shown.
-        </p>
-
-        <p class="govuk-body">
-          Results older than two weeks are not shown.
-        </p>
-      </div>
-    </div>
+    <%= render 'logs/filtered_results_explanation', logs: @logs %>
 
     <div class="govuk-grid-column-two-thirds">
       <h3 class="govuk-body">

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,4 +1,3 @@
-
 <%= render "logs/back_link", params: params %>
 
 <% if @logs.present? %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -45,18 +45,6 @@
 
     <%= render 'logs/filtered_results_explanation', logs: @logs %>
 
-    <div class="govuk-grid-column-two-thirds">
-      <h3 class="govuk-body">
-        If you were expecting to see results, we recommend:
-      </h3>
-
-      <ul class="govuk-list govuk-list--bullet">
-        <li>Checking your <%= link_to 'configured IP addresses', ips_path, class: "govuk-link" %> match your authenticator IPs </li>
-        <li>Checking your authenticators have the right RADIUS secret keys</li>
-        <li><%= link_to 'Browsing the technical documentation', SITE_CONFIG['organisation_docs_link'], class: "govuk-link" %></li>
-      </ul>
-
-      <p class="govuk-body"> If you still need help, <%= link_to "contact us", signed_in_new_help_path, class: "govuk-link" %></p>
-    </div>
+    <%= render 'logs/no_logs_explanation' %>
   </div>
 <% end %>


### PR DESCRIPTION
When the super admin views logs, the copy was geared towards organisations and made no sense to super admins.

This PR:
- removes organisation specific copy from the super admin view
- gives super admin advice on how to solve the problem
- uses partials to make the view file easier to comprehend

**SUPER ADMIN**
![Screenshot 2019-03-26 at 16 53 16](https://user-images.githubusercontent.com/2160769/55016977-bab56300-4fe7-11e9-9498-638931cabebe.png)
![Screenshot 2019-03-26 at 16 53 29](https://user-images.githubusercontent.com/2160769/55016978-bab56300-4fe7-11e9-8d9d-e92bda053861.png)

**ORGANISATION**
![Screenshot 2019-03-26 at 16 52 45](https://user-images.githubusercontent.com/2160769/55016992-be48ea00-4fe7-11e9-8012-5e532dfb5ad3.png)
![Screenshot 2019-03-26 at 16 52 56](https://user-images.githubusercontent.com/2160769/55016993-be48ea00-4fe7-11e9-817d-9725c28dc465.png)


