### PR TITLE
Add whitelisted email domains table headings 

### DIFF
--- a/app/views/admin/authorised_email_domains/_table.html.erb
+++ b/app/views/admin/authorised_email_domains/_table.html.erb
@@ -1,8 +1,17 @@
 <table class="govuk-table govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-m">Email domains that are already whitelisted</h2>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col">Email Domain</th>
+        <th class="govuk-table__header" scope="col">Date Added</th>
+        <th class="govuk-table__header" scope="col"></th>
+      </tr>
+    </thead>
   <tbody class="govuk-table__body" id="domains-table">
     <% domains.each do |domain| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-third"><%= domain.name %></td>
+        <td class="govuk-table__cell"><%= domain.created_at.strftime('%e %b %Y') %></td>
         <td class="govuk-table__cell text-right">
           <%= link_to 'Remove', admin_authorised_email_domains_path(id: domain.id, domain_to_remove: domain.name), class: "govuk-link" %>
         </td>


### PR DESCRIPTION
**WHY:**
The table for the whitelisted emails just displays email domains and a remove link to the super admin.
See below:

![Screenshot 2019-04-01 at 15 59 04](https://user-images.githubusercontent.com/32823756/55337710-1c1d7c00-5497-11e9-8476-a09eaf1a8486.png)

------------------------------------------------------------------------------------------------------

**IN THIS PR:**
- The table style was edited so that a `Date Added` table heading could be added.
- Added heading for email domains.
- Extra wording to describe the table.

![Screenshot 2019-04-01 at 15 47 36](https://user-images.githubusercontent.com/32823756/55337812-42dbb280-5497-11e9-8de2-16ab92b5e5a1.png)
 
------------------------------------------------------------------------------------------------------

**Any feedback/suggestions on this, would be appreciated.**