### PR TITLE
Don't display whitelist error when no organisation is selected

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -6,7 +6,7 @@ class Organisation < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :service_email, presence: true
-  validate :validate_in_register?
+  validate :validate_in_register?, unless: Proc.new { |org| org.name.blank? }
 
   def validate_in_register?
     unless Organisation.fetch_organisations_from_register.include?(name)

--- a/app/views/layouts/_form_errors.html.erb
+++ b/app/views/layouts/_form_errors.html.erb
@@ -5,7 +5,7 @@
       <div class="govuk-error-summary__body">
         <ul class="govuk-list govuk-error-summary__list">
           <% resource.errors.full_messages.each do |message| %>
-            <li><%= message.html_safe %></li>
+            <li id="error-message"><%= message.html_safe %></li>
           <% end %>
         </ul>
       </div>

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -188,4 +188,24 @@ describe 'Sign up as an organisation' do
       expect(page).to have_content("Email is already associated with an account. If you can't sign in, reset your password")
     end
   end
+
+  context 'when no organisation has been selected' do
+    let(:org_name_left_blank) { '' }
+
+    before { sign_up_for_account }
+
+    it 'will tell the user the organisation name cannot be left blank' do
+      update_user_details(organisation_name: org_name_left_blank)
+      within('div#error-summary') do
+        expect(page).to have_content("Organisation name can't be blank")
+      end
+    end
+
+    it 'will not display a non-whitelist error for a blank entry' do
+      update_user_details(organisation_name: org_name_left_blank)
+      within('div#error-summary') do
+        expect(page).to_not have_content("isn't a whitelisted organisation")
+      end
+    end
+  end
 end

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -194,17 +194,10 @@ describe 'Sign up as an organisation' do
 
     before { sign_up_for_account }
 
-    it 'will tell the user the organisation name cannot be left blank' do
+    it 'displays one error message that the name cannot be left blank' do
       update_user_details(organisation_name: org_name_left_blank)
       within('div#error-summary') do
-        expect(page).to have_content("Organisation name can't be blank")
-      end
-    end
-
-    it 'will not display a non-whitelist error for a blank entry' do
-      update_user_details(organisation_name: org_name_left_blank)
-      within('div#error-summary') do
-        expect(page).to_not have_content("isn't a whitelisted organisation")
+        expect(page).to have_selector("li#error-message", count: 1, text: "Organisation name can't be blank")
       end
     end
   end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -46,5 +46,39 @@ describe Organisation do
         expect { create(:organisation, name: 'Some invalid organisation name') }.to raise_error ActiveRecord::RecordInvalid
       end
     end
+
+    context 'when adding an organisation name at account confirmation' do
+      let(:organisation) { build(:organisation, name: organisation_name) }
+
+      context 'when organisation name is left blank' do
+        let(:organisation_name) { '' }
+
+        it 'is invalid' do
+          expect(organisation).not_to be_valid
+        end
+
+        it 'explains why it is invalid' do
+          organisation.valid?
+          expect(organisation.errors.full_messages).to eq([
+            "Name can't be blank"
+          ])
+        end
+      end
+
+      context 'when organisation name is not in register' do
+        let(:organisation_name) { 'Some Name' }
+
+        it 'is invalid' do
+          expect(organisation).not_to be_valid
+        end
+
+        it 'calls this method' do
+          organisation.valid?
+          expect(organisation.errors.full_messages).to eq([
+            "#{organisation.name} isn't a whitelisted organisation"
+          ])
+        end
+      end
+    end
   end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -42,42 +42,32 @@ describe Organisation do
     end
 
     context 'when my organisation is not in the GovUk register' do
+      let(:organisation) { build(:organisation, name: 'Some invalid organisation name') }
+
       it 'is not valid' do
-        expect { create(:organisation, name: 'Some invalid organisation name') }.to raise_error ActiveRecord::RecordInvalid
+        expect(organisation).not_to be_valid
+      end
+
+      it 'explains why it is invalid' do
+        organisation.valid?
+        expect(organisation.errors.full_messages).to eq([
+          "#{organisation.name} isn't a whitelisted organisation"
+        ])
       end
     end
 
-    context 'when adding an organisation name at account confirmation' do
-      let(:organisation) { build(:organisation, name: organisation_name) }
+    context 'when organisation name is left blank' do
+      let(:organisation) { build(:organisation, name: '') }
 
-      context 'when organisation name is left blank' do
-        let(:organisation_name) { '' }
-
-        it 'is invalid' do
-          expect(organisation).not_to be_valid
-        end
-
-        it 'explains why it is invalid' do
-          organisation.valid?
-          expect(organisation.errors.full_messages).to eq([
-            "Name can't be blank"
-          ])
-        end
+      it 'is invalid' do
+        expect(organisation).not_to be_valid
       end
 
-      context 'when organisation name is not in register' do
-        let(:organisation_name) { 'Some Name' }
-
-        it 'is invalid' do
-          expect(organisation).not_to be_valid
-        end
-
-        it 'calls this method' do
-          organisation.valid?
-          expect(organisation.errors.full_messages).to eq([
-            "#{organisation.name} isn't a whitelisted organisation"
-          ])
-        end
+      it 'explains why it is invalid' do
+        organisation.valid?
+        expect(organisation.errors.full_messages).to eq([
+          "Name can't be blank"
+        ])
       end
     end
   end


### PR DESCRIPTION
**WHY:**
When a user doesn't select an organisation from the drop down list of whitelisted organisations and tries to finish creating their account at the confirmation stage. The page would display both these errors: 
- `Organisation name can't be blank`
- `Organisation base isn't a whitelisted organisation`

The organisation name field can only be filled by selecting from the drop-down menu of whitelisted organisations.

The field does not receive/pass any user text inputted directly.

So an instance of a user 'filling in' the field with a name not on the list and an instance of a user leaving the field blank result in the same thing: 
- No organisation is selected and so, no name is received for the organisation name value.
- The subsequent validation of the name value (based on presence) would lead to the `Organisation name can't be blank` error.

Displaying both errors is unneccessary when no organisation has been selected from the list.

**IN THIS PR:**
The `Organisation name can't be blank` error is the only error that would display, if no organisation is selected since the field is not filled unless you select from the list

This is one approach to making the errors we display to users more readable and understandable.

The user should not need to see a whitelist error since there is already an instruction for users on what to do if their organisation is not on the list.

Another approach could be seen in PR: #584 

**BEFORE:**

<img width="1052" alt="Screenshot 2019-03-28 at 12 27 24" src="https://user-images.githubusercontent.com/32823756/55160104-726a8200-515a-11e9-85b2-9a051b40de83.png">

**AFTER:**

<img width="1031" alt="Screenshot 2019-03-28 at 12 27 36" src="https://user-images.githubusercontent.com/32823756/55160113-78f8f980-515a-11e9-8a7b-94ecd1bdb31c.png">

**Any suggestions/feedback would be appreciated.**