### PR TITLE
Always show organisation name in subnav

### DIFF
--- a/app/views/application/_subnavigation.html.erb
+++ b/app/views/application/_subnavigation.html.erb
@@ -1,11 +1,7 @@
 <div class='govuk-grid-row subnav govuk-!-margin-0'>
   <div class='govuk-grid-column-one-quarter govuk-grid-column-one-third-from-desktop govuk-!-padding-left-0 organisation-name'>
     <p class='govuk-body govuk-!-margin-0 govuk-!-padding-0'>
-      <% if super_admin? %>
-        <strong>GovWifi Super Admin</strong>
-      <% else %>
-        <strong><%= current_organisation.name %></strong>
-      <% end %>
+      <strong><%= current_organisation.name %></strong>
     </p>
   </div>
 


### PR DESCRIPTION
We used to not show the real organisation name if you were signed in as a super admin. This is no longer required.

Before:
![Screenshot 2019-04-02 at 15 59 14](https://user-images.githubusercontent.com/2160769/55413058-7df5e880-5560-11e9-800c-92a0f81de8b7.png)

After:
![Screenshot 2019-04-02 at 16 00 22](https://user-images.githubusercontent.com/2160769/55413112-98c85d00-5560-11e9-9b47-0028536b4507.png)
