### PR TITLE
Lint all remaining ruby files

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/BlockLength
 guard :rspec, cmd: "bundle exec rspec" do
   require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)
@@ -42,3 +43,4 @@ guard :rspec, cmd: "bundle exec rspec" do
     Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ serve: stop build
 
 lint: lint-ruby lint-sass lint-erb
 lint-ruby: build
-	$(DOCKER_COMPOSE) run --rm app bundle exec govuk-lint-ruby app lib spec Gemfile
+	$(DOCKER_COMPOSE) run --rm app bundle exec govuk-lint-ruby
 lint-sass: build
 	$(DOCKER_COMPOSE) run --rm app bundle exec govuk-lint-sass app/assets/stylesheets
 lint-erb: build

--- a/bin/setup
+++ b/bin/setup
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 require 'pathname'
 require 'fileutils'
+# rubocop:disable Style/MixinUsage
 include FileUtils
+# rubocop:enable Style/MixinUsage
 
 # path to your application root.
 APP_ROOT = Pathname.new File.expand_path('..', __dir__)

--- a/bin/update
+++ b/bin/update
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 require 'pathname'
 require 'fileutils'
+# rubocop:disable Style/MixinUsage
 include FileUtils
+# rubocop:enable Style/MixinUsage
 
 # path to your application root.
 APP_ROOT = Pathname.new File.expand_path('..', __dir__)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,6 @@
 require 'action_mailer/railtie'
+
+# rubocop:disable Metrics/BlockLength
 Rails.application.configure do
   config.active_storage.service = :local
   # Settings specified here will take precedence over those in config/application.rb.
@@ -105,4 +107,5 @@ Rails.application.configure do
     }
   }
 end
+# rubocop:enable Metrics/BlockLength
 ActionMailer::Base.perform_deliveries = false

--- a/config/initializers/read_replica_database.rb
+++ b/config/initializers/read_replica_database.rb
@@ -1,2 +1,4 @@
-config = File.read(File.join( Rails.root, 'config', 'database.yml'))
+config = File.read(File.join(Rails.root, 'config', 'database.yml'))
+# rubocop:disable Security/YAMLLoad
 READ_REPLICA_DB = YAML.load(ERB.new(config).result).fetch('read_replica')
+# rubocop:enable Security/YAMLLoad

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   root 'home#index'
 
@@ -72,7 +73,8 @@ Rails.application.routes.draw do
     resources :authorised_email_domains, only: %i[index new create destroy]
   end
 
-  %w( 404 422 500 ).each do |code|
+  %w(404 422 500).each do |code|
     get code, to: 'application#error', code: code
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@ super_admin_organisation = Organisation.create!(
   name: 'GovWifi Super Administrators', service_email: 'it@gds.com', super_admin: true
 )
 
-admin_user = super_admin_organisation.users.create(
+super_admin_organisation.users.create(
   email: "admin@gov.uk",
   password: "password",
   name: "Steve",
@@ -18,7 +18,7 @@ admin_user = super_admin_organisation.users.create(
 organisation = Organisation.create(
   name: 'UKTI Education', service_email: 'it@parks.com'
 )
-user = organisation.users.create(
+organisation.users.create(
   email: "test@gov.uk",
   password: "password",
   name: "Steve",
@@ -45,28 +45,29 @@ end
   )
 end
 
-location_1 = Location.create!(
+location_one = Location.create!(
   address: 'Momentum Centre, London',
   postcode: 'SE10SX',
   organisation_id: organisation.id
 )
 
-location_2 = Location.create!(
+location_two = Location.create!(
   address: '136 Southwark Street, London',
   postcode: 'E33EH',
   organisation_id: organisation.id
 )
 
 20.times do
-  Ip.create!(address: Faker::Internet.unique.public_ip_v4_address, location: location_1)
+  Ip.create!(address: Faker::Internet.unique.public_ip_v4_address, location: location_one)
 end
 
 20.times do
-  Ip.create!(address: Faker::Internet.unique.public_ip_v4_address, location: location_2)
+  Ip.create!(address: Faker::Internet.unique.public_ip_v4_address, location: location_two)
 end
 
-location_2.ips.each_with_index do |ip, index|
-  Session.create(start: (Time.now - index.day).to_s,
+location_two.ips.each_with_index do |ip, index|
+  Session.create(
+    start: (Time.now - index.day).to_s,
     success: index.even?,
     username: "Garry",
     siteIP: ip.address


### PR DESCRIPTION
Removes the arguments from  `bundle exec govuk-lint-ruby` in the `Makefile`.

Did a lot of disabling here.