### PR TITLE
Add 'Connect to GovWifi' & Offer GovWifi' links to main nav

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -83,9 +83,6 @@
                 <%= link_to 'Offer GovWifi', SITE_CONFIG['organisation_docs_link'], class: "govuk-header__link" %>
               </li>
               <li class="govuk-header__navigation-item">
-                <%= link_to 'Documentation', SITE_CONFIG['organisation_docs_link'], class: "govuk-header__link" %>
-              </li>
-              <li class="govuk-header__navigation-item">
                 <% if user_signed_in? %>
                   <%= link_to 'Support', signed_in_new_help_path, class: "govuk-header__link #{active_tab(signed_in_new_help_path)}" %>
                 <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -77,6 +77,12 @@
           <nav>
             <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
               <li class="govuk-header__navigation-item">
+                <%= link_to 'Connect to GovWifi', SITE_CONFIG['connect_to_govwifi_link'], class: "govuk-header__link" %>
+              </li>
+              <li class="govuk-header__navigation-item">
+                <%= link_to 'Offer GovWifi', SITE_CONFIG['organisation_docs_link'], class: "govuk-header__link" %>
+              </li>
+              <li class="govuk-header__navigation-item">
                 <%= link_to 'Documentation', SITE_CONFIG['organisation_docs_link'], class: "govuk-header__link" %>
               </li>
               <li class="govuk-header__navigation-item">

--- a/config/site.yml
+++ b/config/site.yml
@@ -2,6 +2,7 @@ default: &default
   end_user_docs_link: 'https://www.gov.uk/government/collections/connect-to-govwifi'
   end_user_troubleshooting_link: 'https://www.gov.uk/guidance/solve-problems-with-connecting-to-govwifi'
   organisation_docs_link: 'https://docs.wifi.service.gov.uk'
+  connect_to_govwifi_link: 'https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi'
   cookies_docs_link: 'https://www.wifi.service.gov.uk/cookies'
   product_page_link: 'https://wifi.service.gov.uk'
   organisation_register_url: 'https://government-organisation.register.gov.uk/records.json?page-size=5000'


### PR DESCRIPTION
<img width="835" alt="Screenshot 2019-04-29 at 13 32 47" src="https://user-images.githubusercontent.com/40758489/56896321-4d33a100-6a83-11e9-8835-a815a9c6ac11.png">

Normalised the main navigation to match our other GovWifi related pages, so not to confuse the user.
