### PR TITLE
Refactor and improve specs for displaying radius Ips

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,6 @@ AllCops:
     - spec/use_cases/organisation/view_radius_ip_addresses_spec.rb
     - spec/use_cases/administrator/publish_signup_whitelist_spec.rb
     - spec/use_cases/administrator/create_support_ticket_spec.rb
-    - spec/features/guidance_after_sign_in_spec.rb
     - spec/features/registration/sign_up_as_an_organisation_spec.rb
     - spec/features/registration/resend_confirmation_instructions_spec.rb
     - spec/features/contact_us_when_not_signed_in_spec.rb

--- a/app/assets/stylesheets/components/plain_list.scss
+++ b/app/assets/stylesheets/components/plain_list.scss
@@ -1,4 +1,4 @@
 .plain-list {
   list-style-type: none;
-  padding-left: 0px;
+  padding-left: 0;
 }

--- a/app/assets/stylesheets/components/plain_list.scss
+++ b/app/assets/stylesheets/components/plain_list.scss
@@ -1,0 +1,4 @@
+.plain-list {
+  list-style-type: none;
+  padding-left: 0px;
+}

--- a/app/views/application/_radius_details.html.erb
+++ b/app/views/application/_radius_details.html.erb
@@ -16,12 +16,17 @@
     <% end %>
 
     <h3> London: </h3>
-    <% london_ips.each do |ip| %>
-      <p class="govuk-body"> <%= ip %>
-    <% end %>
+    <ul class="plain-list" id="london-radius-ips">
+      <% london_ips.each do |ip| %>
+        <li><p class="govuk-body"> <%= ip %></li>
+      <% end %>
+    </ul>
+
     <h3> Dublin: </h3>
-    <% dublin_ips.each do |ip| %>
-      <p class="govuk-body"> <%= ip %>
-    <% end %>
+    <ul class="plain-list" id="dublin-radius-ips">
+      <% dublin_ips.each do |ip| %>
+        <li><p class="govuk-body"> <%= ip %></li>
+      <% end %>
+    </ul>
   </div>
 </details>

--- a/spec/features/guidance_after_sign_in_spec.rb
+++ b/spec/features/guidance_after_sign_in_spec.rb
@@ -1,4 +1,4 @@
-describe 'guidance after sign in' do
+describe 'Guidance after sign in', type: :feature do
   include_context 'with a mocked notifications client'
 
   let(:user) { create(:user) }
@@ -18,12 +18,11 @@ describe 'guidance after sign in' do
 
     before { visit root_path }
 
-    it 'shows me the landing guidance' do
+    it 'displays the landing guidance' do
       expect(page).to have_content 'Get GovWifi'
-      expect(page).to have_content 'If you have trouble setting up GovWifi,'
     end
 
-    context 'and an IP, clicking on that IP' do
+    context 'with one IP' do
       let(:ip_address) { '141.0.149.130' }
 
       before do
@@ -32,13 +31,13 @@ describe 'guidance after sign in' do
         click_on '1 IP'
       end
 
-      it 'shows me the IP address' do
+      it 'displays the IP address' do
         expect(page).to have_content(ip_address)
       end
     end
 
-    context 'and no IPs' do
-      it 'shows me I can add new IPs' do
+    context 'with no IPs' do
+      it 'allows user to add new IPs' do
         click_on 'add the IPs'
         expect(page).to have_content('Enter IP address')
       end
@@ -55,17 +54,14 @@ describe 'guidance after sign in' do
         ENV['DUBLIN_RADIUS_IPS'] = "#{radius_ip_3},#{radius_ip_4}"
       end
 
-      it 'displays RADIUS settings' do
-        expect(page).to have_content('RADIUS')
-        expect(page).to have_content('London')
-        expect(page).to have_content('Dublin')
+      it 'displays the London IPs' do
+        ips = page.all(:css, '#london-radius-ips li').map(&:text)
+        expect(ips).to match_array([radius_ip_1, radius_ip_2])
       end
 
-      it 'displays the correct IPs' do
-        expect(page).to have_content(radius_ip_1)
-        expect(page).to have_content(radius_ip_2)
-        expect(page).to have_content(radius_ip_3)
-        expect(page).to have_content(radius_ip_4)
+      it 'displays the Dublin IPs' do
+        ips = page.all(:css, '#dublin-radius-ips li').map(&:text)
+        expect(ips).to match_array([radius_ip_3, radius_ip_4])
       end
     end
   end


### PR DESCRIPTION
This list of Ips should have been a `ul` from the start. So I've fixed this which makes it easier to test properly and pass linting.

Still looks the same: 
![Screenshot 2019-04-08 at 17 05 17](https://user-images.githubusercontent.com/2160769/55739748-93b45380-5a21-11e9-82d0-ee20f64b8c51.png)
