### PR TITLE
Give no indication of the existence of a user's account.

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -81,7 +81,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -36,7 +36,7 @@ en:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
       unconfirmed: "You must confirm your account before resetting your password."
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
-      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      send_paranoid_instructions: "If you have an account with us, you will receive an email with a password reset link shortly."
       updated: "Your password has been changed successfully. You are now signed in."
       updated_not_active: "Your password has been changed successfully."
     registrations:

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -5,7 +5,7 @@ en:
     confirmations:
       confirmed: ""
       send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
-      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If you have an account with us, you will receive an email with a confirmation link shortly."
     failure:
       already_authenticated: ""
       inactive: "Your account is not activated yet."

--- a/spec/features/authentication/lock_user_account_spec.rb
+++ b/spec/features/authentication/lock_user_account_spec.rb
@@ -1,6 +1,6 @@
 require 'support/notifications_service'
 
-describe 'Locking a users account', type: :feature do
+describe 'Locking a user account', type: :feature do
   include_context 'with a mocked notifications client'
 
   let(:correct_password) { 'password' }
@@ -9,21 +9,7 @@ describe 'Locking a users account', type: :feature do
 
   before { visit new_user_session_path }
 
-  context 'when they have tried to login nine times with the wrong password' do
-    before do
-      9.times do
-        fill_in 'Email', with: user.email
-        fill_in 'Password', with: incorrect_password
-        click_on 'Continue'
-      end
-    end
-
-    it 'warns them one more wrong attempt will lock their account' do
-      expect(page).to have_content 'You have one more attempt before your account is locked.'
-    end
-  end
-
-  context 'when they have tried to login ten times with the wrong password' do
+  context 'when they login ten consecutive times with the wrong password' do
     before do
       10.times do
         fill_in 'Email', with: user.email
@@ -32,15 +18,23 @@ describe 'Locking a users account', type: :feature do
       end
     end
 
-    it 'locks their account' do
-      expect(page).to have_content 'Your account is locked.'
+    it 'displays a generic response' do
+      expect(page).to have_content 'Invalid Email or password.'
     end
 
-    it 'sends one email' do
+    it 'disregards any further attempts to sign in' do
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: correct_password
+      click_on 'Continue'
+
+      expect(page).to have_link 'Sign in'
+    end
+
+    it 'triggers a notification to be sent' do
       expect(notifications.count).to eq 1
     end
 
-    it 'sends the right type of email' do
+    it 'sends an unlock email' do
       expect(last_notification_type).to eq 'unlock'
     end
 

--- a/spec/features/authentication/reset_password_spec.rb
+++ b/spec/features/authentication/reset_password_spec.rb
@@ -22,7 +22,7 @@ describe "Resetting a password", type: :feature do
     end
 
     it "displays a generic response" do
-      expect(page).to have_content("If your email address exists in our database")
+      expect(page).to have_content("If you have an account with us, you will receive an email with a password reset link shortly.")
     end
 
     it 'sends no email' do
@@ -58,7 +58,7 @@ describe "Resetting a password", type: :feature do
     end
 
     it "displays a generic response" do
-      expect(page).to have_content("If your email address exists in our database")
+      expect(page).to have_content("If you have an account with us, you will receive an email with a password reset link shortly.")
     end
 
     it "sends a reset password email" do

--- a/spec/features/authentication/reset_password_spec.rb
+++ b/spec/features/authentication/reset_password_spec.rb
@@ -14,17 +14,15 @@ describe "Resetting a password", type: :feature do
     expect(page).to have_content("Reset your GovWifi network admin account password")
   end
 
-  context "when user does not exist" do
+  context "when the user has never signed up" do
     before do
       visit new_user_password_path
       fill_in "user_email", with: "user@user.com"
       click_on "Send me reset password instructions"
     end
 
-    it_behaves_like "errors in form"
-
-    it "tells the user the email cannot be found" do
-      expect(page).to have_content("Email not found")
+    it "displays a generic response" do
+      expect(page).to have_content("If your email address exists in our database")
     end
 
     it 'sends no email' do
@@ -32,7 +30,7 @@ describe "Resetting a password", type: :feature do
     end
   end
 
-  context "when user is not yet confirmed" do
+  context "when the user has signed up but has NOT been confirmed" do
     let(:user) { create(:user, :unconfirmed) }
 
     before do
@@ -50,7 +48,7 @@ describe "Resetting a password", type: :feature do
     end
   end
 
-  context "when the user does exist" do
+  context "when the user has signed up and has been confirmed" do
     let(:user) { create(:user) }
 
     before do
@@ -59,16 +57,16 @@ describe "Resetting a password", type: :feature do
       click_on "Send me reset password instructions"
     end
 
+    it "displays a generic response" do
+      expect(page).to have_content("If your email address exists in our database")
+    end
+
     it "sends a reset password email" do
       expect(last_notification_type).to eq "reset"
     end
-
-    it "displays a confirmation message to the user" do
-      expect(page).to have_content("You will receive an email with instructions")
-    end
   end
 
-  context "when clicking on reset link" do
+  context "when clicking on the reset link" do
     let(:user) { create(:user) }
 
     before do
@@ -82,24 +80,28 @@ describe "Resetting a password", type: :feature do
       expect(URI(last_notification_link).scheme).to eq("https")
     end
 
-    it "redirects user to edit password page" do
+    it "redirects the user to the edit password page" do
       expect(page).to have_content("Change your password")
     end
 
-    context "when entering correct passwords" do
+    context "when entering a password that is 6 to 80 characters long" do
       before do
-        fill_in "user_password", with: "password"
+        fill_in "user_password", with: "new_password"
         click_on "Change my password"
       end
 
-      it "changes to users password" do
+      it "automatically signs them in using the new password" do
         expect(page).to have_content("Sign out")
+      end
+
+      it "tells the user their password has been changed" do
+        expect(page).to have_content("Your password has been changed successfully")
       end
     end
 
-    context "when entering a password that is too short" do
+    context "when entering a password that is less than 6 characters" do
       before do
-        fill_in "user_password", with: "1"
+        fill_in "user_password", with: "pass"
         click_on "Change my password"
       end
 

--- a/spec/features/registration/resend_confirmation_instructions_spec.rb
+++ b/spec/features/registration/resend_confirmation_instructions_spec.rb
@@ -8,7 +8,7 @@ describe 'Resending confirmation instructions', type: :feature do
   include_context 'when sending a confirmation email'
   include_context 'when using the notifications service'
 
-  context 'when entering an email address that has signed up' do
+  context 'when entering an email address that has signed up but not confirmed' do
     before do
       sign_up_for_account(email: unconfirmed_email)
       visit new_user_confirmation_path
@@ -50,7 +50,7 @@ describe 'Resending confirmation instructions', type: :feature do
       fill_in 'user_email', with: new_user_email
     end
 
-    it 'displays generic response message to the user' do
+    it 'displays a generic response to the user' do
       click_on 'Resend confirmation instructions'
       expect(page).to have_content 'If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.'
     end
@@ -63,18 +63,15 @@ describe 'Resending confirmation instructions', type: :feature do
   end
 
   context 'when email address has already been confirmed' do
-    let(:confirmed_email) { unconfirmed_email }
+    let(:user) { create(:user, email: unconfirmed_email) }
+    let(:confirmed_email) { user.email }
 
     before do
-      sign_up_for_account(email: unconfirmed_email)
-      update_user_details
-      sign_out
-
       visit new_user_confirmation_path
       fill_in 'user_email', with: confirmed_email
     end
 
-    it 'displays generic response message to the user' do
+    it 'displays a generic response to the user' do
       click_on 'Resend confirmation instructions'
       expect(page).to have_content 'If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.'
     end

--- a/spec/features/registration/resend_confirmation_instructions_spec.rb
+++ b/spec/features/registration/resend_confirmation_instructions_spec.rb
@@ -63,8 +63,8 @@ describe 'Resending confirmation instructions', type: :feature do
   end
 
   context 'when email address has already been confirmed' do
-    let(:user) { create(:user, email: unconfirmed_email) }
-    let(:confirmed_email) { user.email }
+    let(:confirmed_user) { create(:user, email: unconfirmed_email) }
+    let(:confirmed_email) { confirmed_user.email }
 
     before do
       visit new_user_confirmation_path

--- a/spec/features/registration/resend_confirmation_instructions_spec.rb
+++ b/spec/features/registration/resend_confirmation_instructions_spec.rb
@@ -23,7 +23,7 @@ describe 'Resending confirmation instructions', type: :feature do
 
     it 'displays generic response message to the user' do
       click_on 'Resend confirmation instructions'
-      expect(page).to have_content 'If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.'
+      expect(page).to have_content 'If you have an account with us, you will receive an email with a confirmation link shortly.'
     end
   end
 
@@ -52,7 +52,7 @@ describe 'Resending confirmation instructions', type: :feature do
 
     it 'displays a generic response to the user' do
       click_on 'Resend confirmation instructions'
-      expect(page).to have_content 'If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.'
+      expect(page).to have_content 'If you have an account with us, you will receive an email with a confirmation link shortly.'
     end
 
     it 'does not sent any confirmation link' do
@@ -73,7 +73,7 @@ describe 'Resending confirmation instructions', type: :feature do
 
     it 'displays a generic response to the user' do
       click_on 'Resend confirmation instructions'
-      expect(page).to have_content 'If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.'
+      expect(page).to have_content 'If you have an account with us, you will receive an email with a confirmation link shortly.'
     end
 
     it 'does not sent any confirmation link' do


### PR DESCRIPTION
**WHY:**
We should not display messages that could give an attacker any information about the existence or status of a user account. 
e.g When entering a username/password combo, we would potentially be telling an attacker that the username entered was correct if the error message only displays `password is incorrect` or vice-versa.
Good read on this is the [OWASP Cheatsheet.](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Authentication_Cheat_Sheet.md)

We should be responding with generic messages that give no indication as to whether:
- An account exists or doesn't.
- Any sign-in credentials are correct or incorrect.

Devise has a [paranoid feature](https://github.com/plataformatec/devise/wiki/How-To:-Using-paranoid-mode,-avoid-user-enumeration-on-registerable). 
This sends/displays instructions that are the same regardless of whether, the user credentials provided were right or wrong.

**IN THIS PR:**

- Set [`config.paranoid`](https://github.com/alphagov/govwifi-admin/compare/reword-exposing-messages?expand=1#diff-a8a4112d0760c0fd11f691c6a5fb22adR84) in [`devise.rb`](config/initializers/devise.rb) to true.

- Edit assertions in example tests that describe [locking a user account](spec/features/authentication/lock_user_account_spec.rb), [resending a confirmation email](spec/features/registration/resend_confirmation_instructions_spec.rb) & [resetting a password](spec/features/authentication/reset_password_spec.rb) to expect the generic response.

- Refactor the examples in the above spec files to describe/explain the user flow better since specific messages are no longer being used.

**Password reset request**
After providing an email address in the text field and clicking on `Send me reset password instructions`, it displays:

<img width="995" alt="Screenshot 2019-04-18 at 13 51 33" src="https://user-images.githubusercontent.com/32823756/56372891-cadfed00-61f7-11e9-84e4-2dfa335561a4.png">

------------------------------------------------------------------------------------------------------

**Locked Account**
After 10 consecutive failed sign in attempts, it will send the unlock email but will also continue to display:

<img width="995" alt="Screenshot 2019-04-18 at 15 33 56" src="https://user-images.githubusercontent.com/32823756/56372948-e814bb80-61f7-11e9-8816-796a6cecbf56.png">

and will not change even if the username/password combo entered on the next attempt is correct, i.e account is now locked.

------------------------------------------------------------------------------------------------------


**Resend Confirmation Email**
After providing an email address in the text field and clicking on `Resend confirmation instructions`, it displays:

<img width="998" alt="Screenshot 2019-04-18 at 13 51 15" src="https://user-images.githubusercontent.com/32823756/56372992-f82c9b00-61f7-11e9-8826-4bd20d241453.png">

------------------------------------------------------------------------------------------------------

**Any feedback/suggestions on this approach would be appreciated.**