### PR TITLE
add analytics paths for MOU uploading

### DIFF
--- a/app/controllers/mou_controller.rb
+++ b/app/controllers/mou_controller.rb
@@ -5,12 +5,20 @@ class MouController < ApplicationController
   end
 
   def create
+    redirect_path = replacing? ? replaced_mou_index_path : created_mou_index_path
     if params[:signed_mou]
       current_organisation.signed_mou.attach(params[:signed_mou])
       flash[:notice] = "MOU uploaded successfully."
     else
       flash[:alert] = "Choose a file before uploading "
+      redirect_path = mou_index_path
     end
-    redirect_to mou_index_path
+    redirect_to redirect_path
+  end
+
+private
+
+  def replacing?
+    current_organisation.signed_mou.attached?
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,13 @@ Rails.application.routes.draw do
       get 'removed', to: 'team_members#index'
     end
   end
-  resources :mou, only: %i[index create]
+
+  resources :mou, only: %i[index create] do
+    collection do
+      get 'created', to: 'mou#index'
+      get 'replaced', to: 'mou#index'
+    end
+  end
   resources :logs, only: %i[index]
 
   resources :logs_searches, path: 'logs/search', only: %i[new index create] do

--- a/spec/features/upload_download_mous_spec.rb
+++ b/spec/features/upload_download_mous_spec.rb
@@ -24,12 +24,38 @@ describe 'Uploading and downloading an MOU', type: :feature do
         click_on 'Upload'
       end
 
-      it 'can upload and download a version of the mou' do
+      it 'can upload a version of the mou' do
         expect(page).to have_content("MOU uploaded successfully.")
       end
 
       it 'displays the download link' do
         expect(page).to have_link("download and view the document.")
+      end
+
+      it 'redirects to "after MOU uploaded" path for analytics' do
+        expect(page).to have_current_path('/mou/created')
+      end
+    end
+
+    context 'when replacing the signed mou' do
+      before do
+        visit mou_index_path
+        attach_file("signed_mou", Rails.root + "spec/fixtures/mou.pdf")
+        click_on 'Upload'
+        attach_file("signed_mou", Rails.root + "spec/fixtures/mou.pdf")
+        click_on 'Replace MOU'
+      end
+
+      it 'can upload a version of the mou' do
+        expect(page).to have_content("MOU uploaded successfully.")
+      end
+
+      it 'displays the download link' do
+        expect(page).to have_link("download and view the document.")
+      end
+
+      it 'redirects to "after MOU uploaded" path for analytics' do
+        expect(page).to have_current_path('/mou/replaced')
       end
     end
   end


### PR DESCRIPTION
### uploading their first MOU
`/mou -> /mou/created`
![image](https://user-images.githubusercontent.com/2099618/55225100-c84a3300-5209-11e9-8b42-ce799f05770b.png)
![image](https://user-images.githubusercontent.com/2099618/55225968-c6816f00-520b-11e9-8ee9-47684febc9f7.png)

### replacing an MOU
`/mou -> /mou/replaced`
![image](https://user-images.githubusercontent.com/2099618/55226003-db5e0280-520b-11e9-9a5b-6ccac01d172f.png)
![image](https://user-images.githubusercontent.com/2099618/55226021-e4e76a80-520b-11e9-8af8-85f7f4a298a0.png)

