### PR TITLE
Update footer to match product page

### DIFF
--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -1,0 +1,3 @@
+.govuk-footer__list-item {
+  margin-bottom: 10px;
+}

--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -1,3 +1,0 @@
-.govuk-footer__list-item {
-  margin-bottom: 10px;
-}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -115,26 +115,45 @@
     <footer class="govuk-footer " role="contentinfo">
       <div class="govuk-width-container ">
         <div class="govuk-footer__navigation">
-          <div class="govuk-footer__section">
+          <div class="govuk-grid-column-one-third govuk-!-margin-bottom-5">
+            <h2>About</h2>
             <ul class="govuk-footer__list govuk-footer__list--columns-1">
               <li class="govuk-footer__list-item">
-                <% if user_signed_in? %>
-                  <%= link_to 'Support', signed_in_new_help_path, class: "govuk-footer__link" %>
-                <% else %>
-                  <%= link_to 'Support', new_help_path, class: "govuk-footer__link" %>
-                <% end %>
+                <%= link_to 'Our service', 'https://www.wifi.service.gov.uk/about-govwifi/', class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__list-item">
-                <%= link_to 'Documentation', SITE_CONFIG['organisation_docs_link'], class: "govuk-footer__link" %>
+                <%= link_to 'Terms and conditions', 'https://www.wifi.service.gov.uk/terms-and-conditions/', class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__list-item">
-                <%= link_to 'Cookie Policy', SITE_CONFIG['cookies_docs_link'], class: "govuk-footer__link" %>
+                <%= link_to 'Performance', 'https://www.gov.uk/performance/govwifi', class: "govuk-footer__link" %>
+              </li>
+            </ul>
+          </div>
+          <div class="govuk-grid-column-one-third govuk-!-margin-bottom-5">
+            <h2>Connect</h2>
+            <ul class="govuk-footer__list govuk-footer__list--columns-1">
+              <li class="govuk-footer__list-item">
+                <%= link_to 'Connect to GovWifi', 'https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi/', class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__list-item">
-                <%= link_to 'Feedback', feedback_new_help_path, class: "govuk-footer__link" %>
+                <%= link_to 'Organisations using GovWifi', 'https://www.wifi.service.gov.uk/about-govwifi/organisations-using-govwifi/', class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__list-item">
-                <%= link_to 'System status', status_index_path, class: "govuk-footer__link" %>
+                <%= link_to 'Support', 'https://www.wifi.service.gov.uk/support/', class: "govuk-footer__link" %>
+              </li>
+            </ul>
+          </div>
+          <div class="govuk-grid-column-one-third govuk-!-margin-bottom-5">
+            <h2>Admin</h2>
+            <ul class="govuk-footer__list govuk-footer__list--columns-1">
+              <li class="govuk-footer__list-item">
+                <%= link_to 'Offer GovWifi in your organisation', 'https://docs.wifi.service.gov.uk/', class: "govuk-footer__link" %>
+              </li>
+              <li class="govuk-footer__list-item">
+                <%= link_to 'Network Administrator login', 'https://admin.wifi.service.gov.uk/users/sign_in', class: "govuk-footer__link"%>
+              </li>
+              <li class="govuk-footer__list-item">
+                <%= link_to 'Technical Documentation', 'https://docs.wifi.service.gov.uk/manage/#manage-govwifi', class: "govuk-footer__link" %>
               </li>
             </ul>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -142,6 +142,17 @@
         <hr class="govuk-footer__section-break">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+            <ul class="govuk-footer__inline-list">
+              <li class="govuk-footer__inline-list-item">
+                Built by the <%= link_to 'Government Digital Service', "https://www.gov.uk/government/organisations/government-digital-service", class: "govuk-footer__link" %>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <%= link_to 'Privacy notice', "https://www.wifi.service.gov.uk/privacy-notice/", class: "govuk-footer__link" %>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <%= link_to 'Cookies', "https://www.wifi.service.gov.uk/cookies/", class: "govuk-footer__link" %>
+              </li>
+            </ul>
             <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
               <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
             </svg>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -150,7 +150,7 @@
                 <%= link_to 'Offer GovWifi in your organisation', 'https://docs.wifi.service.gov.uk/', class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__list-item">
-                <%= link_to 'Network Administrator login', 'https://admin.wifi.service.gov.uk/users/sign_in', class: "govuk-footer__link"%>
+                <%= link_to 'Network Administrator login', 'https://admin.wifi.service.gov.uk/users/sign_in', class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__list-item">
                 <%= link_to 'Technical Documentation', 'https://docs.wifi.service.gov.uk/manage/#manage-govwifi', class: "govuk-footer__link" %>

--- a/app/views/setup_instructions/index.html.erb
+++ b/app/views/setup_instructions/index.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row">
-  <h2 class="govuk-heading-l govuk-grid-column-full">Get GovWifi access in your organisation</h2>
+  <h2 class="govuk-heading-l govuk-grid-column-full" id="setup-header">Get GovWifi access in your organisation</h2>
   <div class="govuk-grid-column-two-thirds">
     <h3 class="govuk-heading-m"> 1. Add IPs </h3>
       <% if @locations.empty? %>

--- a/spec/features/ips/view_ip_addresses_spec.rb
+++ b/spec/features/ips/view_ip_addresses_spec.rb
@@ -16,7 +16,7 @@ describe 'Viewing IP addresses', type: :feature do
     it 'redirects the user to the setting up page' do
       visit root_path
 
-      within("h2") do
+      within("#setup-header") do
         expect(page).to have_content("Get GovWifi access in your organisation")
       end
     end

--- a/spec/features/support/setup_instructions.rb
+++ b/spec/features/support/setup_instructions.rb
@@ -1,6 +1,6 @@
 shared_examples 'shows the setup instructions page' do
   it 'shows the user the setup instructions page' do
-    within("h2") do
+    within("#setup-header") do
       expect(page).to have_content("Get GovWifi access in your organisation")
     end
   end

--- a/spec/features/support/user_not_authorised.rb
+++ b/spec/features/support/user_not_authorised.rb
@@ -1,7 +1,7 @@
 shared_examples 'user not authorised' do
   # Assumes that users created for the purpose of testing have no IPs initially, which routes them differently from root.
   it 'redirects to setting up page' do
-    within("h2") do
+    within("#setup-header") do
       expect(page).to have_content("Get GovWifi access in your organisation")
     end
   end

--- a/spec/features/team/permissions_spec.rb
+++ b/spec/features/team/permissions_spec.rb
@@ -45,7 +45,7 @@ describe 'Invite a team member', type: :feature do
     it 'prevents visiting the invites page directly' do
       visit new_user_invitation_path
 
-      within("h2") do
+      within("#setup-header") do
         expect(page).to have_content("Get GovWifi access in your organisation")
       end
     end


### PR DESCRIPTION
**WHY:**
Need to match the footer across all admin pages for consistency.

**IN THIS PR:**
- Restructure footer to be the same as the one in the product page.
- Fix & refactor tests that failed as a result of the footer change.

BEFORE:

![Screenshot 2019-04-30 at 12 02 22](https://user-images.githubusercontent.com/32823756/56966259-9ef92b80-6b56-11e9-8a3d-83c0d908d5c4.png)

**AFTER:**

![Screenshot 2019-04-30 at 12 38 42](https://user-images.githubusercontent.com/32823756/56966273-a8829380-6b56-11e9-8e28-86e0c755916c.png)

------------------------------------------------------------------------------------------------------

**Any feedback/suggestions would be appreciated.**