### PR TITLE
[WIP]: Allow javascript testing v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ENV RR_DB_NAME rr_govwifi
 WORKDIR /usr/src/app
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-  apt-get update && apt-get install -y apt-transport-https nodejs libuv1 && \
+  apt-get update && apt-get install -y apt-transport-https nodejs libuv1 chromium chromedriver && \
   curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.9.4 && \
   rm -rf /var/lib/apt/lists/*
 ENV PATH "$PATH:/root/.yarn/bin:/root/.config/yarn/global/node_modules/.bin"

--- a/Gemfile
+++ b/Gemfile
@@ -33,9 +33,11 @@ group :test do
   gem 'guard-rspec'
   gem 'nokogiri'
   gem 'rspec-rails', '~> 3'
+  gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 4.0'
   gem 'simplecov', require: false
   gem 'timecop', '~> 0.9.1'
+  gem 'webdrivers', '~> 3.0'
   gem 'webmock', '~> 3.5.1'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,8 @@ GEM
     capybara-screenshot (1.0.22)
       capybara (>= 1.0, < 4)
       launchy
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crack (0.4.3)
@@ -182,6 +184,7 @@ GEM
     multipart-post (2.0.0)
     mysql2 (0.5.2)
     nenv (0.3.0)
+    net_http_ssl_fix (0.0.10)
     nio4r (2.3.1)
     nokogiri (1.10.2)
       mini_portile2 (~> 2.4.0)
@@ -271,6 +274,7 @@ GEM
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
+    rubyzip (1.2.2)
     safe_yaml (1.0.5)
     sass (3.7.3)
       sass-listen (~> 4.0.0)
@@ -286,6 +290,9 @@ GEM
     scss_lint (0.57.1)
       rake (>= 0.9, < 13)
       sass (~> 3.5, >= 3.5.5)
+    selenium-webdriver (3.141.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2, >= 1.2.2)
     sentry-raven (2.9.0)
       faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
@@ -316,6 +323,11 @@ GEM
     unicode-display_width (1.5.0)
     warden (1.2.8)
       rack (>= 2.0.6)
+    webdrivers (3.7.2)
+      net_http_ssl_fix
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -360,12 +372,14 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rspec-rails (~> 3)
   sass-rails (~> 5.0)
+  selenium-webdriver
   sentry-raven
   shoulda-matchers (~> 4.0)
   simplecov
   timecop (~> 0.9.1)
   tzinfo-data
   uk_postcode (~> 2.1, >= 2.1.3)
+  webdrivers (~> 3.0)
   webmock (~> 3.5.1)
   zendesk_api
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,13 @@ services:
     links:
       - db
       - rr_db
+      - selenium
     expose:
     - "3000"
     depends_on:
       - 'govuk-fake-registers'
+
+  selenium:
+    image: "selenium/standalone-chrome"
+    expose:
+      - "4444"

--- a/spec/features/ips/filter_ips_by_location_spec.rb
+++ b/spec/features/ips/filter_ips_by_location_spec.rb
@@ -1,4 +1,5 @@
 describe 'filtering IP addresses by dynamic search', type: :feature do
+
   before do
     create(:location, organisation: organisation, address: 'Apple Street')
     create(:location, organisation: organisation, address: 'Banana Road')
@@ -38,6 +39,8 @@ describe 'filtering IP addresses by dynamic search', type: :feature do
   end
 
   context 'when user fills in the search bar', js: true do
+    Capybara.app_host = "http://app:3000"
+
     let(:filter_value) { 'b' }
 
     before { page.driver.evaluate_script(filter_function_string) }

--- a/spec/features/ips/filter_ips_by_location_spec.rb
+++ b/spec/features/ips/filter_ips_by_location_spec.rb
@@ -1,5 +1,7 @@
 describe 'filtering IP addresses by dynamic search', type: :feature do
 
+  Capybara.app_host = "http://app:3000"
+
   before do
     create(:location, organisation: organisation, address: 'Apple Street')
     create(:location, organisation: organisation, address: 'Banana Road')
@@ -11,49 +13,26 @@ describe 'filtering IP addresses by dynamic search', type: :feature do
   let!(:organisation) { create(:organisation) }
 
   let(:user) { create(:user, organisation: organisation) }
-  let(:filter_function_string) {
-    "(
-      function filterLocations(){
-        let filterValue = #{filter_value};
-        let table = document.getElementById('wrapper')
-        let location_name = table.querySelectorAll('table.govuk-table');
-        let ips = table.querySelectorAll('tbody#ips-table');
-
-        for(let i = 0;i < location_name.length;i++){
-          let text = location_name[i].getElementsByTagName('div')[0];
-
-          if(text.innerHTML.toUpperCase().indexOf(filterValue) > -1){
-            location_name[i].style.display = '';
-            ips[i].style.display = '';
-          } else {
-            location_name[i].style.display = 'none';
-            ips[i].style.display = 'none';
-          }
-        }
-      }
-    )"
-  }
-
-  it 'goes to the IPs page' do
-    expect(page).to have_current_path('/ips')
-  end
 
   context 'when user fills in the search bar', js: true do
-    Capybara.app_host = "http://app:3000"
 
     let(:filter_value) { 'b' }
 
-    before { page.driver.evaluate_script(filter_function_string) }
+    before { fill_in 'input#filterInput', with: filter_value }
 
-    it 'displays Banana Road since it has the letter b, in it' do
+    it 'goes to the IPs page' do
+      expect(page).to have_current_path('/ips')
+    end
+
+    it 'displays Banana Road as it has the letter b in it' do
       expect(page).to have_content('Banana Road')
     end
 
-    xit 'does not display Apple Street' do
+    it 'does not display Apple Street' do
       expect(page).not_to have_content('Apple Street')
     end
 
-    xit 'does not display Citrus Lane' do
+    it 'does not display Citrus Lane' do
       expect(page).not_to have_content('Citrus Lane')
     end
   end

--- a/spec/features/ips/filter_ips_by_location_spec.rb
+++ b/spec/features/ips/filter_ips_by_location_spec.rb
@@ -1,0 +1,57 @@
+describe 'filtering IP addresses by dynamic search', type: :feature do
+  before do
+    create(:location, organisation: organisation, address: 'Apple Street')
+    create(:location, organisation: organisation, address: 'Banana Road')
+    create(:location, organisation: organisation, address: 'Citrus Lane')
+    sign_in_user user
+    visit ips_path
+  end
+
+  let!(:organisation) { create(:organisation) }
+
+  let(:user) { create(:user, organisation: organisation) }
+  let(:filter_function_string) {
+    "(
+      function filterLocations(){
+        let filterValue = #{filter_value};
+        let table = document.getElementById('wrapper')
+        let location_name = table.querySelectorAll('table.govuk-table');
+        let ips = table.querySelectorAll('tbody#ips-table');
+
+        for(let i = 0;i < location_name.length;i++){
+          let text = location_name[i].getElementsByTagName('div')[0];
+
+          if(text.innerHTML.toUpperCase().indexOf(filterValue) > -1){
+            location_name[i].style.display = '';
+            ips[i].style.display = '';
+          } else {
+            location_name[i].style.display = 'none';
+            ips[i].style.display = 'none';
+          }
+        }
+      }
+    )"
+  }
+
+  it 'goes to the IPs page' do
+    expect(page).to have_current_path('/ips')
+  end
+
+  context 'when user fills in the search bar', js: true do
+    let(:filter_value) { 'b' }
+
+    before { page.driver.evaluate_script(filter_function_string) }
+
+    it 'displays Banana Road since it has the letter b, in it' do
+      expect(page).to have_content('Banana Road')
+    end
+
+    xit 'does not display Apple Street' do
+      expect(page).not_to have_content('Apple Street')
+    end
+
+    xit 'does not display Citrus Lane' do
+      expect(page).not_to have_content('Citrus Lane')
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,8 @@ require 'rspec/rails'
 require 'capybara/rspec'
 require 'support/factory_bot'
 require 'webmock/rspec'
+require "selenium-webdriver"
+require 'webdrivers'
 #
 # The following line is provided for convenience purposes. It has the downside
 # of increasing the boot-up time by auto-requiring all files in the support
@@ -27,6 +29,24 @@ RSpec.configure do |config|
 
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
+
+  Capybara.register_driver :remote_chrome do |app|
+    Capybara::Selenium::Driver.new(
+      app,
+      browser: :remote,
+      desired_capabilities: :chrome,
+      url: "http://selenium:4444/wd/hub"
+    )
+  end
+
+  Capybara.javascript_driver = :remote_chrome
+
+  config.before do
+    WebMock.disable_net_connect!(
+      allow_localhost: true,
+      allow: ["selenium:4444", "%r{chromedriver/storage/googleapis/com"]
+    )
+  end
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,10 +31,12 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 
   Capybara.register_driver :remote_chrome do |app|
+    caps = Selenium::WebDriver::Remote::Capabilities.chrome("chromeOptions" => {"excludeSwitches" => [ "--ignore-certificate-errors" ]})
+
     Capybara::Selenium::Driver.new(
       app,
       browser: :remote,
-      desired_capabilities: :chrome,
+      desired_capabilities: caps,
       url: "http://selenium:4444/wd/hub"
     )
   end
@@ -44,7 +46,7 @@ RSpec.configure do |config|
   config.before do
     WebMock.disable_net_connect!(
       allow_localhost: true,
-      allow: ["selenium:4444", "%r{chromedriver/storage/googleapis/com"]
+      allow: ["app:3000", "selenium:4444", "%r{chromedriver/storage/googleapis/com"]
     )
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,18 +30,19 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 
-  Capybara.register_driver :remote_chrome do |app|
-    caps = Selenium::WebDriver::Remote::Capabilities.chrome("chromeOptions" => {"excludeSwitches" => [ "--ignore-certificate-errors" ]})
-
-    Capybara::Selenium::Driver.new(
-      app,
-      browser: :remote,
-      desired_capabilities: caps,
-      url: "http://selenium:4444/wd/hub"
+  Capybara.register_driver :headless_chrome do |app|
+    capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+      chromeOptions: { args: %w(headless disable-gpu allow-insecure-localhost ignore-certificate-errors no-sandbox) }
     )
+
+    Capybara::Selenium::Driver.new app,
+      browser: :chrome,
+      url: 'http://selenium:4444/wd/hub',
+      desired_capabilities: capabilities
   end
 
-  Capybara.javascript_driver = :remote_chrome
+
+  Capybara.javascript_driver = :headless_chrome
 
   config.before do
     WebMock.disable_net_connect!(


### PR DESCRIPTION
**WHY:**
VERSION TWO OF PR #654 
We currently do not have a test to describe the filter added in PR #645.

This PR is an attempt to add a test for this feature so that additional changes to the dynamic filter feature can be made with more confidence.

**IN THIS PR:**
- Add `selenium-webdriver` gem.
- Add `webdriver` gem.
- Add failing test to describe behaviour.
- Set up using chromium package and chrome driver in the `Dockerfile`.
- Add selenium chrome image to `docker-compose.yml`

Currently experiencing this error in the test ([on this line](https://github.com/alphagov/govwifi-admin/compare/add-javascript-testing-v2?expand=1#diff-cb47a38d8225ef7ac9caadc38233ee6fR45)):

<img width="1431" alt="Screenshot 2019-04-17 at 15 33 37" src="https://user-images.githubusercontent.com/32823756/56298007-52125f80-6129-11e9-8e2e-9ea90cca5b23.png">

------------------------------------------------------------------------------------------------------

NOTE: The test currently fails because the page is trying to redirect to localhost and can't.

**Would appreciate any feedback on the current test setup and/or how to test javascript with the selenium-webdriver and/or any suggestions on a better way to test javascript in our code.**