### PR TITLE
Validate service email format when creating or updating it

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -5,7 +5,7 @@ class Organisation < ApplicationRecord
   has_many :ips, through: :locations
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
-  validates :service_email, presence: true, format: { with: Devise.email_regexp, unless: Proc.new { |org| org.service_email.blank? }, message: "must be a valid email address" }
+  validates :service_email, format: { with: Devise.email_regexp, message: "must be a valid email address" }
   validate :validate_in_register?, unless: Proc.new { |org| org.name.blank? }
 
   def validate_in_register?

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -5,7 +5,7 @@ class Organisation < ApplicationRecord
   has_many :ips, through: :locations
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
-  validates :service_email, presence: true
+  validates :service_email, presence: true, format: { with: Devise.email_regexp, unless: Proc.new { |org| org.service_email.blank? }, message: "must be a valid email address" }
   validate :validate_in_register?, unless: Proc.new { |org| org.name.blank? }
 
   def validate_in_register?

--- a/spec/features/edit_organisation_details_spec.rb
+++ b/spec/features/edit_organisation_details_spec.rb
@@ -42,7 +42,7 @@ describe 'Editing an organisations details', type: :feature do
     end
 
     it 'will display an error to the user' do
-      expect(page).to have_content("Service email can't be blank")
+      expect(page).to have_content("Service email must be a valid email address")
     end
   end
 end

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -123,7 +123,7 @@ describe 'Sign up as an organisation', type: :feature do
     it_behaves_like 'errors in form'
 
     it 'tells the user that the service email must be present' do
-      expect(page).to have_content "Organisation service email can't be blank"
+      expect(page).to have_content "Organisation service email must be a valid email address"
     end
   end
 

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -127,6 +127,19 @@ describe 'Sign up as an organisation', type: :feature do
     end
   end
 
+  context 'when service email entered is not an email address' do
+    before do
+      sign_up_for_account
+      update_user_details(service_email: "InvalidEmail")
+    end
+
+    it_behaves_like 'errors in form'
+
+    it 'tells the user that the service email must be a valid email address' do
+      expect(page).to have_content "Organisation service email must be a valid email address"
+    end
+  end
+
   context 'when password is too short' do
     before do
       sign_up_for_account

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -68,4 +68,34 @@ describe Organisation do
       ])
     end
   end
+
+  context 'when organisation service email is left blank' do
+    let(:organisation) { build(:organisation, service_email: '') }
+
+    it 'is not valid' do
+      expect(organisation).not_to be_valid
+    end
+
+    it 'explains why it is invalid' do
+      organisation.valid?
+      expect(organisation.errors.full_messages).to eq([
+        "Service email can't be blank"
+      ])
+    end
+  end
+
+  context 'when organisation service email is not an email address' do
+    let(:organisation) { build(:organisation, service_email: 'IncorrectFormat') }
+
+    it 'is not valid' do
+      expect(organisation).not_to be_valid
+    end
+
+    it 'explains why it is invalid' do
+      organisation.valid?
+      expect(organisation.errors.full_messages).to eq([
+        "Service email must be a valid email address"
+      ])
+    end
+  end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -79,7 +79,7 @@ describe Organisation do
     it 'explains why it is invalid' do
       organisation.valid?
       expect(organisation.errors.full_messages).to eq([
-        "Service email can't be blank"
+        "Service email must be a valid email address"
       ])
     end
   end


### PR DESCRIPTION
**WHY:**
When a user adds or edits their organisation's service email, it only validates the email's presence i.e. `email can't be blank` but it doesn't validate the email's format.
As a result, this allowed any form of text to be accepted and saved to the organisation, even if the text was not an email address.

**IN THIS PR:**
- Add validation on the service email to match Devise's email regex.
- Add tests on the model and on the feature to describe validating a service email's format.

**BEFORE:**

Adding any text and clicking on save, redirected to the Team members page and displayed:
![Screenshot 2019-04-23 at 11 40 08](https://user-images.githubusercontent.com/32823756/56575034-a780bd80-65bc-11e9-93cd-1b205f2ac129.png)

------------------------------------------------------------------------------------------------------

**AFTER:**

Adding any text and clicking on save, check's the format of the text and displays an error message, if the text does not match devise's email regexp:

![Screenshot 2019-04-23 at 11 40 35](https://user-images.githubusercontent.com/32823756/56575143-eadb2c00-65bc-11e9-8f8d-acd13e4c3f26.png)

------------------------------------------------------------------------------------------------------

**Any feedback/suggestions would be appreciated.**