### PR TITLE
[WIP] Spike manage super admin privileges Option 1

### DIFF
--- a/app/controllers/admin/users/permissions_controller.rb
+++ b/app/controllers/admin/users/permissions_controller.rb
@@ -1,0 +1,9 @@
+class Admin::Users::PermissionsController < AdminController
+  def create
+    # Grant the user super admin privileges
+  end
+
+  def destroy
+    # Revoke the users super admin privileges
+  end
+end

--- a/app/views/admin/organisations/_team.html.erb
+++ b/app/views/admin/organisations/_team.html.erb
@@ -7,6 +7,15 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" scope="row"><%= user.name %></td>
           <td class="govuk-table__cell text-right" scope="row"><%= user.email %></td>
+          <td class="govuk-table__cell text-right" scope="row">
+            <% if user.super_admin? %>
+              <%= button_to("revoke super admin", admin_user_revoke_permission_path(user),
+                method: :delete, class: 'resend-invite-button') %>
+            <% else %>
+              <%= button_to("grant super admin", admin_user_grant_permission_path(user),
+                method: :post, class: 'resend-invite-button') %>
+            <% end %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,10 @@ Rails.application.routes.draw do
     resources :organisations, only: %i[index show destroy]
     resources :custom_organisations, only: %i[index create destroy]
     resources :authorised_email_domains, only: %i[index new create destroy]
+    resources :users, only: [] do
+      post 'permission', to: 'users/permissions#create', as: :grant_permission
+      delete 'permission', to: 'users/permissions#destroy', as: :revoke_permission
+    end
   end
 
   %w( 404 422 500 ).each do |code|

--- a/spec/features/super_admin/super_admin_privileges_spec.rb
+++ b/spec/features/super_admin/super_admin_privileges_spec.rb
@@ -1,0 +1,28 @@
+describe 'Managing super admin privileges' do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in_user create(:user, super_admin: true)
+    visit admin_organisation_path(user.organisation)
+  end
+
+  context 'when granting super admin privileges' do
+    before do
+      user.update(super_admin: false)
+    end
+
+    it 'displays the make super admin link' do
+      expect(page).to have_button("grant super admin")
+    end
+  end
+
+  context 'when revoking super admin privileges' do
+    before do
+      user.update(super_admin: true)
+    end
+
+    it 'displays the revoke super admin link' do
+      expect(page).to have_button("revoke super admin")
+    end
+  end
+end


### PR DESCRIPTION
Spike for allowing GDS to invite a super admin. 

![Screenshot 2019-04-01 at 16 54 28](https://user-images.githubusercontent.com/2160769/55341595-d664b180-549e-11e9-9a0e-99665466320c.png)

Other options include:
- Option 2: Doing "super admin" permissions on a team, eg: "GovWifi Super Administrators". If you belong to this team you are a super admin. View here: https://github.com/alphagov/govwifi-admin/pull/598
OR
- Option 1b:Adding a "super admin" checkbox to an edit permissions page, eg:
![Screenshot 2019-04-01 at 17 11 54](https://user-images.githubusercontent.com/2160769/55342786-758aa880-54a1-11e9-87a0-2e3554ad8dec.png)
![Screenshot 2019-04-01 at 17 13 04](https://user-images.githubusercontent.com/2160769/55342787-758aa880-54a1-11e9-9229-f262dde2d4aa.png)
OR
![Screenshot 2019-04-01 at 17 14 18](https://user-images.githubusercontent.com/2160769/55342844-a1a62980-54a1-11e9-965f-e332b6f11a95.png)
