### PR TITLE
Rollback alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,8 @@
-FROM ruby:2.6.2-alpine3.9
+FROM ruby:2.6.2
+ARG BUNDLE_INSTALL_CMD
 
 # required for certain linting tools that read files, such as erb-lint
 ENV LANG 'C.UTF-8'
-
-WORKDIR /usr/src/app
-
-RUN apk add --no-cache nodejs yarn build-base mysql-dev bash
-
-COPY Gemfile Gemfile.lock .ruby-version ./
-
-ARG BUNDLE_INSTALL_FLAGS
-RUN echo "${BUNDLE_INSTALL_FLAGS}"
-RUN bundle install --no-cache ${BUNDLE_INSTALL_FLAGS}
-
-COPY package.json yarn.lock ./
-RUN yarn && yarn cache clean
-
-RUN apk del build-base
-
-COPY . .
 
 ENV RACK_ENV development
 ENV DB_USER root
@@ -41,7 +25,21 @@ ENV RR_DB_PASS root
 ENV RR_DB_HOST rr_db
 ENV RR_DB_NAME rr_govwifi
 
-RUN mkdir -p /tmp
+WORKDIR /usr/src/app
+
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+  apt-get update && apt-get install -y apt-transport-https nodejs libuv1 && \
+  curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.9.4 && \
+  rm -rf /var/lib/apt/lists/*
+ENV PATH "$PATH:/root/.yarn/bin:/root/.config/yarn/global/node_modules/.bin"
+
+COPY Gemfile Gemfile.lock .ruby-version ./
+RUN ${BUNDLE_INSTALL_CMD}
+
+COPY package.json yarn.lock ./
+RUN yarn
+
+COPY . .
 
 ARG RUN_PRECOMPILATION=true
 RUN if [ ${RUN_PRECOMPILATION} = 'true' ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.2
+FROM ruby:2.6.2-slim
 ARG BUNDLE_INSTALL_CMD
 
 # required for certain linting tools that read files, such as erb-lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
 ENV PATH "$PATH:/root/.yarn/bin:/root/.config/yarn/global/node_modules/.bin"
 
 COPY Gemfile Gemfile.lock .ruby-version ./
-RUN ${BUNDLE_INSTALL_CMD}
+ARG BUNDLE_INSTALL_FLAGS
+RUN bundle install --no-cache ${BUNDLE_INSTALL_FLAGS}
 
 COPY package.json yarn.lock ./
 RUN yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.2-slim
+FROM ruby:2.6.2
 ARG BUNDLE_INSTALL_CMD
 
 # required for certain linting tools that read files, such as erb-lint


### PR DESCRIPTION
This is a partial revert of #617 

We seem to have some issues on our Jenkins installation where every so often, builds will fail due to issues with the `/tmp` directory.

Roll back to debian as a short term resolution