### PR TITLE
Lint specs in gateways folder part one

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,6 @@ AllCops:
     - spec/support/reset_password_use_case.rb
     - spec/support/invite_use_case.rb
     - spec/facades/ips/publish_spec.rb
-    - spec/gateways/s3_spec.rb
     - spec/gateways/zendesk_support_tickets_spec.rb
     - spec/gateways/govuk_organisations_register_gateway_spec.rb
     - spec/gateways/ips_spec.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,6 @@ AllCops:
     - spec/support/reset_password_use_case.rb
     - spec/support/invite_use_case.rb
     - spec/facades/ips/publish_spec.rb
-    - spec/gateways/zendesk_support_tickets_spec.rb
     - spec/gateways/govuk_organisations_register_gateway_spec.rb
     - spec/gateways/ips_spec.rb
     - spec/gateways/authorised_email_domains_spec.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,6 @@ AllCops:
     - spec/support/reset_password_use_case.rb
     - spec/support/invite_use_case.rb
     - spec/facades/ips/publish_spec.rb
-    - spec/gateways/ips_spec.rb
     - spec/gateways/authorised_email_domains_spec.rb
     - spec/gateways/email_spec.rb
     - spec/gateways/sessions_spec.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,6 @@ AllCops:
     - spec/support/reset_password_use_case.rb
     - spec/support/invite_use_case.rb
     - spec/facades/ips/publish_spec.rb
-    - spec/gateways/govuk_organisations_register_gateway_spec.rb
     - spec/gateways/ips_spec.rb
     - spec/gateways/authorised_email_domains_spec.rb
     - spec/gateways/email_spec.rb

--- a/spec/gateways/govuk_organisations_register_gateway_spec.rb
+++ b/spec/gateways/govuk_organisations_register_gateway_spec.rb
@@ -1,42 +1,25 @@
 describe Gateways::GovukOrganisationsRegisterGateway do
-  it 'fetches the organisations' do
-    result = subject.government_orgs
-    expect(result).to eq(
-      [
-        'Gov Org 1',
-        'Gov Org 2',
-        'Gov Org 3',
-        'Gov Org 4'
-      ]
-    )
+  subject(:register_gateway) { described_class.new }
+
+  it 'fetches the organisation names from the register' do
+    result = register_gateway.government_orgs
+    expect(result).to eq(['Gov Org 1', 'Gov Org 2', 'Gov Org 3', 'Gov Org 4'])
   end
 
-  it 'fetches the local auths' do
-    result = subject.local_authorities
-    expect(result).to eq(
-      [
-        'Local Auth 1',
-        'Local Auth 2',
-        'Local Auth 3',
-        'Local Auth 4'
-      ]
-    )
+  it 'fetches the local authority names from the register' do
+    result = register_gateway.local_authorities
+    expect(result).to eq(['Local Auth 1', 'Local Auth 2', 'Local Auth 3', 'Local Auth 4'])
   end
 
-  context 'with custom organisations' do
+  context 'when custom organisations are added' do
     before do
       CustomOrganisationName.create(name: 'Custom Org 1')
       CustomOrganisationName.create(name: 'Custom Org 2')
     end
 
-    it 'fetches the custom orgs' do
-      result = subject.custom_orgs
-      expect(result).to eq(
-        [
-        'Custom Org 1',
-        'Custom Org 2'
-        ]
-      )
+    it 'fetches the custom organisation names from the register' do
+      result = register_gateway.custom_orgs
+      expect(result).to eq(['Custom Org 1', 'Custom Org 2'])
     end
   end
 end

--- a/spec/gateways/ips_spec.rb
+++ b/spec/gateways/ips_spec.rb
@@ -1,4 +1,6 @@
 describe Gateways::Ips do
+  subject(:ip_gateway) { described_class.new }
+
   let(:location_1) { create(:location, organisation: create(:organisation)) }
   let(:location_2) { create(:location, organisation: create(:organisation)) }
   let(:result) do
@@ -19,6 +21,6 @@ describe Gateways::Ips do
   end
 
   it "fetches the locations_ips" do
-    expect(subject.fetch_ips).to eq(result)
+    expect(ip_gateway.fetch_ips).to eq(result)
   end
 end

--- a/spec/gateways/s3_spec.rb
+++ b/spec/gateways/s3_spec.rb
@@ -1,16 +1,16 @@
 describe Gateways::S3 do
-  subject { described_class.new(bucket: bucket, key: key) }
+  subject(:gateway) { described_class.new(bucket: bucket, key: key) }
 
   let(:bucket) { 'StubBucket' }
   let(:key) { 'StubKey' }
   let(:data) { { blah: 'foobar' }.to_json }
 
 
-  it 'writes the data to the bucket' do
-    expect(subject.write(data: data)).to eq({})
+  it 'writes the data to the S3 bucket' do
+    expect(gateway.write(data: data)).to eq({})
   end
 
-  context 'when we read from the S3 file' do
+  context 'when reading a file from the S3 bucket' do
     before do
       Rails.application.config.s3_aws_config = {
         stub_responses: {
@@ -23,8 +23,8 @@ describe Gateways::S3 do
       }
     end
 
-    it 'returns the contents' do
-      expect(subject.read).to eq('some data')
+    it 'returns the contents of the file' do
+      expect(gateway.read).to eq('some data')
     end
   end
 end

--- a/spec/gateways/zendesk_support_tickets_spec.rb
+++ b/spec/gateways/zendesk_support_tickets_spec.rb
@@ -1,13 +1,14 @@
 describe Gateways::ZendeskSupportTickets do
   include_context 'with a mocked support tickets client'
+  subject(:ticket_gateway) { described_class.new }
 
-  context 'creating a ticket' do
+  context 'when creating a ticket' do
     before do
       ENV['ZENDESK_API_ENDPOINT'] = 'https://zendesk-example.api.com'
       ENV['ZENDESK_API_USER'] = 'example-zendesk-admin@user.com'
       ENV['ZENDESK_API_TOKEN'] = 'abcdefghihgfedcba'
 
-      subject.create(
+      ticket_gateway.create(
         subject: 'example subject',
         email: 'alice@company.com',
         name: requester_name,
@@ -68,10 +69,10 @@ describe Gateways::ZendeskSupportTickets do
     end
   end
 
-  context 'creating multiple tickets' do
+  context 'when creating multiple tickets' do
     before do
       3.times do
-        subject.create(
+        ticket_gateway.create(
           subject: 'example subject',
           email: 'alice@company.com',
           name: 'alice',
@@ -80,7 +81,7 @@ describe Gateways::ZendeskSupportTickets do
       end
     end
 
-    it 'creates three tickets' do
+    it 'creates all desired number of tickets' do
       expect(support_tickets.count).to eq(3)
     end
   end


### PR DESCRIPTION
**WHY:**
Consistency & general housekeeping.

**IN THIS PR:**
Lint and refactor the following files in the `spec/gateways` folder:
    - `spec/gateways/s3_spec.rb`
    - `spec/gateways/zendesk_support_tickets_spec.rb`
    - `spec/gateways/govuk_organisations_register_gateway_spec.rb`
    - `spec/gateways/ips_spec.rb`

**Any suggestions/feedback would be appreciated.**