### PR TITLE
Remove the membership association between org and user

### DIFF
--- a/app/controllers/team_members_controller.rb
+++ b/app/controllers/team_members_controller.rb
@@ -8,10 +8,10 @@ class TeamMembersController < ApplicationController
   end
 
   def destroy
-    user = current_organisation.users.find_by(id: params.fetch(:id))
-    redirect_to team_members_path && return unless user
+    membership = current_organisation.memberships.find_by(user_id: params.fetch(:id))
+    redirect_to team_members_path && return unless membership
 
-    user.destroy
+    membership.destroy
     redirect_to removed_team_members_path, notice: "Team member has been removed"
   end
 

--- a/spec/features/team/remove_a_team_member_spec.rb
+++ b/spec/features/team/remove_a_team_member_spec.rb
@@ -20,8 +20,8 @@ describe "Remove a team member", type: :feature do
       expect(page).not_to have_content("Remove user from service")
     end
 
-    it "deletes the user" do
-      expect { click_on "Yes, remove this team member" }.to change(User, :count).by(-1)
+    it "deletes the membership" do
+      expect { click_on "Yes, remove this team member" }.to change(Membership, :count).by(-1)
     end
 
     it 'redirects to "after user removed" team members page for analytics' do

--- a/spec/requests/team_members/delete_spec.rb
+++ b/spec/requests/team_members/delete_spec.rb
@@ -8,10 +8,10 @@ describe "DELETE /team_members/:id", type: :request do
   end
 
   context "when the user has permissions to delete a team member" do
-    it "deletes the team member" do
+    it "deletes the team membership" do
       expect {
         delete team_member_path(team_member)
-      }.to change(User, :count).by(-1)
+      }.to change(Membership, :count).by(-1)
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/ztLrtJEj/26-when-removing-a-user-from-a-team-only-delete-membership

The 'through' association between and `Organisation` and a `User` is `Membership`.
Operations to disassociate users from organisations (ie removing a team member)
will now remove the relevant `Membership` record.