### PR TITLE
cache the ruby debian image

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -30,7 +30,7 @@ resources:
     type: registry-image
     source:
       repository: ruby
-      tag: 2.6.2-alpine3.9
+      tag: '2.6.2'
 
   - name: nginx-image
     type: registry-image


### PR DESCRIPTION
We've recently moved from ruby-alpine to debian, as alpine was giving us some issues.

Ensure we're caching the correct image, which takes us from 9 minutes to 4.5 minute run times