### PR TITLE
Redirect from offline support if signed in

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,9 +1,8 @@
 class HelpController < ApplicationController
   skip_before_action :authenticate_user!
+  before_action :redirect_signed_in_user, only: :new
 
   def new
-    return redirect_to signed_in_new_help_path if current_user
-
     case params[:choice]
     when "signing_up"
       redirect_to signing_up_new_help_path
@@ -63,6 +62,10 @@ class HelpController < ApplicationController
   end
 
 private
+
+  def redirect_signed_in_user
+    return redirect_to signed_in_new_help_path if current_user
+  end
 
   def support_form_params
     params.require(:support_form).permit(:name, :details, :email, :organisation, :choice)

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -2,6 +2,8 @@ class HelpController < ApplicationController
   skip_before_action :authenticate_user!
 
   def new
+    return redirect_to signed_in_new_help_path if !!current_user
+
     case params[:choice]
     when "signing_up"
       redirect_to signing_up_new_help_path

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -2,7 +2,7 @@ class HelpController < ApplicationController
   skip_before_action :authenticate_user!
 
   def new
-    return redirect_to signed_in_new_help_path if !!current_user
+    return redirect_to signed_in_new_help_path if current_user
 
     case params[:choice]
     when "signing_up"

--- a/spec/features/contact_us_when_signed_in_spec.rb
+++ b/spec/features/contact_us_when_signed_in_spec.rb
@@ -52,8 +52,8 @@ describe 'Contact us when signed in', type: :feature do
   context 'when visiting from the root/help path' do
     before { visit '/help' }
 
-    it 'shows the user the not signed in support page' do
-      expect(page).to have_content 'How can we help?'
+    it 'redirects the user to the signed in support page' do
+      expect(page).to have_button 'Send support request'
     end
   end
 end


### PR DESCRIPTION
**WHY:**
There's a bug that occurs when a signed in user clicks on the `Documentation` menu link and then subsequently clicks on the `Support` menu link.

The support page displayed to the signed in user is the offline support page.
Clicking on the `Support` link again redirects the user to the online support page.

A signed in user should only ever see the online support page and user not signed in, should only ever see an offline version of the support page.

**IN THIS PR:**
- Add a redirect in the new method in the [`HelpController`](app/controllers/help_controller.rb) to redirect to the signed_in version of support if the user is signed in.
- Refactor a [test](https://github.com/alphagov/govwifi-admin/compare/fix-display-error-offline-support?expand=1#diff-102458bca0162d5fc48989ced7de8b51R55) that initially allowed a signed in user to see the offline version of the support page.

**NOTE:**
This may need to be pushed to production to see if this works. 
The `Documentation` menu link is a link to the tech docs which is a separate subdomain from the admin portal. 
The `Support` and `Sign in ` links on the tech docs all navigate to the production version of the admin portal.

**Any feedback/suggestions on this would be appreciated.**