### PR TITLE
Improve language to help redirect lost end users

### DIFF
--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -3,6 +3,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l">Resend confirmation instructions</h2>
+
+    <%= render "users/shared/end_user_warning" %>
+
     <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, novalidate: '' }) do |f| %>
       <div class="govuk-form-group <%= field_error(resource, :email) %>">
         <%= f.label :email, "Enter your email address", class: "govuk-label" %>

--- a/app/views/users/confirmations/show.html.erb
+++ b/app/views/users/confirmations/show.html.erb
@@ -1,7 +1,9 @@
 <%= render "layouts/form_errors" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Create your account</h2>
+    <h2 class="govuk-heading-l">Create your GovWifi network admin account</h2>
+
+    <%= render "users/shared/end_user_warning" %>
 
     <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
       <%= form_for(resource, as: resource_name, url: users_confirmations_path, html: { method: :put, novalidate: '' }) do |f| %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -2,7 +2,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Reset your password</h2>
+    <h2 class="govuk-heading-l">Reset your GovWifi network admin account password</h2>
+
+    <%= render "users/shared/end_user_warning" %>
 
     <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
       <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, novalidate: '' }) do |f| %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -4,9 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Sign up your organisation to GovWifi</h1>
 
-    <p class="govuk-body">
-      If you are an individual user trying to connect to GovWifi, <%= link_to "follow these instructions.", SITE_CONFIG['end_user_docs_link'], class: "govuk-link" %>
-    </p>
+    <%= render "users/shared/end_user_warning" %>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { novalidate: '' }) do |f| %>
       <div class="govuk-form-group <%= field_error(resource, :email) %>">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -2,7 +2,8 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l">Sign in</h2>
 
-    <p class="govuk-body">If you do not have an account, you can
+    <p class="govuk-body">If you do not have a GovWifi network admin account and
+      want to offer GovWifi in your building, you can
       <%= link_to "create one now.", new_user_registration_path, class: "govuk-link" %>
     </p>
 

--- a/app/views/users/shared/_end_user_warning.html.erb
+++ b/app/views/users/shared/_end_user_warning.html.erb
@@ -1,4 +1,4 @@
 <p class="govuk-body">
   If you are an individual user trying to connect to GovWifi, you are in the wrong place. You can view our
-  <%= link_to "separate instructions on how to connect to GovWifi", "https://www.gov.uk/government/collections/connect-to-govwifi" %>.
+  <%= link_to "separate instructions on how to connect to GovWifi", SITE_CONFIG['end_user_docs_link'], class: "govuk-link" %>.
 </p>

--- a/app/views/users/shared/_end_user_warning.html.erb
+++ b/app/views/users/shared/_end_user_warning.html.erb
@@ -1,0 +1,4 @@
+<p class="govuk-body">
+  If you are an individual user trying to connect to GovWifi, you are in the wrong place. You can view our
+  <%= link_to "separate instructions on how to connect to GovWifi", "https://www.gov.uk/government/collections/connect-to-govwifi" %>.
+</p>

--- a/spec/features/authentication/reset_password_spec.rb
+++ b/spec/features/authentication/reset_password_spec.rb
@@ -11,7 +11,7 @@ describe "Resetting a password", type: :feature do
   it "links to forgot password form" do
     visit root_path
     click_on "Forgot your password?"
-    expect(page).to have_content("Reset your password")
+    expect(page).to have_content("Reset your GovWifi network admin account password")
   end
 
   context "when user does not exist" do

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -92,7 +92,7 @@ describe 'Sign up as an organisation' do
     before do
       sign_up_for_account
       update_user_details(password: '1')
-      expect(page).to have_content 'Create your account'
+      expect(page).to have_content 'Create your GovWifi network admin account'
     end
 
     it_behaves_like 'errors in form'
@@ -121,7 +121,7 @@ describe 'Sign up as an organisation' do
     before do
       sign_up_for_account
       update_user_details(service_email: "")
-      expect(page).to have_content 'Create your account'
+      expect(page).to have_content 'Create your GovWifi network admin account'
     end
 
     it_behaves_like 'errors in form'
@@ -135,7 +135,7 @@ describe 'Sign up as an organisation' do
     before do
       sign_up_for_account
       update_user_details(password: '1')
-      expect(page).to have_content 'Create your account'
+      expect(page).to have_content 'Create your GovWifi network admin account'
     end
 
     it_behaves_like 'errors in form'


### PR DESCRIPTION
Improve the "end user warning" as well as display it everywhere an end user could potentially find themselves.

![Screenshot 2019-04-01 at 13 54 06](https://user-images.githubusercontent.com/2160769/55329876-93e3aa80-5487-11e9-858f-34ab23cf8643.png)
![Screenshot 2019-04-01 at 13 53 50](https://user-images.githubusercontent.com/2160769/55329878-947c4100-5487-11e9-93ff-eb9810fe78ae.png)
![Screenshot 2019-04-01 at 13 54 17](https://user-images.githubusercontent.com/2160769/55329879-9514d780-5487-11e9-9682-1e11f7fe25e6.png)
![Screenshot 2019-04-01 at 13 53 59](https://user-images.githubusercontent.com/2160769/55329881-9514d780-5487-11e9-8056-fdbc2b80ef78.png)
![Screenshot 2019-04-01 at 13 55 41](https://user-images.githubusercontent.com/2160769/55329883-9514d780-5487-11e9-8b61-8af8742931ce.png)
