### PR TITLE
Add MOU & IP routes to Organisation/UUID scope

### DIFF
--- a/app/controllers/admin/mou_controller.rb
+++ b/app/controllers/admin/mou_controller.rb
@@ -5,9 +5,9 @@ class Admin::MouController < AdminController
 
   def create
     if params[:id]
-      organisation = Organisation.find(params[:id])
-      attach_to_organisation(organisation)
-      redirect_to admin_organisation_path(organisation)
+      organisation = Organisation.find_by(id: params[:id])
+      attach_to_organisation(organisation.id)
+      redirect_to admin_organisation_path(organisation.id)
     else
       attach_to_template
     end

--- a/app/controllers/admin/mou_controller.rb
+++ b/app/controllers/admin/mou_controller.rb
@@ -6,7 +6,7 @@ class Admin::MouController < AdminController
   def create
     if params[:id]
       organisation = Organisation.find_by(id: params[:id])
-      attach_to_organisation(organisation.id)
+      attach_to_organisation(organisation)
       redirect_to admin_organisation_path(organisation.id)
     else
       attach_to_template

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -10,13 +10,13 @@ class Admin::OrganisationsController < AdminController
   end
 
   def show
-    @organisation = Organisation.find(params[:id])
+    @organisation = Organisation.find_by(id: params[:id])
     @team = sorted_team_members(@organisation)
     @locations = @organisation.locations.order("address asc")
   end
 
   def destroy
-    organisation = Organisation.find(params[:id])
+    organisation = Organisation.find_by(id: params[:id])
     organisation.destroy
     redirect_to admin_organisations_path, notice: "Organisation has been removed"
   end

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -10,13 +10,13 @@ class Admin::OrganisationsController < AdminController
   end
 
   def show
-    @organisation = Organisation.find_by(id: params[:id])
+    @organisation = Organisation.find_by(id: params[:id]) || Organisation.find_by(uuid: params[:id])
     @team = sorted_team_members(@organisation)
     @locations = @organisation.locations.order("address asc")
   end
 
   def destroy
-    organisation = Organisation.find_by(id: params[:id])
+    organisation = Organisation.find_by(id: params[:id]) || Organisation.find_by(uuid: params[:id])
     organisation.destroy
     redirect_to admin_organisations_path, notice: "Organisation has been removed"
   end

--- a/app/controllers/ips_controller.rb
+++ b/app/controllers/ips_controller.rb
@@ -13,7 +13,7 @@ class IpsController < ApplicationController
     if @ip.save
       Facades::Ips::Publish.new.execute
       redirect_to(
-        created_ips_path,
+        created_ips_path(organisation: current_organisation),
         notice: "#{@ip.address} added, it will be active starting tomorrow"
       )
     else

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -10,7 +10,7 @@ class LocationsController < ApplicationController
     if @location.save
       Facades::Ips::Publish.new.execute
       redirect_to(
-        @location.ips.any? ? created_location_with_ip_ips_path : created_location_ips_path,
+        @location.ips.any? ? created_location_with_ip_ips_path(organisation: current_organisation) : created_location_ips_path(organisation: current_organisation),
         notice: "Successfully added #{@location.ips.length} #{'IP address'.pluralize(@location.ips.length)} to #{@location.full_address}"
       )
     else
@@ -21,10 +21,10 @@ class LocationsController < ApplicationController
 
   def destroy
     location = current_organisation.locations.find_by(id: params.fetch(:id))
-    redirect_to ips_path && return unless location && location.ips.empty?
+    redirect_to ips_path(organisation: current_organisation) && return unless location && location.ips.empty?
 
     location.destroy
-    redirect_to removed_location_ips_path, notice: "Successfully removed location #{location.address}"
+    redirect_to removed_location_ips_path(organisation: current_organisation), notice: "Successfully removed location #{location.address}"
   end
 
 private

--- a/app/controllers/mou_controller.rb
+++ b/app/controllers/mou_controller.rb
@@ -6,9 +6,9 @@ class MouController < ApplicationController
 
   def create
     redirect_path = if replacing?
-                      replaced_mou_index_path(organisation_uuid: current_organisation.uuid)
+                      replaced_mou_index_path(organisation: current_organisation)
                     else
-                      created_mou_index_path(organisation_uuid: current_organisation.uuid)
+                      created_mou_index_path(organisation: current_organisation)
                     end
 
     if params[:signed_mou]

--- a/app/controllers/mou_controller.rb
+++ b/app/controllers/mou_controller.rb
@@ -5,7 +5,12 @@ class MouController < ApplicationController
   end
 
   def create
-    redirect_path = replacing? ? replaced_mou_index_path : created_mou_index_path
+    redirect_path = if replacing?
+                      replaced_mou_index_path(organisation_uuid: current_organisation.uuid)
+                    else
+                      created_mou_index_path(organisation_uuid: current_organisation.uuid)
+                    end
+
     if params[:signed_mou]
       current_organisation.signed_mou.attach(params[:signed_mou])
       flash[:notice] = "MOU uploaded successfully."

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -16,7 +16,7 @@ class OrganisationsController < ApplicationController
 private
 
   def set_organisation
-    @organisation = Organisation.find_by(id: params.fetch(:id))
+    @organisation = Organisation.find_by(id: params[:id]) || Organisation.find_by(uuid: params[:id])
   end
 
   def validate_user_is_part_of_organisation

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -16,7 +16,7 @@ class OrganisationsController < ApplicationController
 private
 
   def set_organisation
-    @organisation = Organisation.find(params.fetch(:id))
+    @organisation = Organisation.find_by(id: params.fetch(:id))
   end
 
   def validate_user_is_part_of_organisation

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -24,7 +24,7 @@ private
   end
 
   def set_target_organisation
-    @target_organisation = Organisation.find(params[:id] || invite_params[:organisation_id])
+    @target_organisation = Organisation.find_by(id: params[:id] || invite_params[:organisation_id])
   end
 
   def user_is_invalid?

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -27,4 +27,8 @@ class Organisation < ApplicationRecord
 
     self.uuid = SecureRandom.uuid
   end
+
+  def to_param
+    uuid
+  end
 end

--- a/app/views/admin/organisations/index.html.erb
+++ b/app/views/admin/organisations/index.html.erb
@@ -28,7 +28,7 @@
     <% @organisations.each do |organisation| %>
       <tr class="govuk-table__row result-row">
         <td class="govuk-table__cell govuk-!-width-one-half" scope="row">
-          <%= link_to organisation.name, admin_organisation_path(organisation), class: "govuk-link filter-by" %>
+          <%= link_to organisation.name, admin_organisation_path(organisation.id), class: "govuk-link filter-by" %>
         </td>
         <td class="govuk-table__cell" scope="row">
           <%= organisation.created_at.strftime('%e %b %Y') %>

--- a/app/views/application/_radius_details.html.erb
+++ b/app/views/application/_radius_details.html.erb
@@ -10,9 +10,9 @@
     </p>
 
     <% if current_organisation.locations.empty? %>
-      <p>Your RADIUS secret keys will be generated when you <%= link_to 'add your first IP address', new_ip_path, class: "govuk-link" %></p>
+      <p>Your RADIUS secret keys will be generated when you <%= link_to 'add your first IP address', new_ip_path(organisation: current_organisation), class: "govuk-link" %></p>
     <% else %>
-      <p> Your RADIUS secret keys are shown under <%= link_to "your organisation's locations", ips_path, class: "govuk-link" %>.</p>
+      <p> Your RADIUS secret keys are shown under <%= link_to "your organisation's locations", ips_path(organisation: current_organisation), class: "govuk-link" %>.</p>
     <% end %>
 
     <h3> London: </h3>

--- a/app/views/application/_subnavigation.html.erb
+++ b/app/views/application/_subnavigation.html.erb
@@ -19,7 +19,7 @@
         <% else %>
           <%= link_to 'Setup', setup_instructions_path, class: active_tab(setup_instructions_path) + active_tab('mou') %>
         <% end %>
-        <%= link_to 'IPs', ips_path, id: 'nav-ips', class: active_tab('ips') + active_tab('locations') %>
+        <%= link_to 'IPs', ips_path(organisation: current_organisation), id: 'nav-ips', class: active_tab('ips') + active_tab('locations') %>
         <%= link_to 'Logs', new_logs_search_path, class: active_tab('logs') %>
         <%= link_to 'Team', team_members_path, class: active_tab('team') + active_tab('user') %>
       <% end %>

--- a/app/views/help/signed_in.html.erb
+++ b/app/views/help/signed_in.html.erb
@@ -30,7 +30,7 @@
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        Check your <%= link_to 'IPs and RADIUS secret keys', ips_path, class: "govuk-link" %> match your local configuration
+        Check your <%= link_to 'IPs and RADIUS secret keys', ips_path(organisation: current_organisation), class: "govuk-link" %> match your local configuration
       </li>
       <% unless current_organisation.locations.empty? %>
         <li>

--- a/app/views/ips/_confirm_remove_ip.html.erb
+++ b/app/views/ips/_confirm_remove_ip.html.erb
@@ -17,6 +17,6 @@
       </tbody>
     </table>
 
-    <%= button_to 'Yes, remove this IP', ip_path(@ip_to_delete), method: :delete, class: "govuk-button red-button" %>
+    <%= button_to 'Yes, remove this IP', ip_path(@ip_to_delete, organisation: current_organisation.uuid), method: :delete, class: "govuk-button red-button" %>
   </div>
 </div>

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -11,7 +11,7 @@
     </div>
     <% if current_user.can_manage_locations? %>
       <p class="govuk-body govuk-!-margin-bottom-1">
-        <%= link_to "Add IP to this location", new_ip_path(location: location), class: "govuk-link" %>
+        <%= link_to "Add IP to this location", new_ip_path(location: location, organisation: current_organisation.uuid), class: "govuk-link" %>
       </p>
     <% end %>
 
@@ -39,7 +39,7 @@
         </td>
         <td class="govuk-table__cell text-right">
           <% if current_user.can_manage_locations? %>
-            <%= link_to 'Remove', ip_remove_path(ip), class: "govuk-link" %>
+            <%= link_to 'Remove', ip_remove_path(ip, organisation: current_organisation.uuid), class: "govuk-link" %>
           <% end %>
         </td>
         <td class="govuk-table__cell text-right">

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -11,7 +11,7 @@
         <% if current_organisation.locations.empty? %>
           <%= link_to 'Add IP address', new_location_path, class: "govuk-button" %>
         <% else %>
-          <%= link_to 'Add IP address', new_ip_path, class: "govuk-button" %>
+          <%= link_to 'Add IP address', new_ip_path(organisation: current_organisation), class: "govuk-button" %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/ips/new.html.erb
+++ b/app/views/ips/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= link_to "Back to list", ips_path, class: "govuk-back-link" %>
+    <%= link_to "Back to list", ips_path(organisation: current_organisation), class: "govuk-back-link" %>
 
     <h2 class="govuk-heading-l">Add a new IP address</h2>
 

--- a/app/views/locations/new.erb
+++ b/app/views/locations/new.erb
@@ -19,7 +19,7 @@
 
 <div class='govuk-grid-row'>
   <div class='govuk-grid-column-full'>
-    <%= link_to 'Back to list', ips_path, class: 'govuk-back-link' %>
+    <%= link_to 'Back to list', ips_path(organisation: current_organisation), class: 'govuk-back-link' %>
 
     <% if current_organisation.locations.empty? %>
       <h2 class='govuk-heading-l'>Add your first location and IP addresses</h2>

--- a/app/views/logs/_no_logs_explanation.html.erb
+++ b/app/views/logs/_no_logs_explanation.html.erb
@@ -16,7 +16,7 @@
     </h3>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>Checking your <%= link_to 'configured IP addresses', ips_path, class: "govuk-link" %> match your authenticator IPs </li>
+      <li>Checking your <%= link_to 'configured IP addresses', ips_path(organisation: current_organisation), class: "govuk-link" %> match your authenticator IPs </li>
       <li>Checking your authenticators have the right RADIUS secret keys</li>
       <li><%= link_to 'Browsing the technical documentation', SITE_CONFIG['organisation_docs_link'], class: "govuk-link" %></li>
     </ul>

--- a/app/views/logs_searches/ip.html.erb
+++ b/app/views/logs_searches/ip.html.erb
@@ -19,6 +19,6 @@
       <%= f.submit 'Show logs', class: 'govuk-button' %>
     <% end %>
 
-    <p class='govuk-body'> Or, click "view logs" from <%= link_to 'your list of IP addresses', ips_path %></p>
+    <p class='govuk-body'> Or, click "view logs" from <%= link_to 'your list of IP addresses', ips_path(organisation: current_organisation) %></p>
   </div>
 </div>

--- a/app/views/mou/index.html.erb
+++ b/app/views/mou/index.html.erb
@@ -27,7 +27,7 @@
     <% end %>
 
     <div>
-      <%= form_with url: mou_index_path(organisation_uuid: current_organisation.uuid), method: 'post' do |form| %>
+      <%= form_with url: mou_index_path(organisation: current_organisation), method: 'post' do |form| %>
         <div class="govuk-form-group">
           <%= form.file_field(:signed_mou, class: 'govuk-file-upload') %>
         </div>

--- a/app/views/mou/index.html.erb
+++ b/app/views/mou/index.html.erb
@@ -27,7 +27,7 @@
     <% end %>
 
     <div>
-      <%= form_with url: mou_index_path, method: 'post' do |form| %>
+      <%= form_with url: mou_index_path(organisation_uuid: current_organisation.uuid), method: 'post' do |form| %>
         <div class="govuk-form-group">
           <%= form.file_field(:signed_mou, class: 'govuk-file-upload') %>
         </div>

--- a/app/views/overview/index.html.erb
+++ b/app/views/overview/index.html.erb
@@ -17,7 +17,7 @@
           <%= @locations.count %>
         </h1>
         <p class="govuk-panel__body text-left govuk-!-font-size-27">
-          <%= link_to "Locations", ips_path, class: "govuk-link govuk-link--no-visited-state summary-link-colour" %>
+          <%= link_to "Locations", ips_path(organisation: current_organisation), class: "govuk-link govuk-link--no-visited-state summary-link-colour" %>
         </p>
       </div>
     </div>
@@ -27,7 +27,7 @@
           <%= @ips.count %>
         </h1>
         <p class="govuk-panel__body text-left govuk-!-font-size-27">
-          <%= link_to "IPs", ips_path, class: "govuk-link govuk-link--no-visited-state summary-link-colour" %>
+          <%= link_to "IPs", ips_path(organisation: current_organisation), class: "govuk-link govuk-link--no-visited-state summary-link-colour" %>
         </p>
       </div>
     </div>

--- a/app/views/setup_instructions/index.html.erb
+++ b/app/views/setup_instructions/index.html.erb
@@ -11,12 +11,12 @@
       <% elsif @ips.empty? %>
         <% if current_user.can_manage_locations? %>
           <p class="govuk-body">
-            You need to <%= link_to "add the IPs", new_ip_path, class: "govuk-link" %> of your authenticator(s).
+            You need to <%= link_to "add the IPs", new_ip_path(organisation: current_organisation), class: "govuk-link" %> of your authenticator(s).
           </p>
         <% end %>
       <% else %>
         <p class="govuk-body">
-          You have <%= link_to "#{pluralize(@ips.count, 'IP')} configured.", ips_path, class: "govuk-link" %>
+          You have <%= link_to "#{pluralize(@ips.count, 'IP')} configured.", ips_path(organisation: current_organisation), class: "govuk-link" %>
         </p>
       <% end %>
       <p class="govuk-body">If your authenticators are allocated IPs dynamically, you can use Firewall NAT rules, so that your requests come from consistent IPs.</p>
@@ -80,7 +80,7 @@
 
     <h3 class="govuk-heading-m"> 6. Sign your agreement </h3>
     <p class="govuk-body">
-      <%= link_to "Sign a memorandum of understanding (MOU)", mou_index_path(organisation_uuid: current_organisation.uuid), class: "govuk-link" %> with the Government Digital Service (GDS).
+      <%= link_to "Sign a memorandum of understanding (MOU)", mou_index_path(organisation: current_organisation), class: "govuk-link" %> with the Government Digital Service (GDS).
     </p>
     <p class="govuk-body">This must be done by someone in your organisation who has permission to sign off and procure services'.</p>
 

--- a/app/views/setup_instructions/index.html.erb
+++ b/app/views/setup_instructions/index.html.erb
@@ -80,7 +80,7 @@
 
     <h3 class="govuk-heading-m"> 6. Sign your agreement </h3>
     <p class="govuk-body">
-      <%= link_to "Sign a memorandum of understanding (MOU)", mou_index_path, class: "govuk-link" %> with the Government Digital Service (GDS).
+      <%= link_to "Sign a memorandum of understanding (MOU)", mou_index_path(organisation_uuid: current_organisation.uuid), class: "govuk-link" %> with the Government Digital Service (GDS).
     </p>
     <p class="govuk-body">This must be done by someone in your organisation who has permission to sign off and procure services'.</p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,15 +15,6 @@ Rails.application.routes.draw do
 
   get '/healthcheck', to: 'monitoring#healthcheck'
   resources :status, only: %i[index]
-  resources :ips, only: %i[index new create destroy] do
-    get 'remove', to: 'ips#index'
-    get 'created', to: 'ips#index', on: :collection
-    get 'created/location', to: 'ips#index', on: :collection
-    get 'created/location/with-ip', to: 'ips#index', on: :collection
-    get 'removed', to: 'ips#index', on: :collection
-    get 'removed/location', to: 'ips#index', on: :collection
-  end
-
   resources :help, only: %i[create new] do
     get '/', on: :collection, to: 'help#new'
     get 'signed_in', on: :new
@@ -44,7 +35,16 @@ Rails.application.routes.draw do
     end
   end
 
-  scope '/organisations/:organisation_uuid' do
+  scope '/organisations/:organisation' do
+    resources :ips, only: %i[index new create destroy] do
+      get 'remove', to: 'ips#index'
+      get 'created', to: 'ips#index', on: :collection
+      get 'created/location', to: 'ips#index', on: :collection
+      get 'created/location/with-ip', to: 'ips#index', on: :collection
+      get 'removed', to: 'ips#index', on: :collection
+      get 'removed/location', to: 'ips#index', on: :collection
+    end
+
     resources :mou, only: %i[index create] do
       collection do
         get 'created', to: 'mou#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,10 +44,12 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :mou, only: %i[index create] do
-    collection do
-      get 'created', to: 'mou#index'
-      get 'replaced', to: 'mou#index'
+  scope '/organisations/:organisation_uuid' do
+    resources :mou, only: %i[index create] do
+      collection do
+        get 'created', to: 'mou#index'
+        get 'replaced', to: 'mou#index'
+      end
     end
   end
   resources :logs, only: %i[index]

--- a/spec/features/edit_organisation_details_spec.rb
+++ b/spec/features/edit_organisation_details_spec.rb
@@ -5,7 +5,7 @@ describe 'Editing an organisations details', type: :feature do
   context 'when editing an organisation you belong to' do
     before do
       sign_in_user user
-      visit edit_organisation_path(organisation)
+      visit edit_organisation_path(organisation.id)
       fill_in 'Service email', with: "NewServiceEmail@gov.uk"
       click_on 'Save'
     end
@@ -28,7 +28,7 @@ describe 'Editing an organisations details', type: :feature do
 
     it 'displays an error message to the user' do
       expect {
-        visit edit_organisation_path(user.organisation)
+        visit edit_organisation_path(organisation.id)
       }.to raise_error(ActionController::RoutingError)
     end
   end
@@ -36,7 +36,7 @@ describe 'Editing an organisations details', type: :feature do
   context 'when inputting invalid details' do
     before do
       sign_in_user user
-      visit edit_organisation_path(organisation)
+      visit edit_organisation_path(organisation.id)
       fill_in 'Service email', with: ''
       click_on 'Save'
     end

--- a/spec/features/ips/add_ip_to_existing_location_spec.rb
+++ b/spec/features/ips/add_ip_to_existing_location_spec.rb
@@ -5,7 +5,7 @@ describe 'Adding an IP to an existing location', type: :feature do
   context 'when selecting a location' do
     before do
       sign_in_user user
-      visit new_ip_path(location: location)
+      visit new_ip_path(location: location, organisation: user.organisation.uuid)
       fill_in 'address', with: ip_address
       click_on 'Add new IP address'
     end
@@ -22,7 +22,7 @@ describe 'Adding an IP to an existing location', type: :feature do
       end
 
       it 'redirects to the "after IP created" path for Analytics' do
-        expect(page).to have_current_path('/ips/created')
+        expect(page).to have_current_path("/organisations/#{user.organisation.uuid}/ips/created")
       end
     end
 
@@ -82,7 +82,7 @@ describe 'Adding an IP to an existing location', type: :feature do
 
     before do
       sign_in_user user
-      visit new_ip_path(location: other_location)
+      visit new_ip_path(location: other_location, organisation: user.organisation.uuid)
       fill_in 'address', with: "141.0.149.130"
       click_on 'Add new IP address'
     end
@@ -96,13 +96,13 @@ describe 'Adding an IP to an existing location', type: :feature do
     end
 
     it 'redirects to the "after IP created" path for Analytics' do
-      expect(page).to have_current_path('/ips/created')
+      expect(page).to have_current_path("/organisations/#{user.organisation.uuid}/ips/created")
     end
   end
 
   context 'when not logged in' do
     before do
-      visit new_ip_path(location: location)
+      visit new_ip_path(location: location, organisation: user.organisation.uuid)
     end
 
     it_behaves_like 'not signed in'

--- a/spec/features/ips/permissions_spec.rb
+++ b/spec/features/ips/permissions_spec.rb
@@ -12,16 +12,16 @@ describe 'Add an IP', type: :feature do
 
     context 'when visiting the add IP page directly' do
       before do
-        visit new_ip_path
+        visit new_ip_path(organisation: user.organisation.uuid)
       end
 
       it 'does not redirect them to the homepage' do
-        expect(page).to have_current_path(new_ip_path)
+        expect(page).to have_current_path(new_ip_path(organisation: user.organisation.uuid))
       end
     end
 
     it 'displays the add new IP link' do
-      visit ips_path
+      visit ips_path(organisation: user.organisation.uuid)
       expect(page).to have_link('Add IP address')
     end
 
@@ -43,13 +43,13 @@ describe 'Add an IP', type: :feature do
     end
 
     it 'hides the add new IP link' do
-      visit ips_path
+      visit ips_path(organisation: user.organisation.uuid)
       expect(page).not_to have_link('Add IP address')
     end
 
     context 'when visiting the add IP page directly' do
       before do
-        visit new_ip_path
+        visit new_ip_path(organisation: user.organisation.uuid)
       end
 
       it_behaves_like 'shows the setup instructions page'

--- a/spec/features/ips/remove_an_ip_spec.rb
+++ b/spec/features/ips/remove_an_ip_spec.rb
@@ -9,7 +9,7 @@ describe 'Removing an IP', type: :feature do
 
   context "with correct permissions" do
     before do
-      visit ips_path
+      visit ips_path(organisation: user.organisation.uuid)
       click_on "Remove"
     end
 
@@ -36,7 +36,7 @@ describe 'Removing an IP', type: :feature do
 
     it 'redirects to the "after IP removed" path for Analytics' do
       click_on "Yes, remove this IP"
-      expect(page).to have_current_path('/ips/removed')
+      expect(page).to have_current_path("/organisations/#{user.organisation.uuid}/ips/removed")
     end
   end
 
@@ -46,7 +46,7 @@ describe 'Removing an IP', type: :feature do
     end
 
     it "does not show the remove button" do
-      visit ips_path
+      visit ips_path(organisation: user.organisation.uuid)
 
       within("#ips-table") do
         expect(page).not_to have_content("Remove")
@@ -55,7 +55,7 @@ describe 'Removing an IP', type: :feature do
 
     context "when visiting the remove IP page directly" do
       before do
-        visit ip_remove_path(ip)
+        visit ip_remove_path(ip, organisation: user.organisation.uuid)
       end
 
       it "does not show the partial" do
@@ -68,7 +68,7 @@ describe 'Removing an IP', type: :feature do
     let(:other_ip) { create(:ip, location: create(:location)) }
 
     before do
-      visit ip_remove_path(other_ip)
+      visit ip_remove_path(other_ip, organisation: user.organisation.uuid)
     end
 
     it "does not show the partial" do

--- a/spec/features/ips/view_ip_address_readiness_spec.rb
+++ b/spec/features/ips/view_ip_address_readiness_spec.rb
@@ -7,13 +7,13 @@ describe 'Wiew whether IPs are ready', type: :feature do
     before do
       create :location, organisation: user.organisation
       sign_in_user user
-      visit new_ip_path
+      visit new_ip_path(organisation: user.organisation.uuid)
       fill_in 'address', with: '141.0.149.130'
       click_on 'Add new IP address'
     end
 
     context 'when viewing the new IP immediately' do
-      before { visit ips_path }
+      before { visit ips_path(organisation: user.organisation.uuid) }
 
       it 'shows it is activating tomorrow' do
         expect(page).to have_content('Not available until 6am tomorrow')
@@ -26,7 +26,7 @@ describe 'Wiew whether IPs are ready', type: :feature do
           ip.update_attributes(created_at: Date.yesterday)
         end
         sign_in_user user
-        visit ips_path
+        visit ips_path(organisation: user.organisation.uuid)
       end
 
       it 'shows it as available' do

--- a/spec/features/ips/view_ip_addresses_spec.rb
+++ b/spec/features/ips/view_ip_addresses_spec.rb
@@ -9,7 +9,7 @@ describe 'Viewing IP addresses', type: :feature do
     end
 
     it 'shows no IPs' do
-      visit ips_path
+      visit ips_path(organisation: user.organisation.uuid)
       expect(page).to have_content 'You need to add the IPs of your authenticator(s)'
     end
 
@@ -28,7 +28,7 @@ describe 'Viewing IP addresses', type: :feature do
 
     before do
       sign_in_user user
-      visit ips_path
+      visit ips_path(organisation: user.organisation.uuid)
     end
 
     it 'shows the RADIUS secret key' do
@@ -54,7 +54,7 @@ describe 'Viewing IP addresses', type: :feature do
     context 'with active IPs' do
       before do
         create(:session, start: Date.today, username: 'abc123', siteIP: ip.address)
-        visit ips_path
+        visit ips_path(organisation: user.organisation.uuid)
       end
 
       it 'Does not label the IP as inactive' do
@@ -66,7 +66,7 @@ describe 'Viewing IP addresses', type: :feature do
   end
 
   context 'when logged out' do
-    before { visit ips_path }
+    before { visit ips_path(organisation: user.organisation.uuid) }
 
     it_behaves_like 'not signed in'
   end

--- a/spec/features/locations/add_new_location_spec.rb
+++ b/spec/features/locations/add_new_location_spec.rb
@@ -7,7 +7,7 @@ describe 'Add new location', type: :feature do
 
   before do
     sign_in_user user
-    visit ips_path
+    visit ips_path(organisation: user.organisation.uuid)
     click_on 'Add IP address'
   end
 
@@ -34,7 +34,7 @@ describe 'Add new location', type: :feature do
 
       it 'redirects to "After location created with IP" path for analytics' do
         click_on 'Add new location'
-        expect(page).to have_current_path('/ips/created/location/with-ip')
+        expect(page).to have_current_path("/organisations/#{user.organisation.uuid}/ips/created/location/with-ip")
       end
     end
 
@@ -72,7 +72,7 @@ describe 'Add new location', type: :feature do
       end
 
       it 'does not add the invalid IP' do
-        visit ips_path
+        visit ips_path(organisation: user.organisation.uuid)
         expect(page).not_to have_content('10.wrong.0.1')
       end
     end
@@ -89,7 +89,7 @@ describe 'Add new location', type: :feature do
       end
 
       it 'redirects to "After location created" path for analytics' do
-        expect(page).to have_current_path('/ips/created/location')
+        expect(page).to have_current_path("/organisations/#{user.organisation.uuid}/ips/created/location")
       end
     end
 

--- a/spec/features/locations/remove_a_location_spec.rb
+++ b/spec/features/locations/remove_a_location_spec.rb
@@ -8,7 +8,7 @@ describe 'Remove a location', type: :feature do
 
   context "with correct permissions" do
     before do
-      visit ips_path
+      visit ips_path(organisation: user.organisation.uuid)
     end
 
     context "when location has no IPs" do
@@ -33,7 +33,7 @@ describe 'Remove a location', type: :feature do
 
       it 'redirects to the "after location removed" path for analytics' do
         click_on "Yes, remove this location"
-        expect(page).to have_current_path('/ips/removed/location')
+        expect(page).to have_current_path("/organisations/#{user.organisation.uuid}/ips/removed/location")
       end
     end
 
@@ -54,7 +54,7 @@ describe 'Remove a location', type: :feature do
     end
 
     it "does not show the remove button" do
-      visit ips_path
+      visit ips_path(organisation: user.organisation.uuid)
       within("#ips-table") do
         expect(page).not_to have_content("Remove location")
       end

--- a/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
@@ -13,7 +13,7 @@ describe 'View authentication requests for an IP', type: :feature do
 
   context 'when using a link' do
     before do
-      visit ips_path
+      visit ips_path(organisation: admin_user.organisation.uuid)
 
       within('#ips-table') do
         click_on 'View logs'

--- a/spec/features/overview/view_overview_page_spec.rb
+++ b/spec/features/overview/view_overview_page_spec.rb
@@ -71,14 +71,14 @@ describe 'Viewing the overview page', type: :feature do
       it 'redirects to the IPs page when Locations is clicked on' do
         click_link 'Locations'
 
-        expect(page).to have_current_path(ips_path)
+        expect(page).to have_current_path(ips_path(organisation: user.organisation.uuid))
       end
 
       it 'redirects to the IPs page when IPs is clicked on' do
         within('div#ips') do
           click_link 'IPs'
         end
-        expect(page).to have_current_path(ips_path)
+        expect(page).to have_current_path(ips_path(organisation: user.organisation.uuid))
       end
     end
   end

--- a/spec/features/super_admin/invite_user_to_organisation_spec.rb
+++ b/spec/features/super_admin/invite_user_to_organisation_spec.rb
@@ -8,7 +8,7 @@ describe "Inviting a team member as a super admin", type: :feature do
 
   before do
     sign_in_user super_admin
-    visit admin_organisation_path(organisation)
+    visit admin_organisation_path(organisation.id)
     click_on 'Add team member'
     fill_in 'Email address', with: email
   end
@@ -18,7 +18,7 @@ describe "Inviting a team member as a super admin", type: :feature do
 
   it "will take the user to the organisation when they click 'back to organisation'" do
     click_on 'Back to organisation'
-    expect(page).to have_current_path(admin_organisation_path(organisation))
+    expect(page).to have_current_path(admin_organisation_path(organisation.id))
   end
 
   it "will display the name of the organisation you want to add a team member to" do
@@ -37,7 +37,7 @@ describe "Inviting a team member as a super admin", type: :feature do
 
   it "will redirect the user to the organisation page on success" do
     click_on 'Send invitation email'
-    expect(page).to have_current_path(admin_organisation_path(organisation))
+    expect(page).to have_current_path(admin_organisation_path(organisation.id))
   end
 
   context "without an email address" do
@@ -73,7 +73,7 @@ describe "Inviting a team member as a super admin", type: :feature do
       end
 
       it "will redirect the user to the organisation page on success" do
-        expect(page).to have_current_path(admin_organisation_path(organisation))
+        expect(page).to have_current_path(admin_organisation_path(organisation.id))
       end
     end
   end

--- a/spec/features/super_admin/organisations/delete_organisation_spec.rb
+++ b/spec/features/super_admin/organisations/delete_organisation_spec.rb
@@ -5,7 +5,7 @@ describe 'Deleting an organisation', type: :feature do
   context 'when visiting the organisations page' do
     before do
       sign_in_user admin_user
-      visit admin_organisation_path(organisation)
+      visit admin_organisation_path(organisation.id)
       click_on 'Delete organisation'
     end
 

--- a/spec/features/super_admin/organisations/view_organisation_page_spec.rb
+++ b/spec/features/super_admin/organisations/view_organisation_page_spec.rb
@@ -18,7 +18,7 @@ describe 'View details of an organisation', type: :feature do
       create(:ip, location: location_3)
 
       sign_in_user create(:user, :super_admin)
-      visit admin_organisation_path(organisation)
+      visit admin_organisation_path(organisation.id)
     end
 
     it 'shows details page for the organisations' do
@@ -90,7 +90,7 @@ describe 'View details of an organisation', type: :feature do
         organisation.signed_mou.attach(
           io: File.open(Rails.root + 'spec/fixtures/mou.pdf'), filename: 'mou.pdf'
         )
-        visit admin_organisation_path(organisation)
+        visit admin_organisation_path(organisation.id)
       end
 
       it 'has a download button' do
@@ -113,7 +113,7 @@ describe 'View details of an organisation', type: :feature do
   end
 
   context 'when logged out' do
-    before { visit admin_organisation_path(organisation) }
+    before { visit admin_organisation_path(organisation.id) }
 
     it_behaves_like 'not signed in'
   end
@@ -121,7 +121,7 @@ describe 'View details of an organisation', type: :feature do
   context 'when logged in as a normal user' do
     before do
       sign_in_user create(:user)
-      visit admin_organisation_path(organisation)
+      visit admin_organisation_path(organisation.id)
     end
 
     it_behaves_like 'user not authorised'

--- a/spec/features/super_admin/upload_download_mou_spec.rb
+++ b/spec/features/super_admin/upload_download_mou_spec.rb
@@ -51,7 +51,7 @@ describe 'Upload and download the MOU template', type: :feature do
 
   context 'when an organisation exists with no MOU' do
     before do
-      visit(admin_organisation_path(Organisation.first))
+      visit(admin_organisation_path(Organisation.first.id))
     end
 
     context 'when I attach an MOU' do

--- a/spec/features/track_new_organisations_spec.rb
+++ b/spec/features/track_new_organisations_spec.rb
@@ -25,7 +25,7 @@ describe 'Tracking new organisations', type: :feature do
     let(:ip_address) { '120.0.129.150' }
 
     before do
-      visit new_ip_path(location: location)
+      visit new_ip_path(location: location, organisation: user.organisation.uuid)
       fill_in 'address', with: ip_address
       click_on 'Add new IP address'
       click_on 'Setup'

--- a/spec/features/upload_download_mous_spec.rb
+++ b/spec/features/upload_download_mous_spec.rb
@@ -8,7 +8,7 @@ describe 'Uploading and downloading an MOU', type: :feature do
 
     context 'when no file is chosen to upload' do
       before do
-        visit mou_index_path
+        visit mou_index_path(organisation_uuid: user.organisation.uuid)
         click_on 'Upload'
       end
 
@@ -19,7 +19,7 @@ describe 'Uploading and downloading an MOU', type: :feature do
 
     context 'when uploading the signed mou' do
       before do
-        visit mou_index_path
+        visit mou_index_path(organisation_uuid: user.organisation.uuid)
         attach_file("signed_mou", Rails.root + "spec/fixtures/mou.pdf")
         click_on 'Upload'
       end
@@ -33,13 +33,13 @@ describe 'Uploading and downloading an MOU', type: :feature do
       end
 
       it 'redirects to "after MOU uploaded" path for analytics' do
-        expect(page).to have_current_path('/mou/created')
+        expect(page).to have_current_path("/organisations/#{user.organisation.uuid}/mou/created")
       end
     end
 
     context 'when replacing the signed mou' do
       before do
-        visit mou_index_path
+        visit mou_index_path(organisation_uuid: user.organisation.uuid)
         attach_file("signed_mou", Rails.root + "spec/fixtures/mou.pdf")
         click_on 'Upload'
         attach_file("signed_mou", Rails.root + "spec/fixtures/mou.pdf")
@@ -55,14 +55,14 @@ describe 'Uploading and downloading an MOU', type: :feature do
       end
 
       it 'redirects to "after MOU uploaded" path for analytics' do
-        expect(page).to have_current_path('/mou/replaced')
+        expect(page).to have_current_path("/organisations/#{user.organisation.uuid}/mou/replaced")
       end
     end
   end
 
   context 'when signed out' do
     before do
-      visit mou_index_path
+      visit mou_index_path(organisation_uuid: user.organisation.uuid)
     end
 
     it_behaves_like 'not signed in'

--- a/spec/features/upload_download_mous_spec.rb
+++ b/spec/features/upload_download_mous_spec.rb
@@ -8,7 +8,7 @@ describe 'Uploading and downloading an MOU', type: :feature do
 
     context 'when no file is chosen to upload' do
       before do
-        visit mou_index_path(organisation_uuid: user.organisation.uuid)
+        visit mou_index_path(organisation: user.organisation.uuid)
         click_on 'Upload'
       end
 
@@ -19,7 +19,7 @@ describe 'Uploading and downloading an MOU', type: :feature do
 
     context 'when uploading the signed mou' do
       before do
-        visit mou_index_path(organisation_uuid: user.organisation.uuid)
+        visit mou_index_path(organisation: user.organisation.uuid)
         attach_file("signed_mou", Rails.root + "spec/fixtures/mou.pdf")
         click_on 'Upload'
       end
@@ -39,7 +39,7 @@ describe 'Uploading and downloading an MOU', type: :feature do
 
     context 'when replacing the signed mou' do
       before do
-        visit mou_index_path(organisation_uuid: user.organisation.uuid)
+        visit mou_index_path(organisation: user.organisation.uuid)
         attach_file("signed_mou", Rails.root + "spec/fixtures/mou.pdf")
         click_on 'Upload'
         attach_file("signed_mou", Rails.root + "spec/fixtures/mou.pdf")
@@ -62,7 +62,7 @@ describe 'Uploading and downloading an MOU', type: :feature do
 
   context 'when signed out' do
     before do
-      visit mou_index_path(organisation_uuid: user.organisation.uuid)
+      visit mou_index_path(organisation: user.organisation.uuid)
     end
 
     it_behaves_like 'not signed in'

--- a/spec/requests/ips/create_spec.rb
+++ b/spec/requests/ips/create_spec.rb
@@ -17,6 +17,6 @@ describe "POST /ips", type: :request do
   end
 
   it "publishes IP to s3 for performance platform" do
-    post ips_path, params: { ip: { address: ip_address } }
+    post ips_path(organisation: user.organisation.uuid), params: { ip: { address: ip_address } }
   end
 end

--- a/spec/requests/ips/delete_spec.rb
+++ b/spec/requests/ips/delete_spec.rb
@@ -17,12 +17,12 @@ describe "DELETE /ips/:id", type: :request do
 
     it "deletes the IP" do
       expect {
-        delete ip_path(ip)
+        delete ip_path(ip, organisation: user.organisation.uuid)
       }.to change(Ip, :count).by(-1)
     end
 
     it "publishes the list of remaining IPs after a deletion" do
-      delete ip_path(ip)
+      delete ip_path(ip, organisation: user.organisation.uuid)
       expect(publish_ip).to have_received(:execute)
     end
   end
@@ -32,7 +32,7 @@ describe "DELETE /ips/:id", type: :request do
 
     it "does not delete the IP" do
       expect {
-        delete ip_path(other_ip)
+        delete ip_path(other_ip, organisation: user.organisation.uuid)
       }.to change(Ip, :count).by(0)
     end
   end


### PR DESCRIPTION
**WHY:**
As part of allowing users to register multiple organisations, we want to edit the URL structure to have the current organisation's uuid within it, this is an iterative slice towards that objective.

This slice involves moving the MOU & IP resource routes into `scope '/organisations/:organisation'`

The new URL would look like, e.g: `https://admin.wifi.service.gov.uk/organisations/aaaaaa-bbbbb-cccc-dddd-eeee1111/ips`

**IN THIS PR:**
- Move `resources :ips, only: %i[index new create destroy]` into the `scope '/organisations/:organisation'`

- Move `resources :mou, only: %i[index create]` into the `scope '/organisations/:organisation'`

- Fix failing specs
- Refactor route paths
- Refactor test

**Any feedback/suggestions would be appreciated.**