### PR TITLE
Add scope to MoU routes

### DIFF
--- a/app/controllers/mou_controller.rb
+++ b/app/controllers/mou_controller.rb
@@ -5,7 +5,12 @@ class MouController < ApplicationController
   end
 
   def create
-    redirect_path = replacing? ? replaced_mou_index_path : created_mou_index_path
+    redirect_path = if replacing?
+                      replaced_mou_index_path(organisation_uuid: current_organisation.uuid)
+                    else
+                      created_mou_index_path(organisation_uuid: current_organisation.uuid)
+                    end
+
     if params[:signed_mou]
       current_organisation.signed_mou.attach(params[:signed_mou])
       flash[:notice] = "MOU uploaded successfully."

--- a/app/views/mou/index.html.erb
+++ b/app/views/mou/index.html.erb
@@ -27,7 +27,7 @@
     <% end %>
 
     <div>
-      <%= form_with url: mou_index_path, method: 'post' do |form| %>
+      <%= form_with url: mou_index_path(organisation_uuid: current_organisation.uuid), method: 'post' do |form| %>
         <div class="govuk-form-group">
           <%= form.file_field(:signed_mou, class: 'govuk-file-upload') %>
         </div>

--- a/app/views/setup_instructions/index.html.erb
+++ b/app/views/setup_instructions/index.html.erb
@@ -80,7 +80,7 @@
 
     <h3 class="govuk-heading-m"> 6. Sign your agreement </h3>
     <p class="govuk-body">
-      <%= link_to "Sign a memorandum of understanding (MOU)", mou_index_path, class: "govuk-link" %> with the Government Digital Service (GDS).
+      <%= link_to "Sign a memorandum of understanding (MOU)", mou_index_path(organisation_uuid: current_organisation.uuid), class: "govuk-link" %> with the Government Digital Service (GDS).
     </p>
     <p class="govuk-body">This must be done by someone in your organisation who has permission to sign off and procure services'.</p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,10 +44,12 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :mou, only: %i[index create] do
-    collection do
-      get 'created', to: 'mou#index'
-      get 'replaced', to: 'mou#index'
+  scope '/organisations/:organisation_uuid' do
+    resources :mou, only: %i[index create] do
+      collection do
+        get 'created', to: 'mou#index'
+        get 'replaced', to: 'mou#index'
+      end
     end
   end
   resources :logs, only: %i[index]

--- a/spec/features/upload_download_mous_spec.rb
+++ b/spec/features/upload_download_mous_spec.rb
@@ -8,7 +8,7 @@ describe 'Uploading and downloading an MOU', type: :feature do
 
     context 'when no file is chosen to upload' do
       before do
-        visit mou_index_path
+        visit mou_index_path(organisation_uuid: user.organisation.uuid)
         click_on 'Upload'
       end
 
@@ -19,7 +19,7 @@ describe 'Uploading and downloading an MOU', type: :feature do
 
     context 'when uploading the signed mou' do
       before do
-        visit mou_index_path
+        visit mou_index_path(organisation_uuid: user.organisation.uuid)
         attach_file("signed_mou", Rails.root + "spec/fixtures/mou.pdf")
         click_on 'Upload'
       end
@@ -33,13 +33,13 @@ describe 'Uploading and downloading an MOU', type: :feature do
       end
 
       it 'redirects to "after MOU uploaded" path for analytics' do
-        expect(page).to have_current_path('/mou/created')
+        expect(page).to have_current_path("/organisations/#{user.organisation.uuid}/mou/created")
       end
     end
 
     context 'when replacing the signed mou' do
       before do
-        visit mou_index_path
+        visit mou_index_path(organisation_uuid: user.organisation.uuid)
         attach_file("signed_mou", Rails.root + "spec/fixtures/mou.pdf")
         click_on 'Upload'
         attach_file("signed_mou", Rails.root + "spec/fixtures/mou.pdf")
@@ -55,14 +55,14 @@ describe 'Uploading and downloading an MOU', type: :feature do
       end
 
       it 'redirects to "after MOU uploaded" path for analytics' do
-        expect(page).to have_current_path('/mou/replaced')
+        expect(page).to have_current_path("/organisations/#{user.organisation.uuid}/mou/replaced")
       end
     end
   end
 
   context 'when signed out' do
     before do
-      visit mou_index_path
+      visit mou_index_path(organisation_uuid: user.organisation.uuid)
     end
 
     it_behaves_like 'not signed in'


### PR DESCRIPTION
These now include the organisation UUID in the URL.
Rest of the logged in routes will follow this pattern.