### PR TITLE
Remove UUID column from the organisations table

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -8,8 +8,6 @@ class Organisation < ApplicationRecord
   validates :service_email, format: { with: Devise.email_regexp, message: "must be a valid email address" }
   validate :validate_in_register?, unless: Proc.new { |org| org.name.blank? }
 
-  before_create :set_uuid
-
   def validate_in_register?
     unless Organisation.fetch_organisations_from_register.include?(name)
       errors.add(:base, "#{name} isn't a whitelisted organisation")
@@ -20,11 +18,5 @@ class Organisation < ApplicationRecord
     UseCases::Organisation::FetchOrganisationRegister.new(
       organisations_gateway: Gateways::GovukOrganisationsRegisterGateway.new
     ).execute.sort
-  end
-
-  def set_uuid
-    return if uuid.present?
-
-    self.uuid = SecureRandom.uuid
   end
 end

--- a/db/migrate/20190514130843_remove_uuid_column.rb
+++ b/db/migrate/20190514130843_remove_uuid_column.rb
@@ -1,0 +1,5 @@
+class RemoveUuidColumn < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :organisations, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_14_101700) do
+ActiveRecord::Schema.define(version: 2019_05_14_130843) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -87,8 +87,6 @@ ActiveRecord::Schema.define(version: 2019_05_14_101700) do
     t.datetime "updated_at", null: false
     t.string "service_email"
     t.boolean "super_admin", default: false
-    t.string "uuid", limit: 36, null: false
-    t.index ["uuid"], name: "index_organisations_on_uuid", unique: true
   end
 
   create_table "organisations_users", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -94,24 +94,4 @@ describe Organisation do
       ])
     end
   end
-
-  context 'when an organisation does not have a uuid' do
-    let(:organisation) { described_class.new(name: 'Gov Org 1', service_email: 'foo@bar.com') }
-
-    before { organisation.save! }
-
-    it 'generates a new one' do
-      expect(organisation.uuid).to be_present
-    end
-  end
-
-  context 'when an organisation has a uuid' do
-    let(:organisation) { described_class.new(uuid: 'abcde', name: 'Gov Org 1', service_email: 'foo@bar.com') }
-
-    before { organisation.save! }
-
-    it 'does not generate a new one' do
-      expect(organisation.uuid).to eq('abcde')
-    end
-  end
 end


### PR DESCRIPTION
This PR removes the unused UUID column from the organisations table