### PR TITLE
Track new organisation first IP creation pathway v2.0

### DIFF
--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -3,8 +3,8 @@
 
   <script>
     dataLayer = [{
-      'signed_in': '<%= user_signed_in?.to_json %>'
-      'hasIPs': '<%= (!current_user.nil? && current_organisation.ips.any?).to_json %>'
+      'signedIn': '<%= user_signed_in?.to_json %>'
+      'hasIPs': '<%= (!!current_user && current_organisation.ips.any?).to_json %>'
     }];
   </script>
 

--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -3,7 +3,7 @@
 
   <script>
     dataLayer = [{
-      'signedIn': '<%= user_signed_in?.to_json %>'
+      'signedIn': '<%= user_signed_in?.to_json %>',
       'hasIPs': '<%= (!!current_user && current_organisation.ips.any?).to_json %>'
     }];
   </script>

--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -1,6 +1,13 @@
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=<%= SITE_CONFIG['google_analytics_script_id'] %>"></script>
 
+  <script>
+    dataLayer = [{
+      'signed_in': '<%= user_signed_in?.to_json %>'
+      'hasIPs': '<%= (!current_user.nil? && current_organisation.ips.any?).to_json %>'
+    }];
+  </script>
+
 <!-- Google Tag Manager -->
 <script>
   window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
**WHY:**
_This PR is version 2 of second step to allowing GA to track first IP creation activity paths. PR #602_

First step is PR #595 

A new organisation is an organisation with no IPs set up regardless of adding other things e.g location, team members.

We want to follow a new organisation's conversion i.e adding their first IP address and thus making their installation of GovWifi count as an active one.

We need to follow the difference between new and existing organisations through the "create IP" pathway.

**IN THIS PR:**
- Add data layer script with `signed_in` and `hasIPs` variables:

**_Added  a `signed_in` variable because `hasIPs` is false when the user is not signed in._** 

![Screenshot 2019-04-03 at 14 56 06](https://user-images.githubusercontent.com/32823756/55486678-a6dfb180-5624-11e9-8068-263980e02943.png)

------------------------------------------------------------------------------------------------------

**_`hasIPs` is false when the organisation has no IPs_** 

![Screenshot 2019-04-03 at 14 57 09](https://user-images.githubusercontent.com/32823756/55486816-ddb5c780-5624-11e9-9ce9-80ff55030e3e.png)

------------------------------------------------------------------------------------------------------

**_`hasIPs` is false when the organisation has no IPs (even if locations are added)_** 

![Screenshot 2019-04-03 at 14 55 33](https://user-images.githubusercontent.com/32823756/55486958-1f467280-5625-11e9-9e43-9ea31d950335.png)

------------------------------------------------------------------------------------------------------

**_`hasIPs` is true when the organisation had an IP address_** 

![Screenshot 2019-04-03 at 14 55 56](https://user-images.githubusercontent.com/32823756/55487030-3dac6e00-5625-11e9-8c42-eeceec031c25.png)

------------------------------------------------------------------------------------------------------

**Any feedback or suggestions on this approach would be appreciated**