### PR TITLE
Display when an IP is inactive

### DIFF
--- a/app/models/ip.rb
+++ b/app/models/ip.rb
@@ -4,6 +4,14 @@ class Ip < ApplicationRecord
   validates :address, presence: true, uniqueness: true
   validate :address_must_be_valid_ip
 
+  def inactive?
+    Session
+      .where(siteIP: self.address)
+      .where("start > #{Date.today - 10.days}")
+      .limit(1)
+      .empty?
+  end
+
   def available?
     created_at < Date.today.beginning_of_day
   end

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -24,14 +24,19 @@
 
   <tbody class="govuk-table__body" id="ips-table">
     <% location.ips.each do |ip| %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell govuk-!-width-one-third"><%= ip.address %></td>
+      <tr class="govuk-table__row" id="ips-row-<%= ip.id %>">
+        <td class="govuk-table__cell govuk-!-width-one-quarter"><%= ip.address %></td>
         <% if ip.available? %>
-          <td class="govuk-table__cell govuk-!-width-one-third">Available</td>
+          <td class="govuk-table__cell govuk-!-width-one-quarter">Available</td>
         <% else %>
-          <td class="govuk-table__cell govuk-!-width-one-third text-red">Not available until 6am tomorrow
+          <td class="govuk-table__cell govuk-!-width-one-quarter text-red">Not available until 6am tomorrow
           </td>
         <% end %>
+        <td class="govuk-table__cell govuk-!-width-one-quarter text-red">
+          <% if ip.inactive? %>
+            Inactive (no traffic for the last 10 days)
+          <% end %>
+        </td>
         <td class="govuk-table__cell text-right">
           <% if current_user.can_manage_locations? %>
             <%= link_to 'Remove', ip_remove_path(ip), class: "govuk-link" %>

--- a/spec/features/ips/view_ip_addresses_spec.rb
+++ b/spec/features/ips/view_ip_addresses_spec.rb
@@ -42,6 +42,27 @@ describe 'Viewing IP addresses', type: :feature do
     it 'shows the locations address' do
       expect(page).to have_content(location.address)
     end
+
+    context 'with inactive IPs' do
+      it 'labels the IP as inactive' do
+        within("#ips-row-#{ip.id}") do
+          expect(page).to have_content('Inactive (no traffic for the last 10 days)')
+        end
+      end
+    end
+
+    context 'with active IPs' do
+      before do
+        Session.create(start: Date.today, username: 'abc123', siteIP: ip.address)
+        visit ips_path
+      end
+
+      it 'Does not label the IP as inactive' do
+        within("#ips-row-#{ip.id}") do
+          expect(page).not_to have_content('Inactive (no traffic for the last 10 days)')
+        end
+      end
+    end
   end
 
   context 'when logged out' do

--- a/spec/models/ip_spec.rb
+++ b/spec/models/ip_spec.rb
@@ -90,4 +90,18 @@ describe Ip do
       it { is_expected.to be_available }
     end
   end
+
+  context 'when checking if inactive' do
+    context 'with no sessions for the last 10 days' do
+      it { is_expected.to be_inactive }
+    end
+
+    context 'with sessions in the last 10 days' do
+      before do
+        Session.create(start: Date.today, username: 'abc123', siteIP: ip_address.address)
+      end
+
+      it { is_expected.not_to be_inactive }
+    end
+  end
 end


### PR DESCRIPTION
Administrators find it challenging to identify which IPs are no longer
serving traffic.  Label an IP as inactive so they can safely remove
them.

<img width="1029" alt="Screenshot 2019-04-17 at 14 45 12" src="https://user-images.githubusercontent.com/1215147/56292638-749f7b00-611f-11e9-9026-4ad9d3725c8e.png">
