### PR TITLE
Publish list of domain names to S3 on delete

### DIFF
--- a/app/controllers/admin/whitelists/email_domains_controller.rb
+++ b/app/controllers/admin/whitelists/email_domains_controller.rb
@@ -26,14 +26,8 @@ class Admin::Whitelists::EmailDomainsController < AdminController
     authorised_email_domain = AuthorisedEmailDomain.find_by(id: params.fetch(:id))
 
     authorised_email_domain.destroy
-    UseCases::Administrator::PublishSignupWhitelist.new(
-      destination_gateway: Gateways::S3.new(
-        bucket: ENV.fetch('S3_SIGNUP_WHITELIST_BUCKET'),
-        key: ENV.fetch('S3_SIGNUP_WHITELIST_OBJECT_KEY')
-      ),
-      source_gateway: Gateways::AuthorisedEmailDomains.new,
-      presenter: UseCases::Administrator::FormatEmailDomainsRegex.new
-    ).execute
+    publish_email_domains_regex
+    publish_email_domains_list
 
     redirect_to admin_whitelist_email_domains_path, notice: "#{authorised_email_domain.name} has been deleted"
   end

--- a/spec/requests/email_domain/delete_spec.rb
+++ b/spec/requests/email_domain/delete_spec.rb
@@ -1,8 +1,10 @@
 describe "DELETE /authorised_email_domains/:id", type: :request do
   let!(:email_domain) { create(:authorised_email_domain, name: 'some.domain.org.uk') }
-  let(:gateway) { instance_spy(Gateways::S3, write: nil) }
+  let(:regex_gateway) { instance_spy(Gateways::S3, write: nil) }
+  let(:email_domains_gateway) { instance_spy(Gateways::S3) }
 
-  before { allow(Gateways::S3).to receive(:new).and_return(gateway) }
+
+  before { allow(Gateways::S3).to receive(:new).and_return(regex_gateway, email_domains_gateway) }
 
   context "when the user is a super admin" do
     before do
@@ -16,9 +18,14 @@ describe "DELETE /authorised_email_domains/:id", type: :request do
       }.to change(AuthorisedEmailDomain, :count).by(-1)
     end
 
-    it 'publishes the new list of authorised domains to S3' do
+    it 'publishes the new regex list of authorised domains to S3' do
       delete admin_whitelist_email_domain_path(email_domain)
-      expect(gateway).to have_received(:write)
+      expect(regex_gateway).to have_received(:write)
+    end
+
+    it 'publishes the new list of email domains to S3' do
+      delete admin_whitelist_email_domain_path(email_domain)
+      expect(email_domains_gateway).to have_received(:write)
     end
   end
 


### PR DESCRIPTION
This PR allows the S3 email domains list object to be update on delete.