### PR TITLE
Remove organisation id from user table

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -8,7 +8,7 @@ private
 
   def ensure_organisation_added
     organisation_id = if super_admin?
-                        invite_params[:organisation_id]
+                        params[:user][:organisation_id]
                       else
                         current_organisation.id
                       end
@@ -34,7 +34,7 @@ private
   end
 
   def set_target_organisation
-    @target_organisation = Organisation.find(params[:id] || invite_params[:organisation_id])
+    @target_organisation = Organisation.find(params[:id] || params[:user][:organisation_id])
   end
 
   def user_is_invalid?
@@ -54,7 +54,7 @@ private
 
   def after_invite_path_for(_resource)
     if super_admin?
-      admin_organisation_path(invite_params[:organisation_id])
+      admin_organisation_path(params[:user][:organisation_id])
     else
       resending_invite? ? recreated_invite_team_members_path : created_invite_team_members_path
     end
@@ -82,7 +82,7 @@ private
 
   # Overrides https://github.com/scambra/devise_invitable/blob/master/app/controllers/devise/invitations_controller.rb#L105
   def invite_params
-    params.require(:user).permit(:email, :organisation_id, permission_attributes: %i(
+    params.require(:user).permit(:email, permission_attributes: %i(
       can_manage_team
       can_manage_locations
     ))

--- a/db/migrate/20190513130149_remove_organisation_id_from_users.rb
+++ b/db/migrate/20190513130149_remove_organisation_id_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveOrganisationIdFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :organisation_id, :index
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_07_122113) do
+ActiveRecord::Schema.define(version: 2019_05_13_130149) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -112,7 +112,6 @@ ActiveRecord::Schema.define(version: 2019_05_07_122113) do
     t.datetime "confirmation_sent_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "organisation_id"
     t.string "name"
     t.string "invitation_token"
     t.datetime "invitation_created_at"
@@ -131,7 +130,6 @@ ActiveRecord::Schema.define(version: 2019_05_07_122113) do
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
     t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
-    t.index ["organisation_id"], name: "index_users_on_organisation_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end


### PR DESCRIPTION
**WHY:**
We're removing `organisation.id ` from the user table as it exists in its own table as a many to many relationship.

**IN THIS PR:**
- Create & apply migration to remove the `organisation_id` column from the `users` table.
- Refactor invitations controller as `organisation_id` is no longer to available to pass as params within the `invite_params` method.

**Any suggestions/feedback on this approach would be appreciated.**