### PR TITLE
Fix multiple ip errors when adding a blank IP

### DIFF
--- a/app/models/ip.rb
+++ b/app/models/ip.rb
@@ -13,6 +13,10 @@ private
   def address_must_be_valid_ip
     checker = UseCases::Administrator::CheckIfValidIp.new
     results = checker.execute(self.address)
-    errors.add(:address, results[:error_message]) unless results[:success]
+    errors.add(:address, results[:error_message]) unless results[:success] || address_not_present?
+  end
+
+  def address_not_present?
+    self.address.nil? || self.address.empty?
   end
 end

--- a/spec/features/ips/add_ip_to_existing_location_spec.rb
+++ b/spec/features/ips/add_ip_to_existing_location_spec.rb
@@ -61,6 +61,18 @@ describe 'Adding an IP to an existing location', type: :feature do
         expect(page).to have_content("'192.168.0.0' is a private IP address. Only public IPv4 addresses can be added.")
       end
     end
+
+    context 'with blank data' do
+      let(:ip_address) { '' }
+
+      it 'does not add an IP to the location' do
+        expect(location.reload.ips).to be_empty
+      end
+
+      it 'shows an error message' do
+        expect(page).to have_content("Address can't be blank")
+      end
+    end
   end
 
   context 'when selecting another location' do

--- a/spec/models/ip_spec.rb
+++ b/spec/models/ip_spec.rb
@@ -15,6 +15,13 @@ describe Ip do
       ])
     end
 
+    it 'does not allow a blank address' do
+      ip = described_class.create(address: '', location: location)
+      expect(ip.errors.full_messages).to eq([
+        "Address can't be blank"
+      ])
+    end
+
     context "with an invalid address" do
       let!(:ip) { described_class.create(address: "invalidIP", location: location) }
 


### PR DESCRIPTION
**WHY:**
When a user is adding an IP and tries to submit a blank IP address field, the user receives two error messages:
 - the blank IP error: `Address can't be blank`
 - the IP invalid errors: `Address '' is not valid`

We should only display the blank error message for when a user tries to submit a blank IP address field. `Address '' is not valid` adds no meaning.

**IN THIS PR:**
- Test that only error message is displayed when a blank IP address is submitted.
- Add condition to skip adding the custom error message when the IP is blank.

------------------------------------------------------------------------------------------------------

**BEFORE:**

<img width="1003" alt="Screenshot 2019-04-12 at 12 34 38" src="https://user-images.githubusercontent.com/32823756/56034659-dd51b680-5d1f-11e9-8588-24e96605d831.png">

------------------------------------------------------------------------------------------------------

**AFTER:**

<img width="1000" alt="Screenshot 2019-04-12 at 12 33 54" src="https://user-images.githubusercontent.com/32823756/56034667-e3e02e00-5d1f-11e9-9002-316f2280d15a.png">

------------------------------------------------------------------------------------------------------

**Any feedback/suggestions would be appreciated.**