### PR TITLE
Add template for cross organisation invitations

### DIFF
--- a/config/gov_notify.yml
+++ b/config/gov_notify.yml
@@ -10,6 +10,8 @@ staging:
     template_id: '152cf3ff-e0e2-4f41-9ba0-28091db3f37f'
   unlock_account:
     template_id: '41f8744a-ebe0-417e-98c7-09002ff17a95'
+  cross_organisation_invitation:
+    template_id: 'd360ba95-1e7d-41e4-920c-1255b65f6f65'
 
 development:
   support_email: 'dev@localhost.com'
@@ -23,6 +25,8 @@ development:
     template_id: '152cf3ff-e0e2-4f41-9ba0-28091db3f37f'
   unlock_account:
     template_id: '41f8744a-ebe0-417e-98c7-09002ff17a95'
+  cross_organisation_invitation:
+    template_id: 'd360ba95-1e7d-41e4-920c-1255b65f6f65'
 
 test:
   support_email: 'test@localhost'
@@ -36,6 +40,8 @@ test:
     template_id: 'help'
   unlock_account:
     template_id: 'unlock'
+  cross_organisation_invitation:
+    template_id: 'org_invite'
 
 production:
   support_email: 'govwifi-support@digital.cabinet-office.gov.uk'
@@ -49,4 +55,6 @@ production:
     template_id: '5afffbbc-dbbf-4f50-b29d-8d058eb51734'
   unlock_account:
     template_id: '39465eec-632a-4475-82ac-4bd8a45386ea'
+  cross_organisation_invitation:
+    template_id: '103d1302-f068-4352-af0b-1280b068db01'
 


### PR DESCRIPTION
Inviting someone to join your organisation will send a different email.
These are unused right now but ready for the mailers.