### PR TITLE
Add title and meta descriptions to help pages

### DIFF
--- a/app/views/help/admin_account.erb
+++ b/app/views/help/admin_account.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Administrator account support - GovWifi" %>
-<% content_for :meta_description, "I'm having trouble signing up' to 'Network administrator account support" %>
+<% content_for :meta_description, "I'm having trouble signing up to 'Network administrator account support" %>
 
 <%= render "layouts/form_errors", resource: @support_form %>
 

--- a/app/views/help/admin_account.erb
+++ b/app/views/help/admin_account.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Administrator account support - GovWifi" %>
-<% content_for :meta_description, "Contact us for help and support with your GovWifi administrator account." %>
+<% content_for :meta_description, "Contact us for help and support with your GovWifi administrator account" %>
 
 <%= render "layouts/form_errors", resource: @support_form %>
 

--- a/app/views/help/admin_account.erb
+++ b/app/views/help/admin_account.erb
@@ -1,3 +1,6 @@
+<% content_for :page_title, "Administrator account support - GovWifi" %>
+<% content_for :meta_description, "'I'm having trouble signing up' to 'Network administrator account support" %>
+
 <%= render "layouts/form_errors", resource: @support_form %>
 
 <div class="govuk-grid-row">

--- a/app/views/help/admin_account.erb
+++ b/app/views/help/admin_account.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Administrator account support - GovWifi" %>
-<% content_for :meta_description, "I'm having trouble signing up to 'Network administrator account support" %>
+<% content_for :meta_description, "Contact us for help and support with your GovWifi administrator account." %>
 
 <%= render "layouts/form_errors", resource: @support_form %>
 

--- a/app/views/help/admin_account.erb
+++ b/app/views/help/admin_account.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Administrator account support - GovWifi" %>
-<% content_for :meta_description, "'I'm having trouble signing up' to 'Network administrator account support" %>
+<% content_for :meta_description, "I'm having trouble signing up' to 'Network administrator account support" %>
 
 <%= render "layouts/form_errors", resource: @support_form %>
 

--- a/app/views/help/technical_support.html.erb
+++ b/app/views/help/technical_support.html.erb
@@ -1,3 +1,6 @@
+<% content_for :page_title, "Administrator technical support - GovWifi" %>
+<% content_for :meta_description, "Contact us for technical help and support managing GovWifi in your organisation" %>
+
 <%= render "layouts/form_errors", resource: @support_form %>
 
 <div class="govuk-grid-row">

--- a/app/views/help/user_support.html.erb
+++ b/app/views/help/user_support.html.erb
@@ -1,3 +1,6 @@
+<% content_for :page_title, "User account support - GovWifi" %>
+<% content_for :meta_description, " Contact us for help and support with your GovWifi user account" %>
+
 <%= render "layouts/form_errors", resource: @support_form %>
 
 <div class="govuk-grid-row">

--- a/app/views/help/user_support.html.erb
+++ b/app/views/help/user_support.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "User account support - GovWifi" %>
-<% content_for :meta_description, " Contact us for help and support with your GovWifi user account" %>
+<% content_for :meta_description, "Contact us for help and support with your GovWifi user account" %>
 
 <%= render "layouts/form_errors", resource: @support_form %>
 


### PR DESCRIPTION
This task involved adding titles and meta descriptions to the three help pages which are exposed to users without having to sign in.

<img width="662" alt="Screenshot 2019-05-01 at 14 56 52" src="https://user-images.githubusercontent.com/40758489/57020552-80139b80-6c21-11e9-9aae-c884306e4596.png">
<img width="735" alt="Screenshot 2019-05-01 at 14 56 39" src="https://user-images.githubusercontent.com/40758489/57020554-80139b80-6c21-11e9-8e14-1b4c5d8ea5d2.png">
<img width="787" alt="Screenshot 2019-05-01 at 14 54 51" src="https://user-images.githubusercontent.com/40758489/57020555-80ac3200-6c21-11e9-8c86-0a24a2bc6331.png">