### PR TITLE
Add custom private IP address error message

### DIFF
--- a/lib/use_cases/administrator/check_if_valid_ip.rb
+++ b/lib/use_cases/administrator/check_if_valid_ip.rb
@@ -28,8 +28,16 @@ module UseCases
           address_is_not_private?
       end
 
+      def private_ip_address?
+        address.present? &&
+          address_is_ipv4? &&
+          !address_is_not_private?
+      end
+
       def custom_error_message
         return "'#{address}' is an IPv6 address. Only IPv4 addresses can be added." if valid_ipv6_address?
+
+        return "'#{address}' is a private IP address. Only public IPv4 addresses can be added." if private_ip_address?
 
         "'#{address}' is not valid" if !valid_ipv4_address?
       end

--- a/spec/features/ips/add_ip_to_existing_location_spec.rb
+++ b/spec/features/ips/add_ip_to_existing_location_spec.rb
@@ -49,6 +49,18 @@ describe 'Adding an IP to an existing location', type: :feature do
         expect(page).to have_content("'FE80::0202:B3FF:FE1E:8329' is an IPv6 address. Only IPv4 addresses can be added")
       end
     end
+
+    context 'with data as a private IP address' do
+      let(:ip_address) { '192.168.0.0' }
+
+      it 'does not add an IP to the location' do
+        expect(location.reload.ips).to be_empty
+      end
+
+      it 'shows an error message' do
+        expect(page).to have_content("'192.168.0.0' is a private IP address. Only public IPv4 addresses can be added.")
+      end
+    end
   end
 
   context 'when selecting another location' do

--- a/spec/models/ip_spec.rb
+++ b/spec/models/ip_spec.rb
@@ -54,6 +54,20 @@ describe Ip do
         ])
       end
     end
+
+    context "with a private address" do
+      let!(:ip) { described_class.create(address: "192.168.0.0", location: location) }
+
+      it "does not save the IP" do
+        expect(described_class.count).to eq(0)
+      end
+
+      it "displays an error message" do
+        expect(ip.errors.full_messages).to eq([
+          "Address '192.168.0.0' is a private IP address. Only public IPv4 addresses can be added."
+        ])
+      end
+    end
   end
 
   context 'when checking availability' do

--- a/spec/use_cases/administrator/check_if_valid_ip_spec.rb
+++ b/spec/use_cases/administrator/check_if_valid_ip_spec.rb
@@ -23,6 +23,10 @@ describe UseCases::Administrator::CheckIfValidIp do
       it 'returns false' do
         expect(success_result).to eq(false)
       end
+
+      it 'returns a custom error message' do
+        expect(error_message).to eq("'#{address}' is a private IP address. Only public IPv4 addresses can be added.")
+      end
     end
 
     context 'with an empty string' do


### PR DESCRIPTION
**WHY:**
A public IPv4 address is what we take from the user. 
We don't accept private IP addresses and we let the user know through error messaging when a private IP address was inputted.

However, the error message displayed to the user is vague.
When a user enters a private IP address they see:
 `'192.168.0.0' is not valid`
but are not informed why it is not valid.

IN THIS PR:
- Add conditional message for private IP addresses.
- Refactor modified files.

**BEFORE:**

![Screenshot 2019-04-11 at 15 53 02](https://user-images.githubusercontent.com/32823756/55971361-3dd9e880-5c79-11e9-9ccd-63a2d62194b8.png)

------------------------------------------------------------------------------------------------------

**AFTER:**

![Screenshot 2019-04-11 at 16 31 50](https://user-images.githubusercontent.com/32823756/55971397-4f22f500-5c79-11e9-96a1-0c0445f1f9d2.png)

------------------------------------------------------------------------------------------------------

**Any feedback/suggestions would be appreciated. Currently looking at refactoring opportunities**