### PR TITLE
use rubocop directly instead of govuk-lint-ruby

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ serve: stop build
 
 lint: lint-ruby lint-sass lint-erb
 lint-ruby: build
-	$(DOCKER_COMPOSE) run --rm app bundle exec govuk-lint-ruby
+	$(DOCKER_COMPOSE) run --rm app bundle exec rubocop
 lint-sass: build
 	$(DOCKER_COMPOSE) run --rm app bundle exec govuk-lint-sass app/assets/stylesheets
 lint-erb: build


### PR DESCRIPTION
Ever since we set up inheritance of the rubocop config for ERB linting,
'rubocop' and 'govuk-lint-ruby' both do the same thing.

Recently, govuk-lint has been giving us random failures due to not finding a temporary file.

As govuk-lint is being deprecated ( alphagov/govuk-lint#109 ), move to rubocop as it just works.

This fixes the random lint failures we've been getting sporadically:
```
Configuration file not found: /tmp/tmp-rubocop-all.yml20190429-1-1l4lnm2
```