### PR TITLE
Alphabetise team list in super admin

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -11,6 +11,7 @@ class Admin::OrganisationsController < AdminController
 
   def show
     @organisation = Organisation.find(params[:id])
+    @team = @organisation.users.order(build_order_query)
     @locations = @organisation.locations.order("address asc")
   end
 
@@ -21,6 +22,13 @@ class Admin::OrganisationsController < AdminController
   end
 
 private
+
+  def build_order_query
+    Arel::Nodes::NamedFunction.new("COALESCE", [
+      User.arel_table['name'],
+      User.arel_table['email']
+    ]).asc
+  end
 
   def sortable_columns
     %w[name created_at active_storage_attachments.created_at]

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -11,7 +11,7 @@ class Admin::OrganisationsController < AdminController
 
   def show
     @organisation = Organisation.find(params[:id])
-    @team = @organisation.users.order(build_order_query)
+    @team = sorted_team_members(@organisation)
     @locations = @organisation.locations.order("address asc")
   end
 
@@ -23,11 +23,10 @@ class Admin::OrganisationsController < AdminController
 
 private
 
-  def build_order_query
-    Arel::Nodes::NamedFunction.new("COALESCE", [
-      User.arel_table['name'],
-      User.arel_table['email']
-    ]).asc
+  def sorted_team_members(organisation)
+    UseCases::Administrator::SortUsers.new(
+      users_gateway: Gateways::OrganisationUsers.new(organisation: organisation)
+    ).execute
   end
 
   def sortable_columns

--- a/app/controllers/team_members_controller.rb
+++ b/app/controllers/team_members_controller.rb
@@ -4,7 +4,7 @@ class TeamMembersController < ApplicationController
   helper_method :sort_column, :sort_direction
 
   def index
-    @team_members = current_organisation.users.order(build_order_query)
+    @team_members = sorted_team_members(current_organisation)
   end
 
   def destroy
@@ -26,11 +26,10 @@ class TeamMembersController < ApplicationController
 
 private
 
-  def build_order_query
-    Arel::Nodes::NamedFunction.new("COALESCE", [
-      User.arel_table['name'],
-      User.arel_table['email']
-    ]).asc
+  def sorted_team_members(organisation)
+    UseCases::Administrator::SortUsers.new(
+      users_gateway: Gateways::OrganisationUsers.new(organisation: organisation)
+    ).execute
   end
 
   def set_user

--- a/app/views/admin/organisations/_team.html.erb
+++ b/app/views/admin/organisations/_team.html.erb
@@ -1,9 +1,9 @@
-<% if organisation.users.any? %>
+<% if team.any? %>
   <table class="govuk-table">
     <thead class="govuk-table__head">
     </thead>
     <tbody class="govuk-table__body">
-      <% organisation.users.each do |user| %>
+      <% team.each do |user| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" scope="row"><%= user.name %></td>
           <td class="govuk-table__cell text-right" scope="row"><%= user.email %></td>

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -23,7 +23,7 @@
     <% end %>
 
     <%= render 'section', heading: 'Team' do %>
-      <%= render 'team', organisation: @organisation %>
+      <%= render 'team', team: @team %>
     <% end %>
 
     <%= render 'section', heading: 'MoU' do %>

--- a/lib/gateways/organisation_users.rb
+++ b/lib/gateways/organisation_users.rb
@@ -1,0 +1,11 @@
+module Gateways
+  class OrganisationUsers
+    def initialize(organisation:)
+      @organisation = organisation
+    end
+
+    def fetch
+      @organisation.users
+    end
+  end
+end

--- a/lib/use_cases/administrator/sort_users.rb
+++ b/lib/use_cases/administrator/sort_users.rb
@@ -1,0 +1,23 @@
+module UseCases
+  module Administrator
+    class SortUsers
+      def initialize(users_gateway:)
+        @users_gateway = users_gateway
+      end
+
+      def execute
+        unsorted_users = @users_gateway.fetch
+        unsorted_users.order(build_order_query)
+      end
+
+    private
+
+      def build_order_query
+        Arel::Nodes::NamedFunction.new("COALESCE", [
+          User.arel_table['name'],
+          User.arel_table['email']
+        ]).asc
+      end
+    end
+  end
+end

--- a/spec/features/super_admin/organisations/view_organisation_page_spec.rb
+++ b/spec/features/super_admin/organisations/view_organisation_page_spec.rb
@@ -6,6 +6,10 @@ describe 'View details of an organisation', type: :feature do
     let(:location_2) { create(:location, organisation: organisation, address: 'Carry Street') }
     let(:location_3) { create(:location, organisation: organisation, address: 'Barry Lane') }
 
+    let!(:user_1) { create(:user, name: "Aardvark", organisation: organisation) }
+    let!(:user_2) { create(:user, name: "Zed", organisation: organisation) }
+    let!(:user_3) { create(:user, name: "", email: "batman@batcave.com", organisation: organisation) }
+
     before do
       create(:user, organisation: organisation)
 
@@ -35,7 +39,7 @@ describe 'View details of an organisation', type: :feature do
 
     it 'shows the number of users' do
       within('#user-count') do
-        expect(page).to have_content('1')
+        expect(page).to have_content('4')
       end
     end
 
@@ -43,6 +47,10 @@ describe 'View details of an organisation', type: :feature do
       organisation.users.each do |user|
         expect(page).to have_content(user.name)
       end
+    end
+
+    it 'lists all team members in alphabetical order' do
+      expect(page.body).to match(/#{user_1.name}.*#{user_3.name}.*#{user_2.email}/m)
     end
 
     it 'shows the number of locations' do

--- a/spec/gateways/organisation_users_spec.rb
+++ b/spec/gateways/organisation_users_spec.rb
@@ -15,6 +15,10 @@ describe Gateways::OrganisationUsers do
     it 'fetches the users for the organisation' do
       expect(gateway.fetch).to eq(result)
     end
+
+    it 'returns an ActiveRecord collection' do
+      expect(gateway.fetch.class.ancestors).to include(ActiveRecord::Relation)
+    end
   end
 
   context 'without users' do

--- a/spec/gateways/organisation_users_spec.rb
+++ b/spec/gateways/organisation_users_spec.rb
@@ -1,0 +1,27 @@
+describe Gateways::OrganisationUsers do
+  subject(:gateway) { described_class.new(organisation: organisation) }
+
+  context 'with users' do
+    let(:organisation) { create(:organisation) }
+    let(:result) do
+      organisation.users
+    end
+
+    before do
+      create_list :user, 3, organisation: organisation
+      create(:user)
+    end
+
+    it 'fetches the users for the organisation' do
+      expect(gateway.fetch).to eq(result)
+    end
+  end
+
+  context 'without users' do
+    let(:organisation) { create(:organisation) }
+
+    it 'returns an empty collection' do
+      expect(gateway.fetch).to eq([])
+    end
+  end
+end

--- a/spec/use_cases/administrator/sort_users_spec.rb
+++ b/spec/use_cases/administrator/sort_users_spec.rb
@@ -1,0 +1,26 @@
+describe UseCases::Administrator::SortUsers do
+  subject(:use_case) { described_class.new(users_gateway: gateway_spy) }
+
+  let(:user_collection_spy) { instance_spy('User::ActiveRecord_Relation', order: nil) }
+  let(:gateway_spy) do
+    instance_spy('Gateways::OrganisationUsers', fetch: user_collection_spy)
+  end
+  let(:valid_order_query) do
+    Arel::Nodes::NamedFunction.new("COALESCE", [
+        User.arel_table['name'],
+        User.arel_table['email']
+      ]).asc
+  end
+
+  before do
+    use_case.execute
+  end
+
+  it 'calls the users gateway' do
+    expect(gateway_spy).to have_received(:fetch)
+  end
+
+  it 'calls order on the collection of users' do
+    expect(user_collection_spy).to have_received(:order).with(valid_order_query)
+  end
+end

--- a/spec/use_cases/administrator/sort_users_spec.rb
+++ b/spec/use_cases/administrator/sort_users_spec.rb
@@ -1,26 +1,40 @@
 describe UseCases::Administrator::SortUsers do
-  subject(:use_case) { described_class.new(users_gateway: gateway_spy) }
+  subject(:use_case) { described_class.new(users_gateway: gateway) }
 
-  let(:user_collection_spy) { instance_spy('User::ActiveRecord_Relation', order: nil) }
-  let(:gateway_spy) do
-    instance_spy('Gateways::OrganisationUsers', fetch: user_collection_spy)
-  end
-  let(:valid_order_query) do
-    Arel::Nodes::NamedFunction.new("COALESCE", [
-        User.arel_table['name'],
-        User.arel_table['email']
-      ]).asc
+  let(:user_collection) { instance_spy('User::ActiveRecord_Relation', order: nil) }
+  let(:gateway) do
+    instance_spy('Gateways::OrganisationUsers', fetch: user_collection)
   end
 
-  before do
-    use_case.execute
+  context 'when calling execute' do
+    let(:valid_order_query) do
+      Arel::Nodes::NamedFunction.new("COALESCE", [
+          User.arel_table['name'],
+          User.arel_table['email']
+        ]).asc
+    end
+
+    before do
+      use_case.execute
+    end
+
+    it 'calls the users gateway' do
+      expect(gateway).to have_received(:fetch)
+    end
+
+    it 'calls order on the collection of users' do
+      expect(user_collection).to have_received(:order).with(valid_order_query)
+    end
   end
 
-  it 'calls the users gateway' do
-    expect(gateway_spy).to have_received(:fetch)
-  end
+  context 'when ordering a collection of users' do
+    let(:user_collection) { User.all }
+    let!(:user_1) { create(:user, name: "Aardvark") }
+    let!(:user_2) { create(:user, name: "Zed") }
+    let!(:user_3) { create(:user, name: nil, email: "batman@batcave.com") }
 
-  it 'calls order on the collection of users' do
-    expect(user_collection_spy).to have_received(:order).with(valid_order_query)
+    it 'orders the users by name and email' do
+      expect(use_case.execute).to eq([user_1, user_3, user_2])
+    end
   end
 end


### PR DESCRIPTION
Alphabetising the list on the "show organisation page" in super admin. Must have been missed off the original task.

Involves a refactor using Clean Architecture to DRY up the code. Not 100% sure this is the right way to do it with CA so welcome feedback.

![Screenshot 2019-04-01 at 11 38 03](https://user-images.githubusercontent.com/2160769/55321874-a7d0e180-5472-11e9-9731-50211415be37.png)
