### PR TITLE
Add uuid to organisations

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -8,6 +8,8 @@ class Organisation < ApplicationRecord
   validates :service_email, format: { with: Devise.email_regexp, message: "must be a valid email address" }
   validate :validate_in_register?, unless: Proc.new { |org| org.name.blank? }
 
+  after_initialize :generate_uuid
+
   def validate_in_register?
     unless Organisation.fetch_organisations_from_register.include?(name)
       errors.add(:base, "#{name} isn't a whitelisted organisation")
@@ -18,5 +20,11 @@ class Organisation < ApplicationRecord
     UseCases::Organisation::FetchOrganisationRegister.new(
       organisations_gateway: Gateways::GovukOrganisationsRegisterGateway.new
     ).execute.sort
+  end
+
+  def generate_uuid
+    return if uuid.present?
+
+    self.uuid = SecureRandom.uuid
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -8,8 +8,6 @@ class Organisation < ApplicationRecord
   validates :service_email, format: { with: Devise.email_regexp, message: "must be a valid email address" }
   validate :validate_in_register?, unless: Proc.new { |org| org.name.blank? }
 
-  after_initialize :generate_uuid
-
   def validate_in_register?
     unless Organisation.fetch_organisations_from_register.include?(name)
       errors.add(:base, "#{name} isn't a whitelisted organisation")
@@ -20,11 +18,5 @@ class Organisation < ApplicationRecord
     UseCases::Organisation::FetchOrganisationRegister.new(
       organisations_gateway: Gateways::GovukOrganisationsRegisterGateway.new
     ).execute.sort
-  end
-
-  def generate_uuid
-    return if uuid.present?
-
-    self.uuid = SecureRandom.uuid
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -8,6 +8,8 @@ class Organisation < ApplicationRecord
   validates :service_email, format: { with: Devise.email_regexp, message: "must be a valid email address" }
   validate :validate_in_register?, unless: Proc.new { |org| org.name.blank? }
 
+  before_create :set_uuid
+
   def validate_in_register?
     unless Organisation.fetch_organisations_from_register.include?(name)
       errors.add(:base, "#{name} isn't a whitelisted organisation")
@@ -18,5 +20,11 @@ class Organisation < ApplicationRecord
     UseCases::Organisation::FetchOrganisationRegister.new(
       organisations_gateway: Gateways::GovukOrganisationsRegisterGateway.new
     ).execute.sort
+  end
+
+  def set_uuid
+    return if uuid.present?
+
+    self.uuid = SecureRandom.uuid
   end
 end

--- a/db/migrate/20190501150308_add_uuid_to_organisations.rb
+++ b/db/migrate/20190501150308_add_uuid_to_organisations.rb
@@ -1,5 +1,6 @@
 class AddUuidToOrganisations < ActiveRecord::Migration[5.2]
   def change
     add_column :organisations, :uuid, :string, limit: 36, null: false, default: 'uuid()'
+    add_index :organisations, :uuid, unique: true
   end
 end

--- a/db/migrate/20190501150308_add_uuid_to_organisations.rb
+++ b/db/migrate/20190501150308_add_uuid_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddUuidToOrganisations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :organisations, :uuid, :string, limit: 36, null: false
+  end
+end

--- a/db/migrate/20190501150308_add_uuid_to_organisations.rb
+++ b/db/migrate/20190501150308_add_uuid_to_organisations.rb
@@ -1,5 +1,5 @@
 class AddUuidToOrganisations < ActiveRecord::Migration[5.2]
   def change
-    add_column :organisations, :uuid, :string, limit: 36, null: false, default: 'uuid()'
+    add_column :organisations, :uuid, :string, limit: 36, null: false
   end
 end

--- a/db/migrate/20190501150308_add_uuid_to_organisations.rb
+++ b/db/migrate/20190501150308_add_uuid_to_organisations.rb
@@ -1,5 +1,5 @@
 class AddUuidToOrganisations < ActiveRecord::Migration[5.2]
   def change
-    add_column :organisations, :uuid, :string, limit: 36, null: false
+    add_column :organisations, :uuid, :string, limit: 36, null: false, default: 'uuid()'
   end
 end

--- a/db/migrate/20190501150308_add_uuid_to_organisations.rb
+++ b/db/migrate/20190501150308_add_uuid_to_organisations.rb
@@ -1,6 +1,5 @@
 class AddUuidToOrganisations < ActiveRecord::Migration[5.2]
   def change
     add_column :organisations, :uuid, :string, limit: 36, null: false, default: 'uuid()'
-    add_index :organisations, :uuid, unique: true
   end
 end

--- a/db/migrate/20190502092749_add_uuid_index_to_organisations.rb
+++ b/db/migrate/20190502092749_add_uuid_index_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddUuidIndexToOrganisations < ActiveRecord::Migration[5.2]
+  def change
+    add_index :organisations, :uuid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,7 +75,7 @@ ActiveRecord::Schema.define(version: 2019_05_02_092749) do
     t.datetime "updated_at", null: false
     t.string "service_email"
     t.boolean "super_admin", default: false
-    t.string "uuid", limit: 36, null: false
+    t.string "uuid", limit: 36, null: false, default: 'uuid()'
     t.index ["uuid"], name: "index_organisations_on_uuid", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_01_150308) do
+ActiveRecord::Schema.define(version: 2019_05_02_092749) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -75,7 +75,8 @@ ActiveRecord::Schema.define(version: 2019_05_01_150308) do
     t.datetime "updated_at", null: false
     t.string "service_email"
     t.boolean "super_admin", default: false
-    t.string "uuid", limit: 36, default: "uuid()", null: false
+    t.string "uuid", limit: 36, null: false
+    t.index ["uuid"], name: "index_organisations_on_uuid", unique: true
   end
 
   create_table "permissions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_02_142239) do
+ActiveRecord::Schema.define(version: 2019_05_01_150308) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 2019_04_02_142239) do
     t.datetime "updated_at", null: false
     t.string "service_email"
     t.boolean "super_admin", default: false
+    t.string "uuid", limit: 36, null: false
   end
 
   create_table "permissions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,7 +75,7 @@ ActiveRecord::Schema.define(version: 2019_05_02_092749) do
     t.datetime "updated_at", null: false
     t.string "service_email"
     t.boolean "super_admin", default: false
-    t.string "uuid", limit: 36, null: false, default: 'uuid()'
+    t.string "uuid", limit: 36, null: false
     t.index ["uuid"], name: "index_organisations_on_uuid", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,7 +75,7 @@ ActiveRecord::Schema.define(version: 2019_05_01_150308) do
     t.datetime "updated_at", null: false
     t.string "service_email"
     t.boolean "super_admin", default: false
-    t.string "uuid", limit: 36, null: false
+    t.string "uuid", limit: 36, default: "uuid()", null: false
   end
 
   create_table "permissions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -98,4 +98,24 @@ describe Organisation do
       ])
     end
   end
+
+  context 'when an organisation does not have a uuid' do
+    let(:organisation) { described_class.new(name: 'Gov Org 1', service_email: 'foo@bar.com') }
+
+    before { organisation.save! }
+
+    it 'generates a new one' do
+      expect(organisation.uuid).to be_present
+    end
+  end
+
+  context 'when an organisation has a uuid' do
+    let(:organisation) { described_class.new(uuid: 'abcde', name: 'Gov Org 1', service_email: 'foo@bar.com') }
+
+    before { organisation.save! }
+
+    it 'does not generate a new one' do
+      expect(organisation.uuid).to eq('abcde')
+    end
+  end
 end


### PR DESCRIPTION
When creating an organisation, it will create its own uuid and persist
it in the database. All existing organisations will be manually
backfilled to contain new uuids.