### PR TITLE
Fix whitelist organisation error

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -10,7 +10,7 @@ class Organisation < ApplicationRecord
 
   def validate_in_register?
     unless Organisation.fetch_organisations_from_register.include?(name)
-      errors.add(:base, "#{name} isn't a whitelisted organisation")
+      errors.add(:name, "isn't whitelisted")
     end
   end
 

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -188,4 +188,16 @@ describe 'Sign up as an organisation' do
       expect(page).to have_content("Email is already associated with an account. If you can't sign in, reset your password")
     end
   end
+
+  context 'when no whitelisted organisation is selected' do
+    let(:non_whitelist_org_name) {'Not Whitelisted'}
+
+    before { sign_up_for_account }
+
+    it 'will tell the user the organisation is not whitelisted' do
+      update_user_details(organisation_name: non_whitelist_org_name)
+      expect(page).to have_content("name isn't whitelisted")
+    end
+
+  end
 end

--- a/spec/features/support/sign_up_helpers.rb
+++ b/spec/features/support/sign_up_helpers.rb
@@ -16,7 +16,7 @@ def update_user_details(
 
   visit confirmation_email_link
 
-  select organisation_name, from: 'Organisation name'
+  select organisation_name, from: 'Organisation name' if find_field('Organisation name').has_content?(organisation_name)
 
   fill_in 'Service email', with: service_email
   fill_in 'Your name', with: name


### PR DESCRIPTION
**WHY:**
When a user doesn't select an organisation from the drop down list of whitelisted organisations and tries to finish creating their account at the confirmation stage. The page would display an error that `Organisation base isn't a whitelisted organisation`. 

This is a Rails error message that hasn't displayed the whitelist error as intended/desired.

The method by which this error message is added should be changed so that a better worded message would be shown to the user.

This is one approach to making the errors we display to users more readable and understandable.
Another approach can be seen in PR #586

**IN THIS PR:**
- Change the method from adding the error to `:base` to adding it to the `:name` attribute.

- Edit the select functionality in the signup helper method: `update_user_details` to be conditional. This needed to be done as the capybara would error if it couldn't select anything from the drop down and testing the display of the whitelist error message depends on no selection being made before submission.

**BEFORE:**

<img width="1018" alt="Screenshot 2019-03-28 at 11 30 44" src="https://user-images.githubusercontent.com/32823756/55154571-0cc3c900-514d-11e9-8b0e-0ac685620782.png">

**AFTER:**

<img width="1042" alt="Screenshot 2019-03-28 at 11 31 29" src="https://user-images.githubusercontent.com/32823756/55154581-14836d80-514d-11e9-8097-bffa405a52db.png">


**Any feedback/suggestions would be appreciated.**