### PR TITLE
Improve no traffic message

### DIFF
--- a/app/models/ip.rb
+++ b/app/models/ip.rb
@@ -7,7 +7,7 @@ class Ip < ApplicationRecord
   def inactive?
     Session
       .where(siteIP: self.address)
-      .where("start > #{Date.today - 10.days}")
+      .where("start > ?", Date.today - 10.days)
       .limit(1)
       .empty?
   end

--- a/app/models/ip.rb
+++ b/app/models/ip.rb
@@ -16,6 +16,13 @@ class Ip < ApplicationRecord
     created_at < Date.today.beginning_of_day
   end
 
+  def unused?
+    Session
+      .where(siteIP: self.address)
+      .limit(1)
+      .empty?
+  end
+
 private
 
   def address_must_be_valid_ip

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -34,8 +34,10 @@
           </td>
         <% end %>
         <td class="govuk-table__cell govuk-!-width-one-quarter text-red">
-          <% if ip.inactive? %>
-            Inactive (no traffic for the last 10 days)
+          <% if ip.unused? %>
+            No traffic received yet
+          <% elsif ip.inactive? %>
+            No traffic for the last 10 days
           <% end %>
         </td>
         <td class="govuk-table__cell text-right">

--- a/spec/models/ip_spec.rb
+++ b/spec/models/ip_spec.rb
@@ -104,4 +104,18 @@ describe Ip do
       it { is_expected.not_to be_inactive }
     end
   end
+
+  context 'when checking if unused' do
+    context 'with an IP which has activity' do
+      before do
+        create(:session, start: Date.today, username: 'abc123', siteIP: ip_address.address)
+      end
+
+      it { is_expected.not_to be_unused }
+    end
+
+    context 'with an IP which has no activity' do
+      it { is_expected.to be_unused }
+    end
+  end
 end

--- a/spec/models/ip_spec.rb
+++ b/spec/models/ip_spec.rb
@@ -93,6 +93,10 @@ describe Ip do
 
   context 'when checking if inactive' do
     context 'with no sessions for the last 10 days' do
+      before do
+        create(:session, start: Date.today - 11.days, username: 'abc123', siteIP: ip_address.address)
+      end
+
       it { is_expected.to be_inactive }
     end
 


### PR DESCRIPTION
https://trello.com/c/axmPZhV7/12-2-improve-the-no-traffic-for-last-10-days-message

- Adds _No traffic received yet_ message for unused Ip records
- Fixes issue with `Ip#inactive?` date comparison
- Rewords _Inactive (no traffic for the last 10 days)_ to _No traffic for the last 10 days_

---

#### No traffic received yet...

![Screenshot from 2019-05-29 10-08-38](https://user-images.githubusercontent.com/93511/58544750-d1e81b00-81f9-11e9-89d7-4d2c1bdecc95.png)

---

#### No traffic for the last 10 days...

![Screenshot from 2019-05-29 10-20-42](https://user-images.githubusercontent.com/93511/58545574-73bc3780-81fb-11e9-8c7a-5b0eebebfc89.png)
