### PR TITLE
Edit invalid ip error message

### DIFF
--- a/lib/use_cases/administrator/check_if_valid_ip.rb
+++ b/lib/use_cases/administrator/check_if_valid_ip.rb
@@ -39,7 +39,7 @@ module UseCases
 
         return "'#{address}' is a private IP address. Only public IPv4 addresses can be added." if private_ip_address?
 
-        "'#{address}' is not valid" if !valid_ipv4_address?
+        "'#{address}' is not a valid IP address" if !valid_ipv4_address?
       end
 
       def address_does_not_allows_all?

--- a/spec/features/ips/add_ip_to_existing_location_spec.rb
+++ b/spec/features/ips/add_ip_to_existing_location_spec.rb
@@ -30,7 +30,7 @@ describe 'Adding an IP to an existing location', type: :feature do
       let(:ip_address) { '10.wrong.0.1' }
 
       it 'shows a error message' do
-        expect(page).to have_content("'10.wrong.0.1' is not valid")
+        expect(page).to have_content("'10.wrong.0.1' is not a valid IP address")
       end
 
       it 'does not add an IP to the location' do

--- a/spec/models/ip_spec.rb
+++ b/spec/models/ip_spec.rb
@@ -11,7 +11,7 @@ describe Ip do
     it 'does not allow the address 0.0.0.0' do
       ip = described_class.create(address: '0.0.0.0', location: location)
       expect(ip.errors.full_messages).to eq([
-        "Address '0.0.0.0' is not valid"
+        "Address '0.0.0.0' is not a valid IP address"
       ])
     end
 
@@ -31,7 +31,7 @@ describe Ip do
 
       it "displays an error message" do
         expect(ip.errors.full_messages).to eq([
-          "Address 'invalidIP' is not valid"
+          "Address 'invalidIP' is not a valid IP address"
         ])
       end
     end

--- a/spec/use_cases/administrator/check_if_valid_ip_spec.rb
+++ b/spec/use_cases/administrator/check_if_valid_ip_spec.rb
@@ -13,7 +13,7 @@ describe UseCases::Administrator::CheckIfValidIp do
       end
 
       it 'returns a custom error message' do
-        expect(error_message).to eq("'#{address}' is not valid")
+        expect(error_message).to eq("'#{address}' is not a valid IP address")
       end
     end
 


### PR DESCRIPTION
**WHY:**
When a user enters a wrong IP address (e.g looks like an IP but isn't). The error message currently says for example, `Address '1.2.1111.2222.111' is not valid` which is a bit vague. 

We want the user to be more informed when they see an error message.

**IN THIS PR:**
- Reword the message to read `Address '1.2.1111.2222.111' is not a valid IP address`

------------------------------------------------------------------------------------------------------

**BEFORE:**

![Screenshot 2019-04-15 at 12 02 28](https://user-images.githubusercontent.com/32823756/56127991-5cd8c300-5f76-11e9-9149-f31350eab9b9.png)

------------------------------------------------------------------------------------------------------

**AFTER:**

![Screenshot 2019-04-15 at 11 34 23](https://user-images.githubusercontent.com/32823756/56127997-62360d80-5f76-11e9-9637-6bd58ca07a13.png)

------------------------------------------------------------------------------------------------------

**Any suggestions/feedback would be appreciated. Especially on the rewording.**