### PR TITLE
Lint support specs part two v2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,8 +9,6 @@ AllCops:
     - spec/support/notifications_service.rb
     - spec/support/confirmation_use_case.rb
     - spec/support/unlock_account_use_case_spy.rb
-    - spec/support/reset_password_use_case.rb
-    - spec/support/invite_use_case.rb
     - spec/use_cases/radius/generate_ip_whitelist_spec.rb
     - spec/use_cases/generate_radius_secret_key_spec.rb
     - spec/use_cases/performance_platform/publish_locations_ips_spec.rb

--- a/spec/features/invite_existing_user_spec.rb
+++ b/spec/features/invite_existing_user_spec.rb
@@ -6,7 +6,7 @@ describe 'Inviting an existing user', type: :feature do
   let(:betty) { create(:user) }
   let(:confirmed_user) { create(:user) }
 
-  include_examples 'invite use case spy'
+  include_examples 'when sending an invite email'
 
   context 'with a confirmed user' do
     before do

--- a/spec/features/super_admin/invite_user_to_organisation_spec.rb
+++ b/spec/features/super_admin/invite_user_to_organisation_spec.rb
@@ -14,7 +14,7 @@ describe "Inviting a team member as a super admin", type: :feature do
   end
 
   include_examples 'notifications service'
-  include_examples 'invite use case spy'
+  include_examples 'when sending an invite email'
 
   it "will take the user to the organisation when they click 'back to organisation'" do
     click_on 'Back to organisation'

--- a/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
+++ b/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
@@ -6,7 +6,7 @@ describe "Sign up from invitation", type: :feature do
   let(:invited_user_email) { "invited@gov.uk" }
   let(:user) { create(:user) }
 
-  include_examples 'invite use case spy'
+  include_examples 'when sending an invite email'
   include_examples 'notifications service'
 
   # rubocop:disable RSpec/HooksBeforeExamples

--- a/spec/features/team/invite_a_team_member_spec.rb
+++ b/spec/features/team/invite_a_team_member_spec.rb
@@ -14,7 +14,7 @@ describe "Inviting a team member", type: :feature do
   context "when inviting a team member" do
     let(:user) { create(:user) }
 
-    include_examples 'invite use case spy'
+    include_examples 'when sending an invite email'
     include_examples 'notifications service'
     include_examples 'confirmation use case spy'
 

--- a/spec/features/team/resend_invitation_spec.rb
+++ b/spec/features/team/resend_invitation_spec.rb
@@ -6,7 +6,7 @@ describe 'Resending an invitation to a team member', type: :feature do
   let(:invited_user_email) { 'invited@gov.uk' }
   let(:user) { create(:user) }
 
-  include_examples 'invite use case spy'
+  include_examples 'when sending an invite email'
   include_examples 'notifications service'
 
   # rubocop:disable RSpec/HooksBeforeExamples

--- a/spec/requests/users/invitations/create_spec.rb
+++ b/spec/requests/users/invitations/create_spec.rb
@@ -11,7 +11,7 @@ describe "POST /users/invitation", type: :request do
   end
 
   include_examples 'notifications service'
-  include_examples 'invite use case spy'
+  include_examples 'when sending an invite email'
 
   context 'with tampered organisation_id parameter' do
     let(:email) { 'barry@gov.uk' }

--- a/spec/support/invite_use_case.rb
+++ b/spec/support/invite_use_case.rb
@@ -1,4 +1,4 @@
-shared_context 'invite use case spy' do
+shared_context 'when sending an invite email' do
   require_relative './invite_use_case_spy'
 
   before do

--- a/spec/support/reset_password_use_case.rb
+++ b/spec/support/reset_password_use_case.rb
@@ -1,4 +1,4 @@
-shared_context 'reset password use case spy' do
+shared_context 'when resetting a password' do
   require_relative './reset_password_use_case_spy'
 
   before do


### PR DESCRIPTION
Lint and refactor the following files in the spec/requests folder:

`spec/support/reset_password_use_case.rb`
`spec/support/invite_use_case.rb`

Rename shared example usage were relevant