### PR TITLE
Modify setup instructions URL structure for new orgs

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,8 +2,6 @@ class HomeController < ApplicationController
   def index
     return redirect_to admin_organisations_path if current_user.super_admin?
 
-    return redirect_to setup_instructions_path if current_organisation.ips.empty?
-
-    redirect_to overview_index_path
+    redirect_to(current_organisation.ips.empty? ? initial_setup_instructions_path : overview_index_path)
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,6 @@ class HomeController < ApplicationController
   def index
     return redirect_to admin_organisations_path if current_user.super_admin?
 
-    redirect_to(current_organisation.ips.empty? ? initial_setup_instructions_path : overview_index_path)
+    redirect_to(current_organisation.ips.empty? ? new_organisation_setup_instructions_path : overview_index_path)
   end
 end

--- a/app/views/application/_subnavigation.html.erb
+++ b/app/views/application/_subnavigation.html.erb
@@ -19,7 +19,11 @@
         <%= link_to 'Whitelisted Domains', admin_authorised_email_domains_path, class: active_tab(admin_authorised_email_domains_path) %>
       <% else %>
         <%= link_to 'Overview', overview_index_path, class: active_tab(overview_index_path) %>
-        <%= link_to 'Setup', setup_instructions_path, class: active_tab(setup_instructions_path) + active_tab('mou') %>
+        <% if current_organisation.ips.empty? %>
+          <%= link_to 'Setup', initial_setup_instructions_path, class: active_tab(initial_setup_instructions_path) + active_tab('mou') %>
+        <% else %>
+          <%= link_to 'Setup', setup_instructions_path, class: active_tab(setup_instructions_path) + active_tab('mou') %>
+        <% end %>
         <%= link_to 'IPs', ips_path, id: 'nav-ips', class: active_tab('ips') + active_tab('locations') %>
         <%= link_to 'Logs', new_logs_search_path, class: active_tab('logs') %>
         <%= link_to 'Team', team_members_path, class: active_tab('team') + active_tab('user') %>

--- a/app/views/application/_subnavigation.html.erb
+++ b/app/views/application/_subnavigation.html.erb
@@ -20,7 +20,7 @@
       <% else %>
         <%= link_to 'Overview', overview_index_path, class: active_tab(overview_index_path) %>
         <% if current_organisation.ips.empty? %>
-          <%= link_to 'Setup', initial_setup_instructions_path, class: active_tab(initial_setup_instructions_path) + active_tab('mou') %>
+          <%= link_to 'Setup', new_organisation_setup_instructions_path, class: active_tab(new_organisation_setup_instructions_path) + active_tab('mou') %>
         <% else %>
           <%= link_to 'Setup', setup_instructions_path, class: active_tab(setup_instructions_path) + active_tab('mou') %>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
   resources :organisations, only: %i[edit update]
   resources :setup_instructions, only: %i[index] do
     collection do
-      get 'initial', to: 'setup_instructions#index'
+      get 'initial', to: 'setup_instructions#index', as: :new_organisation
     end
   end
   resources :overview, only: %i[index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,7 +58,11 @@ Rails.application.routes.draw do
   end
 
   resources :organisations, only: %i[edit update]
-  resources :setup_instructions, only: %i[index]
+  resources :setup_instructions, only: %i[index] do
+    collection do
+      get 'initial', to: 'setup_instructions#index'
+    end
+  end
   resources :overview, only: %i[index]
 
   namespace :admin do

--- a/spec/features/allow_GA_to_track_new_org_spec.rb
+++ b/spec/features/allow_GA_to_track_new_org_spec.rb
@@ -1,0 +1,20 @@
+describe 'Allowing GA to track an organisation with no IPs via URL paths', type: :feature do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in_user user
+    visit root_path
+  end
+
+  it 'displays an inital tag on the URL when logged in' do
+    expect(page).to have_current_path('/setup_instructions/initial')
+  end
+
+  context 'when visiting the setup instruction page at any time' do
+    before { click_on 'Setup' }
+
+    it 'displays an inital tag on the URL' do
+      expect(page).to have_current_path('/setup_instructions/initial')
+    end
+  end
+end

--- a/spec/features/contact_us_when_signed_in_spec.rb
+++ b/spec/features/contact_us_when_signed_in_spec.rb
@@ -23,7 +23,9 @@ describe 'Contact us when signed in', type: :feature do
     end
 
     it 'redirects to the home page' do
-      expect(page).to have_current_path(initial_setup_instructions_path)
+      within("h2") do
+        expect(page).to have_content("Get GovWifi access in your organisation")
+      end
     end
 
     it 'opens a support ticket' do

--- a/spec/features/contact_us_when_signed_in_spec.rb
+++ b/spec/features/contact_us_when_signed_in_spec.rb
@@ -22,11 +22,7 @@ describe 'Contact us when signed in', type: :feature do
       expect(page).to have_content('Your support request has been submitted')
     end
 
-    it 'redirects to the home page' do
-      within("h2") do
-        expect(page).to have_content("Get GovWifi access in your organisation")
-      end
-    end
+    it_behaves_like 'display setup instructions'
 
     it 'opens a support ticket' do
       expect(support_tickets.count).to eq 1

--- a/spec/features/contact_us_when_signed_in_spec.rb
+++ b/spec/features/contact_us_when_signed_in_spec.rb
@@ -23,7 +23,7 @@ describe 'Contact us when signed in', type: :feature do
     end
 
     it 'redirects to the home page' do
-      expect(page).to have_current_path(setup_instructions_path)
+      expect(page).to have_current_path(initial_setup_instructions_path)
     end
 
     it 'opens a support ticket' do

--- a/spec/features/contact_us_when_signed_in_spec.rb
+++ b/spec/features/contact_us_when_signed_in_spec.rb
@@ -22,7 +22,7 @@ describe 'Contact us when signed in', type: :feature do
       expect(page).to have_content('Your support request has been submitted')
     end
 
-    it_behaves_like 'display setup instructions'
+    it_behaves_like 'shows the setup instructions page'
 
     it 'opens a support ticket' do
       expect(support_tickets.count).to eq 1

--- a/spec/features/ips/permissions_spec.rb
+++ b/spec/features/ips/permissions_spec.rb
@@ -52,7 +52,7 @@ describe 'Add an IP' do
         visit new_ip_path
       end
 
-      it_behaves_like 'display setup instructions'
+      it_behaves_like 'shows the setup instructions page'
     end
 
     context 'Homepage instructions' do

--- a/spec/features/ips/permissions_spec.rb
+++ b/spec/features/ips/permissions_spec.rb
@@ -52,11 +52,7 @@ describe 'Add an IP' do
         visit new_ip_path
       end
 
-      it 'redirects them to the homepage' do
-        within("h2") do
-          expect(page).to have_content("Get GovWifi access in your organisation")
-        end
-      end
+      it_behaves_like 'display setup instructions'
     end
 
     context 'Homepage instructions' do

--- a/spec/features/ips/permissions_spec.rb
+++ b/spec/features/ips/permissions_spec.rb
@@ -53,7 +53,9 @@ describe 'Add an IP' do
       end
 
       it 'redirects them to the homepage' do
-        expect(page).to have_current_path(initial_setup_instructions_path)
+        within("h2") do
+          expect(page).to have_content("Get GovWifi access in your organisation")
+        end
       end
     end
 

--- a/spec/features/ips/permissions_spec.rb
+++ b/spec/features/ips/permissions_spec.rb
@@ -53,7 +53,7 @@ describe 'Add an IP' do
       end
 
       it 'redirects them to the homepage' do
-        expect(page).to have_current_path(setup_instructions_path)
+        expect(page).to have_current_path(initial_setup_instructions_path)
       end
     end
 

--- a/spec/features/ips/view_ip_addresses_spec.rb
+++ b/spec/features/ips/view_ip_addresses_spec.rb
@@ -23,7 +23,7 @@ describe 'View IP addresses' do
 
       it 'redirects the user to the setting up page' do
         visit root_path
-        expect(page).to have_current_path(setup_instructions_path)
+        expect(page).to have_current_path(initial_setup_instructions_path)
       end
     end
 

--- a/spec/features/ips/view_ip_addresses_spec.rb
+++ b/spec/features/ips/view_ip_addresses_spec.rb
@@ -23,7 +23,10 @@ describe 'View IP addresses' do
 
       it 'redirects the user to the setting up page' do
         visit root_path
-        expect(page).to have_current_path(initial_setup_instructions_path)
+
+        within("h2") do
+          expect(page).to have_content("Get GovWifi access in your organisation")
+        end
       end
     end
 

--- a/spec/features/overview/view_overview_page_spec.rb
+++ b/spec/features/overview/view_overview_page_spec.rb
@@ -8,7 +8,9 @@ describe 'Viewing the overview page', type: :feature do
     end
 
     it 'redirects the user to the setting up page' do
-      expect(page).to have_current_path(initial_setup_instructions_path)
+      within("h2") do
+        expect(page).to have_content("Get GovWifi access in your organisation")
+      end
     end
   end
 

--- a/spec/features/overview/view_overview_page_spec.rb
+++ b/spec/features/overview/view_overview_page_spec.rb
@@ -8,7 +8,7 @@ describe 'Viewing the overview page', type: :feature do
     end
 
     it 'redirects the user to the setting up page' do
-      expect(page).to have_current_path(setup_instructions_path)
+      expect(page).to have_current_path(initial_setup_instructions_path)
     end
   end
 

--- a/spec/features/overview/view_overview_page_spec.rb
+++ b/spec/features/overview/view_overview_page_spec.rb
@@ -7,11 +7,7 @@ describe 'Viewing the overview page', type: :feature do
       visit root_path
     end
 
-    it 'redirects the user to the setting up page' do
-      within("h2") do
-        expect(page).to have_content("Get GovWifi access in your organisation")
-      end
-    end
+    it_behaves_like 'display setup instructions'
   end
 
   context 'with at least one IP' do

--- a/spec/features/overview/view_overview_page_spec.rb
+++ b/spec/features/overview/view_overview_page_spec.rb
@@ -7,7 +7,7 @@ describe 'Viewing the overview page', type: :feature do
       visit root_path
     end
 
-    it_behaves_like 'display setup instructions'
+    it_behaves_like 'shows the setup instructions page'
   end
 
   context 'with at least one IP' do

--- a/spec/features/super_admin/authorised_email_domain_spec.rb
+++ b/spec/features/super_admin/authorised_email_domain_spec.rb
@@ -93,7 +93,7 @@ describe 'Authorising Email Domains', type: :feature do
       visit new_admin_authorised_email_domain_path
     end
 
-    it_behaves_like 'display setup instructions'
+    it_behaves_like 'shows the setup instructions page'
   end
 
   context 'when logged out' do

--- a/spec/features/super_admin/authorised_email_domain_spec.rb
+++ b/spec/features/super_admin/authorised_email_domain_spec.rb
@@ -94,7 +94,9 @@ describe 'Authorising Email Domains', type: :feature do
     end
 
     it 'will redirect to root if users type address manually' do
-      expect(page).to have_current_path(initial_setup_instructions_path)
+      within("h2") do
+        expect(page).to have_content("Get GovWifi access in your organisation")
+      end
     end
   end
 

--- a/spec/features/super_admin/authorised_email_domain_spec.rb
+++ b/spec/features/super_admin/authorised_email_domain_spec.rb
@@ -93,11 +93,7 @@ describe 'Authorising Email Domains', type: :feature do
       visit new_admin_authorised_email_domain_path
     end
 
-    it 'will redirect to root if users type address manually' do
-      within("h2") do
-        expect(page).to have_content("Get GovWifi access in your organisation")
-      end
-    end
+    it_behaves_like 'display setup instructions'
   end
 
   context 'when logged out' do

--- a/spec/features/super_admin/authorised_email_domain_spec.rb
+++ b/spec/features/super_admin/authorised_email_domain_spec.rb
@@ -94,7 +94,7 @@ describe 'Authorising Email Domains', type: :feature do
     end
 
     it 'will redirect to root if users type address manually' do
-      expect(page).to have_current_path(setup_instructions_path)
+      expect(page).to have_current_path(initial_setup_instructions_path)
     end
   end
 

--- a/spec/features/super_admin/upload_download_mou_spec.rb
+++ b/spec/features/super_admin/upload_download_mou_spec.rb
@@ -47,7 +47,9 @@ describe 'Upload and download the MOU template', type: :feature do
     end
 
     it 'redirects unauthorised access' do
-      expect(page).to have_current_path(initial_setup_instructions_path)
+      within("h2") do
+        expect(page).to have_content("Get GovWifi access in your organisation")
+      end
     end
   end
 end

--- a/spec/features/super_admin/upload_download_mou_spec.rb
+++ b/spec/features/super_admin/upload_download_mou_spec.rb
@@ -46,6 +46,6 @@ describe 'Upload and download the MOU template', type: :feature do
       visit admin_mou_index_path
     end
 
-    it_behaves_like 'display setup instructions'
+    it_behaves_like 'shows the setup instructions page'
   end
 end

--- a/spec/features/super_admin/upload_download_mou_spec.rb
+++ b/spec/features/super_admin/upload_download_mou_spec.rb
@@ -46,10 +46,6 @@ describe 'Upload and download the MOU template', type: :feature do
       visit admin_mou_index_path
     end
 
-    it 'redirects unauthorised access' do
-      within("h2") do
-        expect(page).to have_content("Get GovWifi access in your organisation")
-      end
-    end
+    it_behaves_like 'display setup instructions'
   end
 end

--- a/spec/features/super_admin/upload_download_mou_spec.rb
+++ b/spec/features/super_admin/upload_download_mou_spec.rb
@@ -47,7 +47,7 @@ describe 'Upload and download the MOU template', type: :feature do
     end
 
     it 'redirects unauthorised access' do
-      expect(page).to have_current_path(setup_instructions_path)
+      expect(page).to have_current_path(initial_setup_instructions_path)
     end
   end
 end

--- a/spec/features/support/setup_instructions.rb
+++ b/spec/features/support/setup_instructions.rb
@@ -1,4 +1,4 @@
-shared_examples 'display setup instructions' do
+shared_examples 'shows the setup instructions page' do
   it 'shows the user the setup instructions page' do
     within("h2") do
       expect(page).to have_content("Get GovWifi access in your organisation")

--- a/spec/features/support/setup_instructions.rb
+++ b/spec/features/support/setup_instructions.rb
@@ -1,0 +1,7 @@
+shared_examples 'display setup instructions' do
+  it 'shows the user the setup instructions page' do
+    within("h2") do
+      expect(page).to have_content("Get GovWifi access in your organisation")
+    end
+  end
+end

--- a/spec/features/support/user_not_authorised.rb
+++ b/spec/features/support/user_not_authorised.rb
@@ -1,4 +1,5 @@
 shared_examples 'user not authorised' do
+  # Assumes that users created for the purpose of testing have no IPs initially, which routes them differently from root.
   it 'redirects to setting up page' do
     within("h2") do
       expect(page).to have_content("Get GovWifi access in your organisation")

--- a/spec/features/support/user_not_authorised.rb
+++ b/spec/features/support/user_not_authorised.rb
@@ -1,6 +1,7 @@
 shared_examples 'user not authorised' do
-  it 'redirects to setting up' do
-    # this relies on the assumption that users created for the purpose of testing have no IPs, which routes them differently from root.
-    expect(page).to have_current_path(initial_setup_instructions_path)
+  it 'redirects to setting up page' do
+    within("h2") do
+      expect(page).to have_content("Get GovWifi access in your organisation")
+    end
   end
 end

--- a/spec/features/support/user_not_authorised.rb
+++ b/spec/features/support/user_not_authorised.rb
@@ -1,6 +1,6 @@
 shared_examples 'user not authorised' do
   it 'redirects to setting up' do
     # this relies on the assumption that users created for the purpose of testing have no IPs, which routes them differently from root.
-    expect(page).to have_current_path(setup_instructions_path)
+    expect(page).to have_current_path(initial_setup_instructions_path)
   end
 end

--- a/spec/features/team/permissions_spec.rb
+++ b/spec/features/team/permissions_spec.rb
@@ -45,7 +45,7 @@ describe 'Invite a team member', type: :feature do
     it 'prevents visiting the invites page directly' do
       visit new_user_invitation_path
 
-      expect(page).to have_current_path(setup_instructions_path)
+      expect(page).to have_current_path(initial_setup_instructions_path)
     end
 
     it 'does not allow re-sending invites' do

--- a/spec/features/team/permissions_spec.rb
+++ b/spec/features/team/permissions_spec.rb
@@ -45,7 +45,9 @@ describe 'Invite a team member', type: :feature do
     it 'prevents visiting the invites page directly' do
       visit new_user_invitation_path
 
-      expect(page).to have_current_path(initial_setup_instructions_path)
+      within("h2") do
+        expect(page).to have_content("Get GovWifi access in your organisation")
+      end
     end
 
     it 'does not allow re-sending invites' do

--- a/spec/features/track_new_organisations_spec.rb
+++ b/spec/features/track_new_organisations_spec.rb
@@ -1,4 +1,6 @@
 describe 'Tracking new organisations', type: :feature do
+  include_context 'with a mocked notifications client'
+
   let(:user) { create(:user) }
 
   before do
@@ -15,6 +17,22 @@ describe 'Tracking new organisations', type: :feature do
 
     it 'displays the initial tag on the URL' do
       expect(page).to have_current_path('/setup_instructions/initial')
+    end
+  end
+
+  context 'when a user adds their first IP, then clicks setup link' do
+    let!(:location) { create(:location, organisation: user.organisation) }
+    let(:ip_address) { '120.0.129.150' }
+
+    before do
+      visit new_ip_path(location: location)
+      fill_in 'address', with: ip_address
+      click_on 'Add new IP address'
+      click_on 'Setup'
+    end
+
+    it 'does not display the initial tag on the URL' do
+      expect(page).to have_current_path('/setup_instructions')
     end
   end
 end

--- a/spec/features/track_new_organisations_spec.rb
+++ b/spec/features/track_new_organisations_spec.rb
@@ -1,4 +1,4 @@
-describe 'Allowing GA to track an organisation with no IPs via URL paths', type: :feature do
+describe 'Tracking new organisations', type: :feature do
   let(:user) { create(:user) }
 
   before do
@@ -6,14 +6,14 @@ describe 'Allowing GA to track an organisation with no IPs via URL paths', type:
     visit root_path
   end
 
-  it 'displays an inital tag on the URL when logged in' do
+  it 'displays an initial tag on the URL when logged in' do
     expect(page).to have_current_path('/setup_instructions/initial')
   end
 
-  context 'when visiting the setup instruction page at any time' do
+  context 'when a user clicks on the setup sub-navigation link ' do
     before { click_on 'Setup' }
 
-    it 'displays an inital tag on the URL' do
+    it 'displays the initial tag on the URL' do
       expect(page).to have_current_path('/setup_instructions/initial')
     end
   end


### PR DESCRIPTION
**WHY:**
Google analytics (GA) will be used to track users using the app. GA needs to be able to follow a new organisation's "conversion" pathway. i.e an organisation creating its first IP.
A new organisation is an organisation with **zero IPs**, regardless of when they signed up and how many team members or locations they have.

However, there was no way for GA to differentiate between a new org and an org with an IP setup when the land .
e.g 
- Setup Instructions Page URL for a new organisation: `/setup_instructions`.
- Setup Instructions Page URL for an org with at least one IP setup: `/setup_instructions`.
 This is the same url, and would therefore look the same when tracking in GA.

_This PR is the first step to allowing GA to track activity paths of new organisations._

**IN THIS PR:**
- Add an `initial_setup_instructions_path` for a new organisation that switches to `setup_instructions_path` when the organisation has at least one IP.

### **Please note the URLs in the browser address bar.**

**1. New organisation logs in:**
`/ -> /setup_instructions/initial`

![Screenshot 2019-04-01 at 14 45 00](https://user-images.githubusercontent.com/32823756/55332167-c0e68c00-548c-11e9-8ce1-ea715eff962d.png)

------------------------------------------------------------------------------------------------------

**2. New organisation visits setup instructions from another page e.g adding just a location with no IPs:**
`/ -> /setup_instructions/initial -> /ips -> /setup_instructions/initial`

![Screenshot 2019-04-01 at 14 45 00](https://user-images.githubusercontent.com/32823756/55332796-fe97e480-548d-11e9-9eff-d44f5500ae4f.png)

![Screenshot 2019-04-01 at 14 53 42](https://user-images.githubusercontent.com/32823756/55332832-11121e00-548e-11e9-8ea5-f9a20547f706.png)

![Screenshot 2019-04-01 at 14 45 00](https://user-images.githubusercontent.com/32823756/55332871-1c654980-548e-11e9-9b4e-3a1128271660.png)

------------------------------------------------------------------------------------------------------

**3. New organisation visits setup instructions from adding an IP e.g conversion:**
`/ -> /setup_instructions/initial -> /ips -> /ips/created -> /setup_instructions`

![Screenshot 2019-04-01 at 14 45 00](https://user-images.githubusercontent.com/32823756/55333243-cb098a00-548e-11e9-932e-64a5fab884b7.png)

![Screenshot 2019-04-01 at 14 53 42](https://user-images.githubusercontent.com/32823756/55333265-d957a600-548e-11e9-9d0c-13cd113d3d63.png)

![Screenshot 2019-04-01 at 15 00 00](https://user-images.githubusercontent.com/32823756/55333275-deb4f080-548e-11e9-9f7b-796e4c9e218c.png)

![Screenshot 2019-04-01 at 14 44 43](https://user-images.githubusercontent.com/32823756/55333298-e83e5880-548e-11e9-8966-39f46fd2653c.png)

------------------------------------------------------------------------------------------------------

**Not 100% sure on this approach. A lot of files were changed. Any feedback/suggestions on this approach would be appreciated.**