### PR TITLE
Invitations for joining other organisations

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_organisation, :super_admin?
 
   def current_organisation
-    if session[:organisation_id] && current_user.organisations.pluck(:id).include?(session[:organisation_id])
+    @organisation ||= if session[:organisation_id] && current_user.organisations.pluck(&:id).include?(session[:organisation_id])
       Organisation.find(session[:organisation_id])
     else
       current_user.organisations.first

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_organisation, :super_admin?
 
   def current_organisation
-    @organisation ||= if session[:organisation_id] && current_user.organisations.pluck(&:id).include?(session[:organisation_id])
+    if session[:organisation_id] && current_user.organisations.pluck(:id).include?(session[:organisation_id])
       Organisation.find(session[:organisation_id])
     else
       current_user.organisations.first

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -32,7 +32,7 @@ private
 
     AuthenticationMailer.invitation_instructions(invited_user, token).deliver_now
 
-    redirect_to team_members_path, notice: 'done'
+    redirect_to team_members_path, notice: "#{invited_user.email} has been invited to join #{current_organisation.name}"
   end
 
   def user_belongs_to_other_organisations?

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,4 +1,6 @@
 class Users::InvitationsController < Devise::InvitationsController
+  prepend_before_action :create_cross_organisation_invitation, if: :user_belongs_to_other_organisations?, only: :create
+
   before_action :set_target_organisation, if: :super_admin?, only: %i(create new)
   before_action :delete_user_record, if: :user_should_be_cleared?, only: :create
   before_action :return_user_to_invite_page, if: :user_is_invalid?, only: :create
@@ -18,6 +20,25 @@ private
     if user.organisations.empty?
       user.organisations << organisation
     end
+  end
+
+  def create_cross_organisation_invitation
+    token = Devise.friendly_token[0, 20]
+    invited_user.cross_organisation_invitations.create!(
+      invited_by_id: current_user.id,
+      organisation: current_organisation,
+      invitation_token: token
+    )
+
+    AuthenticationMailer.invitation_instructions(invited_user, token).deliver_now
+
+    redirect_to team_members_path, notice: 'done'
+  end
+
+  def user_belongs_to_other_organisations?
+    invited_user.present? &&
+      invited_user.organisations.present? &&
+      invited_user.organisations.pluck(:id).exclude?(current_organisation.id)
   end
 
   def authenticate_inviter!

--- a/app/models/cross_organisation_invitation.rb
+++ b/app/models/cross_organisation_invitation.rb
@@ -1,3 +1,4 @@
 class CrossOrganisationInvitation < ApplicationRecord
   belongs_to :organisation
+  belongs_to :user
 end

--- a/app/models/cross_organisation_invitation.rb
+++ b/app/models/cross_organisation_invitation.rb
@@ -1,0 +1,3 @@
+class CrossOrganisationInvitation < ApplicationRecord
+  belongs_to :organisation
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_and_belongs_to_many :organisations
+  has_many :cross_organisation_invitations
 
   has_one :permission, dependent: :destroy
   accepts_nested_attributes_for :permission, :organisations

--- a/config/gov_notify.yml
+++ b/config/gov_notify.yml
@@ -10,6 +10,8 @@ staging:
     template_id: '152cf3ff-e0e2-4f41-9ba0-28091db3f37f'
   unlock_account:
     template_id: '41f8744a-ebe0-417e-98c7-09002ff17a95'
+  cross_organisation_invitation:
+    template_id: 'd360ba95-1e7d-41e4-920c-1255b65f6f65'
 
 development:
   support_email: 'dev@localhost.com'
@@ -23,6 +25,8 @@ development:
     template_id: '152cf3ff-e0e2-4f41-9ba0-28091db3f37f'
   unlock_account:
     template_id: '41f8744a-ebe0-417e-98c7-09002ff17a95'
+  cross_organisation_invitation:
+    template_id: 'd360ba95-1e7d-41e4-920c-1255b65f6f65'
 
 test:
   support_email: 'test@localhost'
@@ -36,6 +40,8 @@ test:
     template_id: 'help'
   unlock_account:
     template_id: 'unlock'
+  cross_organisation_invitation:
+    template_id: 'org_invite'
 
 production:
   support_email: 'govwifi-support@digital.cabinet-office.gov.uk'
@@ -49,4 +55,6 @@ production:
     template_id: '5afffbbc-dbbf-4f50-b29d-8d058eb51734'
   unlock_account:
     template_id: '39465eec-632a-4475-82ac-4bd8a45386ea'
+  cross_organisation_invitation:
+    template_id: '103d1302-f068-4352-af0b-1280b068db01'
 

--- a/db/migrate/20190513111153_create_cross_organisation_invitations.rb
+++ b/db/migrate/20190513111153_create_cross_organisation_invitations.rb
@@ -1,0 +1,11 @@
+class CreateCrossOrganisationInvitations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :cross_organisation_invitations do |t|
+      t.timestamps
+      t.references :organisation, null: false
+      t.string :invitation_token, null: false
+      t.references :user, null: false
+      t.integer :invited_by_id, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_07_122113) do
+ActiveRecord::Schema.define(version: 2019_05_13_111153) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -37,6 +37,17 @@ ActiveRecord::Schema.define(version: 2019_05_07_122113) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "cross_organisation_invitations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "organisation_id", null: false
+    t.string "invitation_token", null: false
+    t.bigint "user_id", null: false
+    t.integer "invited_by_id", null: false
+    t.index ["organisation_id"], name: "index_cross_organisation_invitations_on_organisation_id"
+    t.index ["user_id"], name: "index_cross_organisation_invitations_on_user_id"
   end
 
   create_table "custom_organisation_names", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/features/invite_existing_user_spec.rb
+++ b/spec/features/invite_existing_user_spec.rb
@@ -3,8 +3,9 @@ require 'support/notifications_service'
 require 'support/confirmation_use_case'
 
 describe 'Inviting an existing user', type: :feature do
-  let(:betty) { create(:user, :with_organisation) }
-  let(:confirmed_user) { create(:user, :with_organisation) }
+  let(:organisation) { create(:organisation) }
+  let(:betty) { create(:user, organisations: [organisation]) }
+  let(:confirmed_user) { create(:user, organisations: [organisation]) }
 
   include_examples 'when sending an invite email'
 
@@ -18,10 +19,6 @@ describe 'Inviting an existing user', type: :feature do
 
     it 'does not send an invitation' do
       expect(InviteUseCaseSpy.invite_count).to eq(0)
-    end
-
-    it 'displays the correct error message' do
-      expect(page).to have_content("Email is already associated with an account. If you can't sign in, reset your password")
     end
 
     context 'when the invited user signs in afterwards' do

--- a/spec/features/invite_user_to_join_organisation_spec.rb
+++ b/spec/features/invite_user_to_join_organisation_spec.rb
@@ -1,0 +1,27 @@
+require 'support/invite_use_case'
+require 'support/notifications_service'
+require 'support/confirmation_use_case'
+
+describe 'Inviting an existing user', type: :feature do
+  let(:betty) { create(:user, :with_organisation) }
+  let(:confirmed_user) { create(:user, :with_organisation) }
+
+  include_examples 'when sending an invite email'
+
+  context 'with a confirmed user' do
+    before do
+      sign_in_user confirmed_user
+      visit new_user_invitation_path
+      fill_in 'Email', with: betty.email
+      click_on 'Send invitation email'
+    end
+
+    it 'sends an invitation' do
+      expect(InviteUseCaseSpy.invite_count).to eq(1)
+    end
+
+    it 'creates a join organisation invitation' do
+      expect(betty.cross_organisation_invitations.count).to eq(1)
+    end
+  end
+end

--- a/spec/features/invite_user_to_join_organisation_spec.rb
+++ b/spec/features/invite_user_to_join_organisation_spec.rb
@@ -23,5 +23,9 @@ describe 'Inviting an existing user', type: :feature do
     it 'creates a join organisation invitation' do
       expect(betty.cross_organisation_invitations.count).to eq(1)
     end
+
+    it 'notifies the user with a success message' do
+      expect(page).to have_content("#{betty.email} has been invited to join #{confirmed_user.organisations.first.name}")
+    end
   end
 end

--- a/spec/features/team/invite_a_team_member_spec.rb
+++ b/spec/features/team/invite_a_team_member_spec.rb
@@ -41,7 +41,8 @@ describe "Inviting a team member", type: :feature do
       end
 
       it "sets the invitees organisation" do
-        expect(invited_user.organisations).to eq(user.organisations)
+        organisations = invited_user.organisations
+        expect(organisations).to eq(user.organisations)
       end
 
       it 'redirects to the "after user invited" path for analytics' do
@@ -122,8 +123,7 @@ describe "Inviting a team member", type: :feature do
     end
 
     context "with an unconfirmed user that has already been invited" do
-      let(:organisation) { create(:organisation) }
-      let!(:invited_user) { create(:user, invitation_sent_at: Time.now, organisations: [organisation], confirmed_at: nil) }
+      let!(:invited_user) { create(:user, invitation_sent_at: Time.now, organisations: user.organisations, confirmed_at: nil) }
       let(:invited_user_email) { invited_user.email }
 
       before do

--- a/spec/models/cross_organisation_invitation_spec.rb
+++ b/spec/models/cross_organisation_invitation_spec.rb
@@ -1,0 +1,4 @@
+describe CrossOrganisationInvitation do
+  it { is_expected.to belong_to(:organisation) }
+  it { is_expected.to belong_to(:user) }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,6 @@
 describe User do
   it { is_expected.to have_and_belong_to_many(:organisations) }
+  it { is_expected.to have_many(:cross_organisation_invitations) }
   it { is_expected.to validate_presence_of(:name).on(:update) }
 
   context 'when creating a user without explicit permissions' do


### PR DESCRIPTION
Inviting existing users to join other organisations has a different flow to inviting non-existent users.
We don't create a new user, rather just create an invitation for them to join another organisation.

There is no confirmation of invitations yet.