### PR TITLE
Update admin help page

### DIFF
--- a/app/views/help/new.html.erb
+++ b/app/views/help/new.html.erb
@@ -32,11 +32,6 @@
         </div>
         <%= submit_tag('Continue', class: 'govuk-button') %>
       <% end %>
-
-      <p class="govuk-body"> If you are having trouble connecting to GovWifi, see <%= link_to 'our guidance on common issues', SITE_CONFIG['end_user_troubleshooting_link'], class: "govuk-link" %>.
-      </p>
-
-      <p class="govuk-body"> If this doesn't resolve the issue, we recommend you contact your organisation’s IT support team.</p>
     </div>
   </div>
 </div>

--- a/app/views/help/new.html.erb
+++ b/app/views/help/new.html.erb
@@ -1,22 +1,33 @@
+<div><% content_for :page_title, 'Contact Us - GovWifi' %></div>
+<div><% content_for :meta_description, 'Contact us for help and support installing GovWifi in your organisation.' %></div>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Support</h2>
+    <h2 class="govuk-heading-l">Contact GovWifi</h2>
     <div class="govuk-details">
+    <p>
+      We provide network administrator guidance on how to offer and manage GovWifi in your organisation in our
+      <%= link_to 'technical documentation', SITE_CONFIG['organisation_docs_link'], class: "govuk-link" %>.
+    </p>
+    <p>
+      If you are having trouble connecting to GovWifi, see our <%= link_to 'user support guidance', 'https://www.wifi.service.gov.uk/support/', class: "govuk-link" %> on common issues.
+    </p>
+
       <h2 class="govuk-body-m">How can we help?</h2>
 
       <%= form_tag new_help_path, class: 'govuk-radios', method: 'get' do %>
         <div class="govuk-radio">
           <div class="govuk-radios__item">
             <%= radio_button_tag(:choice, :technical_support, nil, class: "govuk-radios__input") %>
-            <%= label_tag(:choice_technical_support, "I'm having trouble signing up", class: 'govuk-label govuk-radios__label') %>
+            <%= label_tag(:choice_technical_support, "Network administrator technical support", class: 'govuk-label govuk-radios__label') %>
           </div>
           <div class="govuk-radios__item">
             <%= radio_button_tag(:choice, :admin_account, nil, class: "govuk-radios__input") %>
-            <%= label_tag(:choice_admin_account, "Something's wrong with my admin account", class: 'govuk-label govuk-radios__label') %>
+            <%= label_tag(:choice_admin_account, "Network administrator account support", class: 'govuk-label govuk-radios__label') %>
           </div>
           <div class="govuk-radios__item">
             <%= radio_button_tag(:choice, :user_support, nil, class: "govuk-radios__input") %>
-            <%= label_tag(:choice_user_support, "Ask a question or leave feedback", class: 'govuk-label govuk-radios__label govuk-!-margin-bottom-4') %>
+            <%= label_tag(:choice_user_support, "Connecting to GovWifi user support", class: 'govuk-label govuk-radios__label govuk-!-margin-bottom-4') %>
           </div>
         </div>
         <%= submit_tag('Continue', class: 'govuk-button') %>

--- a/spec/features/contact_us_when_not_signed_in_spec.rb
+++ b/spec/features/contact_us_when_not_signed_in_spec.rb
@@ -20,7 +20,7 @@ describe 'Contact us when not signed in', type: :feature do
 
   context 'when having trouble signing up' do
     before do
-      choose 'I\'m having trouble signing up'
+      choose 'Network administrator technical support'
       click_on 'Continue'
       fill_in 'Your email address', with: email
       fill_in 'Tell us a bit more about your issue', with: details
@@ -34,7 +34,7 @@ describe 'Contact us when not signed in', type: :feature do
 
   context 'when something is wrong with their admin account' do
     before do
-      choose 'Something\'s wrong with my admin account'
+      choose 'Network administrator account support'
       click_on 'Continue'
       fill_in 'Your email address', with: email
       fill_in 'Tell us a bit more about your issue', with: details
@@ -54,7 +54,7 @@ describe 'Contact us when not signed in', type: :feature do
 
   context 'when there is a question or feedback' do
     before do
-      choose 'Ask a question or leave feedback'
+      choose 'Connecting to GovWifi user support'
       click_on 'Continue'
       fill_in 'Your message', with: details
       fill_in 'Your email address', with: email

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -64,7 +64,7 @@ describe 'Sign up as an organisation', type: :feature do
         visit new_user_registration_path
         click_on "Sign up"
         click_on "contact us"
-        expect(page).to have_content("I'm having trouble signing up")
+        expect(page).to have_content("Network administrator technical support")
       end
     end
 


### PR DESCRIPTION
**WHY:**
We needed to update the content on: `https://admin.wifi.service.gov.uk/help` to effectively signpost and triage users more effectively and reconcile with incoming links from product pages, particularly `/support`. 

**IN THIS PR:**

- update page title
- update meta description:
- update content per [spreadsheet](https://docs.google.com/spreadsheets/d/141spueIa6sG7Eyv6EjsqFn8s4ubJ8YX0LzpS0kGT91Q/edit#gid=175160880)

**BEFORE:**

_**Page content**_
![Screenshot 2019-05-01 at 15 16 52](https://user-images.githubusercontent.com/32823756/57021455-2c568180-6c24-11e9-9c5b-b9c985784a9c.png)

------------------------------------------------------------------------------------------------------

**AFTER:**

_**Page content**_
![Screenshot 2019-05-01 at 15 17 37](https://user-images.githubusercontent.com/32823756/57021479-45f7c900-6c24-11e9-9de7-7dbce24a00f6.png)

**_Meta description_**
![Screenshot 2019-05-01 at 14 20 55](https://user-images.githubusercontent.com/32823756/57021507-59a32f80-6c24-11e9-826a-10cfaf178f1a.png)

**_Page title_**
![Screenshot 2019-05-01 at 14 21 09](https://user-images.githubusercontent.com/32823756/57021514-5c9e2000-6c24-11e9-905a-7f4a109277e7.png)

------------------------------------------------------------------------------------------------------
**Any feedback/suggestions would be appreciated.**