### PR TITLE
ensure we set the new build arg for deployment images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,7 @@ def deploy(deploy_environment) {
     sh("eval \$(aws ecr get-login --no-include-email)")
     def appImage = docker.build(
       "govwifi/admin:${deploy_environment}",
-      "--build-arg BUNDLE_INSTALL_CMD='bundle install --without test' ."
+      "--build-arg BUNDLE_INSTALL_FLAGS='--without test development' ."
     )
     appImage.push()
     runMigrations(deploy_environment)


### PR DESCRIPTION
a recent change means we only pass flags in now. Ensure we building production ready images for deployment