### PR TITLE
 Print no results message when filtering in the UI 

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,4 @@ This codebase is released under [the MIT License][mit].
 [notify]:https://www.notifications.service.gov.uk
 [zendesk]:https://govuk.zendesk.com/hc/en-us
 [build-repo]:https://github.com/alphagov/govwifi-build
+

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -26,6 +26,9 @@
     <p class="govuk-body">If your authenticators are allocated IPs dynamically, you can use Firewall NAT rules, so that your requests come from consistent IPs.</p>
 
   <% else %>
+    <p class="govuk-body" id="noLocationResults" style="display: none">
+      No results found
+    </p>
     <% @locations.each do |location| %>
       <%= render "ips/table", location: location %>
     <% end %>

--- a/app/views/shared/_filter_search.html.erb
+++ b/app/views/shared/_filter_search.html.erb
@@ -4,22 +4,32 @@
 
   function filterLocations(){
     let filterValue = document.getElementById('filterInput').value.toUpperCase();
-    let table = document.getElementById('wrapper')
-    let location_name = table.querySelectorAll('table.govuk-table');
-    let ips = table.querySelectorAll('tbody#ips-table');
+    let location_name = document.getElementById('wrapper').querySelectorAll('table.govuk-table');
 
     for(let i = 0;i < location_name.length;i++){
       let text = location_name[i].getElementsByTagName('div')[0];
+      location_name[i].style.display = 'none';
 
       if(text.innerHTML.toUpperCase().indexOf(filterValue) > -1){
         location_name[i].style.display = '';
-        ips[i].style.display = '';
-      } else {
-        location_name[i].style.display = 'none';
-        ips[i].style.display = 'none';
       }
     }
+
+    displayResultsMessage(location_name);
   }
+
+function displayResultsMessage(location_name) {
+  var noResultsMessage = document.getElementById('noLocationResults');
+  noResultsMessage.style.display = 'none';
+
+  var noResults = Array.from(location_name).every(
+    function(e) { return e.style.display == 'none'; }
+  );
+
+  if (noResults) {
+    noResultsMessage.style.display = 'block';
+  }
+}
 </script>
 
 <noscript>


### PR DESCRIPTION
This is a better user experience than not displaying any error messages.

![Screenshot 2019-04-16 at 15 29 58](https://user-images.githubusercontent.com/1215147/56218237-85d38380-605c-11e9-81a5-e28d8b8458dc.png)

