### PR TITLE
Remove dependent organisation memberships

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,6 +1,6 @@
 class Organisation < ApplicationRecord
   has_one_attached :signed_mou
-  has_many :memberships, inverse_of: :organisation
+  has_many :memberships, inverse_of: :organisation, dependent: :destroy
   has_many :users, through: :memberships, inverse_of: :organisations
   has_many :locations, dependent: :destroy
   has_many :ips, through: :locations

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -17,6 +17,10 @@ describe Organisation do
     it 'removes all associated ip addresses' do
       expect { ip.reload }.to raise_error ActiveRecord::RecordNotFound
     end
+
+    it 'removes all associated memberships' do
+      expect(Membership.find_by(organisation_id: org.id)).to be_nil
+    end
   end
 
   context 'when name already exists' do


### PR DESCRIPTION
https://trello.com/c/Ds40Fd3O/27-when-deleting-an-organisation-also-delete-all-memberships

When an `Organisation` is removed the associated `Membership` record
will also be destroyed. The `User` record will be left intact.