### PR TITLE
Add custom IPv6 error message

### DIFF
--- a/app/models/ip.rb
+++ b/app/models/ip.rb
@@ -12,12 +12,7 @@ private
 
   def address_must_be_valid_ip
     checker = UseCases::Administrator::CheckIfValidIp.new
-    valid_ipv4 = checker.execute(self.address)[:success]
-    valid_ipv6 = checker.execute(self.address)[:ipv6?]
-    ipv6_message = "'#{self.address}' is an IPv6 address. Only IPv4 addresses can be added."
-    return errors.add(:address, ipv6_message) if valid_ipv6
-
-    message = "'#{self.address}' is not valid"
-    errors.add(:address, message) unless valid_ipv4
+    results = checker.execute(self.address)
+    errors.add(:address, results[:error_message]) unless results[:success]
   end
 end

--- a/app/models/ip.rb
+++ b/app/models/ip.rb
@@ -13,11 +13,11 @@ private
   def address_must_be_valid_ip
     checker = UseCases::Administrator::CheckIfValidIp.new
     valid_ipv4 = checker.execute(self.address)[:success]
-    valid_ipv6 = checker.execute(self.address)[:ipv6]
-    message2 = "'#{self.address}' is an IPv6 address. Only IPv4 addresses can be added."
-    return errors.add(:address, message2) if valid_ipv6
+    valid_ipv6 = checker.execute(self.address)[:ipv6?]
+    ipv6_message = "'#{self.address}' is an IPv6 address. Only IPv4 addresses can be added."
+    return errors.add(:address, ipv6_message) if valid_ipv6
 
     message = "'#{self.address}' is not valid"
-    errors.add(:address, message) unless valid_ipv4 && !valid_ipv6
+    errors.add(:address, message) unless valid_ipv4
   end
 end

--- a/app/models/ip.rb
+++ b/app/models/ip.rb
@@ -12,8 +12,12 @@ private
 
   def address_must_be_valid_ip
     checker = UseCases::Administrator::CheckIfValidIp.new
-    valid_ip = checker.execute(self.address)[:success]
+    valid_ipv4 = checker.execute(self.address)[:success]
+    valid_ipv6 = checker.execute(self.address)[:ipv6]
+    message2 = "'#{self.address}' is an IPv6 address. Only IPv4 addresses can be added."
+    return errors.add(:address, message2) if valid_ipv6
+
     message = "'#{self.address}' is not valid"
-    errors.add(:address, message) unless valid_ip
+    errors.add(:address, message) unless valid_ipv4 && !valid_ipv6
   end
 end

--- a/lib/use_cases/administrator/check_if_valid_ip.rb
+++ b/lib/use_cases/administrator/check_if_valid_ip.rb
@@ -3,7 +3,7 @@ module UseCases
     class CheckIfValidIp
       def execute(address)
         @address = address
-        { success: valid_address? }
+        { success: valid_address?, ipv6: ipv6_address? }
       end
 
     private
@@ -13,6 +13,15 @@ module UseCases
       def valid_address?
         address.present? &&
           address_is_ipv4? &&
+          address_is_not_subnet? &&
+          address_does_not_allows_all? &&
+          address_is_not_loopback? &&
+          address_is_not_private?
+      end
+
+      def ipv6_address?
+        address.present? &&
+          address_is_ipv6? &&
           address_is_not_subnet? &&
           address_does_not_allows_all? &&
           address_is_not_loopback? &&
@@ -30,6 +39,14 @@ module UseCases
       def address_is_ipv4?
         begin
           IPAddr.new(address).ipv4?
+        rescue IPAddr::InvalidAddressError
+          false
+        end
+      end
+
+      def address_is_ipv6?
+        begin
+          IPAddr.new(address).ipv6?
         rescue IPAddr::InvalidAddressError
           false
         end

--- a/lib/use_cases/administrator/check_if_valid_ip.rb
+++ b/lib/use_cases/administrator/check_if_valid_ip.rb
@@ -3,7 +3,7 @@ module UseCases
     class CheckIfValidIp
       def execute(address)
         @address = address
-        { success: valid_ipv4_address?, ipv6?: valid_ipv6_address? }
+        { success: valid_ipv4_address?, error_message: custom_error_message }
       end
 
     private
@@ -26,6 +26,12 @@ module UseCases
           address_does_not_allows_all? &&
           address_is_not_loopback? &&
           address_is_not_private?
+      end
+
+      def custom_error_message
+        return "'#{address}' is an IPv6 address. Only IPv4 addresses can be added." if valid_ipv6_address?
+
+        "'#{address}' is not valid" if !valid_ipv4_address?
       end
 
       def address_does_not_allows_all?

--- a/lib/use_cases/administrator/check_if_valid_ip.rb
+++ b/lib/use_cases/administrator/check_if_valid_ip.rb
@@ -3,14 +3,14 @@ module UseCases
     class CheckIfValidIp
       def execute(address)
         @address = address
-        { success: valid_address?, ipv6: ipv6_address? }
+        { success: valid_ipv4_address?, ipv6?: valid_ipv6_address? }
       end
 
     private
 
       attr_reader :address
 
-      def valid_address?
+      def valid_ipv4_address?
         address.present? &&
           address_is_ipv4? &&
           address_is_not_subnet? &&
@@ -19,7 +19,7 @@ module UseCases
           address_is_not_private?
       end
 
-      def ipv6_address?
+      def valid_ipv6_address?
         address.present? &&
           address_is_ipv6? &&
           address_is_not_subnet? &&

--- a/spec/features/ips/add_ip_to_existing_location_spec.rb
+++ b/spec/features/ips/add_ip_to_existing_location_spec.rb
@@ -37,6 +37,18 @@ describe 'Adding an IP to an existing location', type: :feature do
         expect(location.reload.ips).to be_empty
       end
     end
+
+    context 'with the wrong IP format' do
+      let(:ip_address) { 'FE80::0202:B3FF:FE1E:8329' }
+
+      it 'does not add an IP to the location' do
+        expect(location.reload.ips).to be_empty
+      end
+
+      it 'shows a error message' do
+        expect(page).to have_content("'FE80::0202:B3FF:FE1E:8329' is an IPv6 address. Only IPv4 addresses can be added")
+      end
+    end
   end
 
   context 'when selecting another location' do

--- a/spec/features/ips/add_ip_to_existing_location_spec.rb
+++ b/spec/features/ips/add_ip_to_existing_location_spec.rb
@@ -38,14 +38,14 @@ describe 'Adding an IP to an existing location', type: :feature do
       end
     end
 
-    context 'with the wrong IP format' do
+    context 'with data as an IPv6 address' do
       let(:ip_address) { 'FE80::0202:B3FF:FE1E:8329' }
 
       it 'does not add an IP to the location' do
         expect(location.reload.ips).to be_empty
       end
 
-      it 'shows a error message' do
+      it 'shows an error message' do
         expect(page).to have_content("'FE80::0202:B3FF:FE1E:8329' is an IPv6 address. Only IPv4 addresses can be added")
       end
     end

--- a/spec/models/ip_spec.rb
+++ b/spec/models/ip_spec.rb
@@ -48,7 +48,7 @@ describe Ip do
         expect(described_class.count).to eq(0)
       end
 
-      it "displays an an error message" do
+      it "displays an error message" do
         expect(ip.errors.full_messages).to eq([
           "Address '2001:db8:0:1234:0:567:8:1' is an IPv6 address. Only IPv4 addresses can be added."
         ])

--- a/spec/models/ip_spec.rb
+++ b/spec/models/ip_spec.rb
@@ -29,7 +29,7 @@ describe Ip do
       end
     end
 
-    context "with a valid address" do
+    context "with a valid IPv4 address" do
       let!(:ip) { described_class.create(address: "141.0.149.130", location: location) }
 
       it "saves the IP" do
@@ -38,6 +38,20 @@ describe Ip do
 
       it "does not display an an error message" do
         expect(ip.errors.full_messages).to eq([])
+      end
+    end
+
+    context "with a valid IPv6 address" do
+      let!(:ip) { described_class.create(address: "2001:db8:0:1234:0:567:8:1", location: location) }
+
+      it "does not save the IP" do
+        expect(described_class.count).to eq(0)
+      end
+
+      it "displays an an error message" do
+        expect(ip.errors.full_messages).to eq([
+          "Address '2001:db8:0:1234:0:567:8:1' is an IPv6 address. Only IPv4 addresses can be added."
+        ])
       end
     end
   end

--- a/spec/use_cases/administrator/check_if_valid_ip_spec.rb
+++ b/spec/use_cases/administrator/check_if_valid_ip_spec.rb
@@ -1,5 +1,6 @@
 describe UseCases::Administrator::CheckIfValidIp do
   subject(:use_case) { described_class.new }
+
   let(:success_result) { use_case.execute(address)[:success] }
   let(:is_ipv6?) { use_case.execute(address)[:ipv6?] }
 

--- a/spec/use_cases/administrator/check_if_valid_ip_spec.rb
+++ b/spec/use_cases/administrator/check_if_valid_ip_spec.rb
@@ -2,7 +2,7 @@ describe UseCases::Administrator::CheckIfValidIp do
   subject(:use_case) { described_class.new }
 
   let(:success_result) { use_case.execute(address)[:success] }
-  let(:is_ipv6?) { use_case.execute(address)[:ipv6?] }
+  let(:error_message) { use_case.execute(address)[:error_message] }
 
   context 'when invalid' do
     context 'with an invalid IP address' do
@@ -10,6 +10,10 @@ describe UseCases::Administrator::CheckIfValidIp do
 
       it 'returns false' do
         expect(success_result).to eq(false)
+      end
+
+      it 'returns a custom error message' do
+        expect(error_message).to eq("'#{address}' is not valid")
       end
     end
 
@@ -86,8 +90,8 @@ describe UseCases::Administrator::CheckIfValidIp do
         expect(success_result).to eq(false)
       end
 
-      it 'recognises the address format' do
-        expect(is_ipv6?).to eq(true)
+      it 'returns a custom error message' do
+        expect(error_message).to eq("'#{address}' is an IPv6 address. Only IPv4 addresses can be added.")
       end
     end
   end

--- a/spec/use_cases/administrator/check_if_valid_ip_spec.rb
+++ b/spec/use_cases/administrator/check_if_valid_ip_spec.rb
@@ -1,13 +1,14 @@
 describe UseCases::Administrator::CheckIfValidIp do
   subject(:use_case) { described_class.new }
+  let(:success_result) { use_case.execute(address)[:success] }
+  let(:is_ipv6?) { use_case.execute(address)[:ipv6?] }
 
   context 'when invalid' do
     context 'with an invalid IP address' do
       let(:address) { "incorrectIP" }
 
       it 'returns false' do
-        result = use_case.execute(address)[:success]
-        expect(result).to eq(false)
+        expect(success_result).to eq(false)
       end
     end
 
@@ -15,8 +16,7 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { "10.255.255.255" }
 
       it 'returns false' do
-        result = use_case.execute(address)[:success]
-        expect(result).to eq(false)
+        expect(success_result).to eq(false)
       end
     end
 
@@ -24,8 +24,7 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { '' }
 
       it 'returns false' do
-        result = use_case.execute(address)[:success]
-        expect(result).to eq(false)
+        expect(success_result).to eq(false)
       end
     end
 
@@ -33,8 +32,7 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { nil }
 
       it 'returns false' do
-        result = use_case.execute(address)[:success]
-        expect(result).to eq(false)
+        expect(success_result).to eq(false)
       end
     end
 
@@ -42,8 +40,7 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { '172.16.254.1.' }
 
       it 'returns false' do
-        result = use_case.execute(address)[:success]
-        expect(result).to eq(false)
+        expect(success_result).to eq(false)
       end
     end
 
@@ -51,8 +48,7 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { '172.16.254.1 ' }
 
       it 'returns false' do
-        result = use_case.execute(address)[:success]
-        expect(result).to eq(false)
+        expect(success_result).to eq(false)
       end
     end
 
@@ -60,8 +56,7 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { '192.618.0.1' }
 
       it 'returns false' do
-        result = use_case.execute(address)[:success]
-        expect(result).to eq(false)
+        expect(success_result).to eq(false)
       end
     end
 
@@ -69,8 +64,7 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { '127.0.0.1' }
 
       it 'returns false' do
-        result = use_case.execute(address)[:success]
-        expect(result).to eq(false)
+        expect(success_result).to eq(false)
       end
     end
   end
@@ -80,8 +74,7 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { '192.168.1.15/24' }
 
       it 'returns false' do
-        result = use_case.execute(address)[:success]
-        expect(result).to eq(false)
+        expect(success_result).to eq(false)
       end
     end
 
@@ -89,13 +82,11 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { '2001:db8:0:1234:0:567:8:1' }
 
       it 'returns false' do
-        result = use_case.execute(address)[:success]
-        expect(result).to eq(false)
+        expect(success_result).to eq(false)
       end
 
-      it 'recognises address as IPv6' do
-        result = use_case.execute(address)[:ipv6]
-        expect(result).to eq(true)
+      it 'recognises the address format' do
+        expect(is_ipv6?).to eq(true)
       end
     end
   end
@@ -105,8 +96,7 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { '141.0.149.130' }
 
       it 'returns true' do
-        result = use_case.execute(address)[:success]
-        expect(result).to eq(true)
+        expect(success_result).to eq(true)
       end
     end
   end

--- a/spec/use_cases/administrator/check_if_valid_ip_spec.rb
+++ b/spec/use_cases/administrator/check_if_valid_ip_spec.rb
@@ -6,8 +6,8 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { "incorrectIP" }
 
       it 'returns false' do
-        result = use_case.execute(address)
-        expect(result).to eq(success: false)
+        result = use_case.execute(address)[:success]
+        expect(result).to eq(false)
       end
     end
 
@@ -15,8 +15,8 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { "10.255.255.255" }
 
       it 'returns false' do
-        result = use_case.execute(address)
-        expect(result).to eq(success: false)
+        result = use_case.execute(address)[:success]
+        expect(result).to eq(false)
       end
     end
 
@@ -24,8 +24,8 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { '' }
 
       it 'returns false' do
-        result = use_case.execute(address)
-        expect(result).to eq(success: false)
+        result = use_case.execute(address)[:success]
+        expect(result).to eq(false)
       end
     end
 
@@ -33,8 +33,8 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { nil }
 
       it 'returns false' do
-        result = use_case.execute(address)
-        expect(result).to eq(success: false)
+        result = use_case.execute(address)[:success]
+        expect(result).to eq(false)
       end
     end
 
@@ -42,8 +42,8 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { '172.16.254.1.' }
 
       it 'returns false' do
-        result = use_case.execute(address)
-        expect(result).to eq(success: false)
+        result = use_case.execute(address)[:success]
+        expect(result).to eq(false)
       end
     end
 
@@ -51,8 +51,8 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { '172.16.254.1 ' }
 
       it 'returns false' do
-        result = use_case.execute(address)
-        expect(result).to eq(success: false)
+        result = use_case.execute(address)[:success]
+        expect(result).to eq(false)
       end
     end
 
@@ -60,8 +60,8 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { '192.618.0.1' }
 
       it 'returns false' do
-        result = use_case.execute(address)
-        expect(result).to eq(success: false)
+        result = use_case.execute(address)[:success]
+        expect(result).to eq(false)
       end
     end
 
@@ -69,8 +69,8 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { '127.0.0.1' }
 
       it 'returns false' do
-        result = use_case.execute(address)
-        expect(result).to eq(success: false)
+        result = use_case.execute(address)[:success]
+        expect(result).to eq(false)
       end
     end
   end
@@ -80,8 +80,8 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { '192.168.1.15/24' }
 
       it 'returns false' do
-        result = use_case.execute(address)
-        expect(result).to eq(success: false)
+        result = use_case.execute(address)[:success]
+        expect(result).to eq(false)
       end
     end
 
@@ -89,8 +89,13 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { '2001:db8:0:1234:0:567:8:1' }
 
       it 'returns false' do
-        result = use_case.execute(address)
-        expect(result).to eq(success: false)
+        result = use_case.execute(address)[:success]
+        expect(result).to eq(false)
+      end
+
+      it 'recognises address as IPv6' do
+        result = use_case.execute(address)[:ipv6]
+        expect(result).to eq(true)
       end
     end
   end
@@ -100,8 +105,8 @@ describe UseCases::Administrator::CheckIfValidIp do
       let(:address) { '141.0.149.130' }
 
       it 'returns true' do
-        result = use_case.execute(address)
-        expect(result).to eq(success: true)
+        result = use_case.execute(address)[:success]
+        expect(result).to eq(true)
       end
     end
   end

--- a/spec/use_cases/administrator/check_if_valid_ip_spec.rb
+++ b/spec/use_cases/administrator/check_if_valid_ip_spec.rb
@@ -103,6 +103,10 @@ describe UseCases::Administrator::CheckIfValidIp do
       it 'returns true' do
         expect(success_result).to eq(true)
       end
+
+      it 'does not return a custom error message' do
+        expect(error_message).to eq(nil)
+      end
     end
   end
 end


### PR DESCRIPTION
**WHY:**
An IPv4 address is what we take from the user. 
We don't accept other types of IP addresses and we let the user know through error messaging when an invalid IP address was inputted.

However, the error message displayed to the user is vague.
When a user enters a valid IPv6 address they see:
 `'1200:0000:AB00:1234:0000:2552:7777:1313' is not valid`
but are not informed why it is not valid.

IN THIS PR:
- Add hash key-value to the use case that checks the validity of submitted IP addresses. This would describe whether the IP address is IPv6 or not.
- Add custom error message for when the value of the IPv6 hash key is true.
- Refactor modified files.

**BEFORE:**

![Screenshot 2019-04-11 at 12 42 46](https://user-images.githubusercontent.com/32823756/55954702-56d1a200-5c57-11e9-9dc2-dcd4a1a37ef8.png)

------------------------------------------------------------------------------------------------------

**AFTER:**
![Screenshot 2019-04-11 at 12 41 59](https://user-images.githubusercontent.com/32823756/55954669-37d31000-5c57-11e9-98fb-24df31309dd2.png)

------------------------------------------------------------------------------------------------------

**Any feedback/suggestions would be appreciated. Especially on the refactoring.**