### PR TITLE
Fix duplicate organisations when switching to another organisation

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -5,8 +5,6 @@ class Membership < ApplicationRecord
   scope :pending, -> { where(confirmed_at: nil) }
 
   def confirm!
-    user.organisations << organisation
-
     touch :confirmed_at
   end
 end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -23,6 +23,10 @@ describe Membership do
       expect(user.organisations.first).to eq(organisation)
     end
 
+    it 'will only have one organisation' do
+      expect(user.organisations.length).to eq(1)
+    end
+
     it 'confirms the invitation' do
       expect(invitation.confirmed_at).not_to be_nil
     end


### PR DESCRIPTION
This PR fixes the issue when a user switches organisations and sees two of the same organisations