### PR TITLE
Confirm invite org

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,11 @@ class ApplicationController < ActionController::Base
   helper_method :current_organisation, :super_admin?
 
   def current_organisation
+<<<<<<< HEAD
     if session[:organisation_id] && current_user.organisations.pluck(:id).include?(session[:organisation_id].to_i)
+=======
+    if session[:organisation_id] && current_user.organisations.pluck(:id).include?(session[:organisation_id])
+>>>>>>> Allow creating Cross Organisation invitations
       Organisation.find(session[:organisation_id])
     else
       current_user.organisations.first

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,11 +7,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_organisation, :super_admin?
 
   def current_organisation
-<<<<<<< HEAD
     if session[:organisation_id] && current_user.organisations.pluck(:id).include?(session[:organisation_id].to_i)
-=======
-    if session[:organisation_id] && current_user.organisations.pluck(:id).include?(session[:organisation_id])
->>>>>>> Allow creating Cross Organisation invitations
       Organisation.find(session[:organisation_id])
     else
       current_user.organisations.first

--- a/app/controllers/users/cross_organisation_confirmations_controller.rb
+++ b/app/controllers/users/cross_organisation_confirmations_controller.rb
@@ -1,0 +1,8 @@
+class Users::CrossOrganisationConfirmationsController < ApplicationController
+  def create
+    invitation = current_user.cross_organisation_invitations.find_by(invitation_token: params.fetch(:token))
+    invitation.confirm!
+
+    redirect_to root_path, notice: "You have successfully joined #{invitation.organisation.name}"
+  end
+end

--- a/app/models/cross_organisation_invitation.rb
+++ b/app/models/cross_organisation_invitation.rb
@@ -1,4 +1,10 @@
 class CrossOrganisationInvitation < ApplicationRecord
   belongs_to :organisation
   belongs_to :user
+
+  def confirm!
+    user.organisations << organisation
+
+    touch :confirmed_at
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
     get 'removed/location', to: 'ips#index', on: :collection
   end
 
-  get 'confirm_cross_organisation_invitations' , to: 'users/cross_organisation_confirmations#create'
+  get 'confirm_cross_organisation_invitations', to: 'users/cross_organisation_confirmations#create'
 
   resources :help, only: %i[create new] do
     get '/', on: :collection, to: 'help#new'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,9 @@ Rails.application.routes.draw do
     get 'removed', to: 'ips#index', on: :collection
     get 'removed/location', to: 'ips#index', on: :collection
   end
+
+  get 'confirm_cross_organisation_invitations' , to: 'users/cross_organisation_confirmations#create'
+
   resources :help, only: %i[create new] do
     get '/', on: :collection, to: 'help#new'
     get 'signed_in', on: :new

--- a/db/migrate/20190514101700_add_confirmed_at_to_cross_organisation_invitations.rb
+++ b/db/migrate/20190514101700_add_confirmed_at_to_cross_organisation_invitations.rb
@@ -1,0 +1,5 @@
+class AddConfirmedAtToCrossOrganisationInvitations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :cross_organisation_invitations, :confirmed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_13_111153) do
+ActiveRecord::Schema.define(version: 2019_05_14_101700) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2019_05_13_111153) do
     t.string "invitation_token", null: false
     t.bigint "user_id", null: false
     t.integer "invited_by_id", null: false
+    t.datetime "confirmed_at"
     t.index ["organisation_id"], name: "index_cross_organisation_invitations_on_organisation_id"
     t.index ["user_id"], name: "index_cross_organisation_invitations_on_user_id"
   end

--- a/spec/factories/cross_organisation_invitation.rb
+++ b/spec/factories/cross_organisation_invitation.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :cross_organisation_invitation
+end

--- a/spec/features/confirm_cross_organisation_invitation_spec.rb
+++ b/spec/features/confirm_cross_organisation_invitation_spec.rb
@@ -1,0 +1,27 @@
+describe 'Confirming a cross organisation invitation' do
+    let(:organisation) { create(:organisation) }
+    let(:user) { create(:user, organisations: [organisation]) }
+    let(:invited_user) { create(:user, :with_organisation) }
+    let(:token) { 'abc123' }
+
+  context 'with an existing user' do
+    before do
+      create(:cross_organisation_invitation,
+             user: invited_user,
+             invited_by_id: user.id,
+             organisation: organisation,
+             invitation_token: token)
+
+      sign_in_user invited_user
+      visit confirm_cross_organisation_invitations_path(token: token)
+    end
+
+    it 'Confirms the invitation' do
+      expect(invited_user.organisations).to include(organisation)
+    end
+
+    it 'prints a success message' do
+      expect(page).to have_content("You have successfully joined #{organisation.name}")
+    end
+  end
+end

--- a/spec/features/confirm_cross_organisation_invitation_spec.rb
+++ b/spec/features/confirm_cross_organisation_invitation_spec.rb
@@ -1,8 +1,8 @@
-describe 'Confirming a cross organisation invitation' do
-    let(:organisation) { create(:organisation) }
-    let(:user) { create(:user, organisations: [organisation]) }
-    let(:invited_user) { create(:user, :with_organisation) }
-    let(:token) { 'abc123' }
+describe 'Confirming a cross organisation invitation', type: :feature do
+  let(:organisation) { create(:organisation) }
+  let(:user) { create(:user, organisations: [organisation]) }
+  let(:invited_user) { create(:user, :with_organisation) }
+  let(:token) { 'abc123' }
 
   context 'with an existing user' do
     before do

--- a/spec/models/cross_organisation_invitation_spec.rb
+++ b/spec/models/cross_organisation_invitation_spec.rb
@@ -24,7 +24,7 @@ describe CrossOrganisationInvitation do
     end
 
     it 'confirms the invitation' do
-      expect(invitation.confirmed_at).to_not be_nil
+      expect(invitation.confirmed_at).not_to be_nil
     end
   end
 end

--- a/spec/models/cross_organisation_invitation_spec.rb
+++ b/spec/models/cross_organisation_invitation_spec.rb
@@ -1,4 +1,30 @@
 describe CrossOrganisationInvitation do
   it { is_expected.to belong_to(:organisation) }
   it { is_expected.to belong_to(:user) }
+
+  describe '.confirm!' do
+    let(:inviter) { create(:user) }
+    let(:user) { create(:user) }
+    let(:organisation) { create(:organisation) }
+
+    let(:invitation) do
+      create(:cross_organisation_invitation,
+             user: user,
+             organisation: organisation,
+             invitation_token: 'some_token',
+             invited_by_id: inviter.id)
+    end
+
+    before do
+      invitation.confirm!
+    end
+
+    it 'converts the invitation to an organisation' do
+      expect(user.organisations).to eq([organisation])
+    end
+
+    it 'confirms the invitation' do
+      expect(invitation.confirmed_at).to_not be_nil
+    end
+  end
 end


### PR DESCRIPTION
Allow confirming cross organisation invitations

This endpoint will join the invited user to the invitee's organisation.
Some more edgecase testing required, like dealing with duplicates and
token not found.
