### PR TITLE
Move super admin privileges to the organisation

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -2,6 +2,6 @@ class AdminController < ApplicationController
   before_action :authorise_admin
 
   def authorise_admin
-    redirect_to root_path unless current_user.super_admin?
+    redirect_to root_path unless super_admin?
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!, except: :error
   before_action :configure_devise_permitted_parameters, if: :devise_controller?
 
-  helper_method :current_organisation
+  helper_method :current_organisation, :super_admin?
 
   def current_organisation
     @current_organisation ||= current_user.organisation
@@ -12,6 +12,10 @@ class ApplicationController < ActionController::Base
 
   def error
     render :error, code: params[:code]
+  end
+
+  def super_admin?
+    current_organisation.super_admin?
   end
 
 protected

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
   end
 
   def super_admin?
-    current_organisation.super_admin?
+    current_organisation&.super_admin?
   end
 
 protected

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,6 @@
 class HomeController < ApplicationController
   def index
-    return redirect_to admin_organisations_path if current_user.super_admin?
+    return redirect_to admin_organisations_path if super_admin?
 
     redirect_to(current_organisation.ips.empty? ? new_organisation_setup_instructions_path : overview_index_path)
   end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -25,7 +25,7 @@ private
   def get_auth_requests
     UseCases::Administrator::GetAuthRequests.new(
       authentication_logs_gateway: Gateways::Sessions.new(
-        ip_filter: current_user.super_admin? ? nil : current_organisation.ips.map(&:address)
+        ip_filter: super_admin? ? nil : current_organisation.ips.map(&:address)
       )
     )
   end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -4,8 +4,6 @@ class Users::InvitationsController < Devise::InvitationsController
   before_action :return_user_to_invite_page, if: :user_is_invalid?, only: :create
   before_action :add_organisation_to_params, unless: :super_admin?, only: :create
 
-  helper_method :super_admin?
-
 private
 
   def authenticate_inviter!
@@ -70,10 +68,6 @@ private
 
   def invited_user_has_no_org?
     invited_user.organisation_id.nil?
-  end
-
-  def super_admin?
-    current_user.super_admin?
   end
 
   # Overrides https://github.com/scambra/devise_invitable/blob/master/app/controllers/devise/invitations_controller.rb#L105

--- a/app/views/application/_subnavigation.html.erb
+++ b/app/views/application/_subnavigation.html.erb
@@ -1,7 +1,7 @@
 <div class='govuk-grid-row subnav govuk-!-margin-0'>
   <div class='govuk-grid-column-one-quarter govuk-grid-column-one-third-from-desktop govuk-!-padding-left-0 organisation-name'>
     <p class='govuk-body govuk-!-margin-0 govuk-!-padding-0'>
-      <% if current_user.super_admin? %>
+      <% if super_admin? %>
         <strong>GovWifi Super Admin</strong>
       <% else %>
         <strong><%= current_organisation.name %></strong>
@@ -11,7 +11,7 @@
 
   <div class='govuk-grid-column-three-quarters govuk-grid-column-two-thirds-from-desktop govuk-!-padding-0 nav-links'>
     <nav class='govuk-body govuk-!-margin-bottom-0'>
-      <% if current_user.super_admin? %>
+      <% if super_admin? %>
         <%= link_to 'Organisations', admin_organisations_path, class: active_tab(admin_organisations_path) %>
         <%= link_to 'Allow Organisations', admin_custom_organisations_path, class: active_tab(admin_custom_organisations_path) %>
         <%= link_to 'MOU', admin_mou_index_path, class: active_tab(admin_mou_index_path) %>

--- a/app/views/logs/_filtered_results_explanation.html.erb
+++ b/app/views/logs/_filtered_results_explanation.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-inset-text govuk-!-margin-top-0">
     <h4 class="govuk-heading-s">Filtered results</h4>
 
-    <% if !current_user.super_admin? %>
+    <% if !super_admin? %>
       <p class="govuk-body">
         Only logs from your organisation's IPs are shown.
       </p>
@@ -22,7 +22,7 @@
       </p>
     <% end %>
 
-    <% if logs.present? && !current_user.super_admin? %>
+    <% if logs.present? && !super_admin? %>
       <p class="govuk-body">
         If you need more logs, <%= link_to "contact us", signed_in_new_help_path, class: "govuk-link" %>.
       </p>

--- a/app/views/logs/_no_logs_explanation.html.erb
+++ b/app/views/logs/_no_logs_explanation.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-column-two-thirds">
-  <% if current_user.super_admin? %>
+  <% if super_admin? %>
     <h3 class="govuk-body">
       If you were expecting to see results, we recommend asking the organisation:
     </h3>

--- a/app/views/logs_searches/new.html.erb
+++ b/app/views/logs_searches/new.html.erb
@@ -15,7 +15,7 @@
         </p>
         <div class="govuk-radios <%= field_error(@search, :filter) %>">
           <%= render 'error_message', key: :filter, message: 'select an option' %>
-          <% if !current_user.super_admin? %>
+          <% if !super_admin? %>
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="choice-location" name="logs_search[filter]" type="radio" value="location">
               <label class="govuk-label govuk-radios__label" for="choice-location">

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_02_134657) do
+ActiveRecord::Schema.define(version: 2019_02_14_165237) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -74,7 +74,6 @@ ActiveRecord::Schema.define(version: 2019_04_02_134657) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "service_email"
-    t.boolean "super_admin", default: false
   end
 
   create_table "permissions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_14_165237) do
+ActiveRecord::Schema.define(version: 2019_04_02_134657) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 2019_02_14_165237) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "service_email"
+    t.boolean "super_admin", default: false
   end
 
   create_table "permissions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,14 +2,16 @@
 # The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
 require 'faker'
 
-admin_organisation = Organisation.create!(
-  name: 'Government Digital Service', service_email: 'it@gds.com'
+CustomOrganisationName.create(name: 'GovWifi Super Administrators')
+
+super_admin_organisation = Organisation.create!(
+  name: 'GovWifi Super Administrators', service_email: 'it@gds.com', super_admin: true
 )
-admin_user = admin_organisation.users.create(
+
+admin_user = super_admin_organisation.users.create(
   email: "admin@gov.uk",
   password: "password",
   name: "Steve",
-  super_admin: true,
   confirmed_at: Time.zone.now
 )
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,6 +8,9 @@ FactoryBot.define do
     confirmed_at { Time.zone.now }
 
     association :organisation
+    trait :super_admin do
+      association :organisation, super_admin: true
+    end
     trait :unconfirmed do
       confirmed_at { nil }
     end

--- a/spec/features/super_admin/authorised_email_domain_spec.rb
+++ b/spec/features/super_admin/authorised_email_domain_spec.rb
@@ -4,7 +4,7 @@ describe 'Authorising Email Domains', type: :feature do
     visit new_admin_authorised_email_domain_path
   end
 
-  let(:admin_user) { create(:user, super_admin: true) }
+  let(:admin_user) { create(:user, :super_admin) }
 
   context 'when whitelisting a domain' do
     before do
@@ -86,7 +86,7 @@ describe 'Authorising Email Domains', type: :feature do
   end
 
   context 'without super admin privileges' do
-    let(:admin_user) { create(:user, super_admin: false) }
+    let(:admin_user) { create(:user) }
 
     before do
       sign_in_user admin_user

--- a/spec/features/super_admin/custom_organisations/add_custom_organisation_spec.rb
+++ b/spec/features/super_admin/custom_organisations/add_custom_organisation_spec.rb
@@ -1,5 +1,5 @@
 describe 'Adding a custom organisation name', type: :feature do
-  let(:admin_user) { create(:user, super_admin: true) }
+  let(:admin_user) { create(:user, :super_admin) }
 
   before do
     sign_in_user admin_user

--- a/spec/features/super_admin/custom_organisations/delete_custom_organisation_spec.rb
+++ b/spec/features/super_admin/custom_organisations/delete_custom_organisation_spec.rb
@@ -1,5 +1,5 @@
 describe 'Delete a custom organisation name', type: :feature do
-  let(:admin_user) { create(:user, super_admin: true) }
+  let(:admin_user) { create(:user, :super_admin) }
 
   before do
     create(:custom_organisation_name, name: 'DummyOrg1')

--- a/spec/features/super_admin/invite_user_to_organisation_spec.rb
+++ b/spec/features/super_admin/invite_user_to_organisation_spec.rb
@@ -3,7 +3,7 @@ require 'support/notifications_service'
 
 describe "Inviting a team member as a super admin", type: :feature do
   let(:organisation) { create(:organisation, name: "Gov Org 3") }
-  let(:super_admin) { create(:user, super_admin: true) }
+  let(:super_admin) { create(:user, :super_admin) }
   let(:email) { 'barry@gov.uk' }
 
   before do

--- a/spec/features/super_admin/logging/view_logs_for_ip_spec.rb
+++ b/spec/features/super_admin/logging/view_logs_for_ip_spec.rb
@@ -7,7 +7,7 @@ describe 'View authentication requests for an IP', type: :feature do
   let(:user_2_location) { create(:location, organisation: user_2.organisation) }
   let(:ip_2) { create(:ip, location: user_2_location, address: '1.2.3.5') }
 
-  let(:super_admin) { create(:user, super_admin: true) }
+  let(:super_admin) { create(:user, :super_admin) }
 
   before do
     Session.create!(

--- a/spec/features/super_admin/logging/view_logs_for_username_spec.rb
+++ b/spec/features/super_admin/logging/view_logs_for_username_spec.rb
@@ -1,7 +1,7 @@
 describe "View authentication requests for a username", type: :feature do
   let(:username) { "Larry" }
 
-  let(:super_admin) { create(:user, super_admin: true) }
+  let(:super_admin) { create(:user, :super_admin) }
   let(:super_admin_location) { create(:location, organisation: super_admin.organisation) }
   let(:super_admin_ip) { create(:ip, location: super_admin_location) }
 

--- a/spec/features/super_admin/organisations/delete_organisation_spec.rb
+++ b/spec/features/super_admin/organisations/delete_organisation_spec.rb
@@ -1,5 +1,5 @@
 describe 'Deleting an organisation', type: :feature do
-  let!(:admin_user) { create(:user, super_admin: true) }
+  let!(:admin_user) { create(:user, :super_admin) }
   let!(:organisation) { create(:organisation, name: 'Gov Org 2') }
 
   context 'when visiting the organisations page' do

--- a/spec/features/super_admin/organisations/sort_organisation_list_spec.rb
+++ b/spec/features/super_admin/organisations/sort_organisation_list_spec.rb
@@ -1,6 +1,6 @@
 describe 'Sorting the organisations list', type: :feature do
   context 'when super admin views the list' do
-    let!(:super_admin) { create(:user, super_admin: true) }
+    let!(:super_admin) { create(:user, :super_admin) }
 
     before do
       create(:organisation, name: "Gov Org 2", created_at: '10 Dec 2013')

--- a/spec/features/super_admin/organisations/view_organisation_list_spec.rb
+++ b/spec/features/super_admin/organisations/view_organisation_list_spec.rb
@@ -19,7 +19,7 @@ describe 'View a list of signed up organisations', type: :feature do
   end
 
   context 'when logged in as an admin' do
-    let(:user) { create(:user, super_admin: true) }
+    let(:user) { create(:user, :super_admin) }
 
     context 'when one organisation exists' do
       let(:org) { create(:organisation, created_at: '1 Feb 2014') }

--- a/spec/features/super_admin/organisations/view_organisation_page_spec.rb
+++ b/spec/features/super_admin/organisations/view_organisation_page_spec.rb
@@ -17,7 +17,7 @@ describe 'View details of an organisation', type: :feature do
       create(:ip, location: location_2)
       create(:ip, location: location_3)
 
-      sign_in_user create(:user, super_admin: true)
+      sign_in_user create(:user, :super_admin)
       visit admin_organisation_path(organisation)
     end
 

--- a/spec/features/super_admin/sign_in_as_super_admin_spec.rb
+++ b/spec/features/super_admin/sign_in_as_super_admin_spec.rb
@@ -1,5 +1,5 @@
 describe 'Signing in as a super admin', type: :feature do
-  let(:user) { create(:user, super_admin: true) }
+  let(:user) { create(:user, :super_admin) }
 
   context 'when visiting the home page' do
     before do

--- a/spec/features/super_admin/upload_download_mou_spec.rb
+++ b/spec/features/super_admin/upload_download_mou_spec.rb
@@ -1,5 +1,5 @@
 describe 'Upload and download the MOU template', type: :feature do
-  let(:super_admin) { create(:user, super_admin: true) }
+  let(:super_admin) { create(:user, :super_admin) }
 
   before do
     sign_in_user super_admin

--- a/spec/requests/email_domain/delete_spec.rb
+++ b/spec/requests/email_domain/delete_spec.rb
@@ -4,7 +4,7 @@ describe "DELETE /authorised_email_domains/:id", type: :request do
   context "when the user is a super admin" do
     before do
       https!
-      sign_in_user(create(:user, super_admin: true))
+      sign_in_user(create(:user, :super_admin))
     end
 
     it "deletes the email domain" do
@@ -22,7 +22,7 @@ describe "DELETE /authorised_email_domains/:id", type: :request do
   context "when the user is not super admin" do
     before do
       https!
-      sign_in_user(create(:user, super_admin: false))
+      sign_in_user(create(:user))
     end
 
     it "does not delete the email domain" do


### PR DESCRIPTION
Moves the `super_admin` boolean to organisation. So now to invite a super admin, the super admin would just need to invite them to the "GovWifi Super Administrators" organisation.

![Screenshot 2019-04-02 at 14 20 09](https://user-images.githubusercontent.com/2160769/55405713-9101bc00-5552-11e9-80f7-fb5342863287.png)
