### PR TITLE
Redirect users without memberships to orgs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!, except: :error
   before_action :configure_devise_permitted_parameters, if: :devise_controller?
-  before_action :ensure_user_belongs_to_organisation, unless: :current_action_is_valid?
+  before_action :redirect_user_with_no_organisation, unless: :current_action_is_valid?
 
   helper_method :current_organisation, :super_admin?
 
@@ -33,23 +33,18 @@ protected
     devise_parameter_sanitizer.permit(:accept_invitation, keys: [:name])
   end
 
-  def ensure_user_belongs_to_organisation
-    if current_user && current_user.organisations.empty?
-      message = 'Please select your organisation'
-
-      redirect_to new_organisation_path, notice: message
+  def redirect_user_with_no_organisation
+    if current_user&.organisations&.empty?
+      msg = "You do not belong to an organisation. Please mention this in your support request."
+      redirect_to signed_in_new_help_path, notice: msg
     end
   end
 
   def current_action_is_valid?
-    valid_actions_for_orphaned_user.fetch(controller_name, []).include?(action_name)
+    controller_name == 'help' && valid_help_actions.include?(action_name)
   end
 
-  def valid_actions_for_orphaned_user
-    @valid_actions_for_orphaned_user ||= {
-      'current_organisation' => %w(edit),
-      'organisations' => %w(new create),
-      'help' => %w(new create technical_support user_support admin_account)
-    }.freeze
+  def valid_help_actions
+    @valid_help_actions ||= %w(signed_in create).freeze
   end
 end

--- a/app/views/application/_subnavigation.html.erb
+++ b/app/views/application/_subnavigation.html.erb
@@ -1,7 +1,7 @@
 <div class='govuk-grid-row subnav govuk-!-margin-0'>
   <div class='govuk-grid-column-one-third govuk-grid-column-one-half-from-desktop govuk-!-padding-left-0 organisation-name'>
     <p class='govuk-body govuk-!-margin-0 govuk-!-padding-0'>
-      <strong class="govuk-!-margin-right-1"><%= current_organisation.name %></strong>
+      <strong class="govuk-!-margin-right-1"><%= current_organisation.name if current_organisation %></strong>
       <%= link_to 'switch', change_organisation_path, class: "govuk-link govuk-body-s" %>
     </p>
   </div>
@@ -16,7 +16,7 @@
         <%= link_to 'Logs', new_logs_search_path, class: active_tab('logs') %>
       <% else %>
         <%= link_to 'Overview', overview_index_path, class: active_tab(overview_index_path) %>
-        <% if current_organisation.ips.empty? %>
+        <% if current_organisation&.ips&.empty? %>
           <%= link_to 'Setup', new_organisation_setup_instructions_path, class: active_tab(new_organisation_setup_instructions_path) + active_tab('mou') %>
         <% else %>
           <%= link_to 'Setup', setup_instructions_path, class: active_tab(setup_instructions_path) + active_tab('mou') %>

--- a/app/views/help/signed_in.html.erb
+++ b/app/views/help/signed_in.html.erb
@@ -11,7 +11,7 @@
       <li>
         Direct them to <%= link_to 'our guidance on common issues', SITE_CONFIG['end_user_troubleshooting_link'], class: "govuk-link" %>.
       </li>
-      <% unless current_organisation.locations.empty? %>
+      <% unless current_organisation&.locations&.empty? %>
         <li>
           <%= link_to 'Search our logs', username_new_logs_search_path, class: "govuk-link" %> to confirm they are reaching our service
         </li>
@@ -32,7 +32,7 @@
       <li>
         Check your <%= link_to 'IPs and RADIUS secret keys', ips_path, class: "govuk-link" %> match your local configuration
       </li>
-      <% unless current_organisation.locations.empty? %>
+      <% unless current_organisation&.locations&.empty? %>
         <li>
           <%= link_to 'Search our logs', location_new_logs_search_path, class: "govuk-link" %> to confirm traffic from you is reaching our service
         </li>

--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -4,7 +4,7 @@
   <script>
     window.dataLayer = [{
       'signedIn': '<%= user_signed_in?.to_json %>',
-      'hasIPs': '<%= (!!current_user && current_organisation.ips.any?).to_json %>'
+      'hasIPs': '<%= (!!current_user && current_organisation&.ips&.any?).to_json %>'
     }];
   </script>
 

--- a/spec/features/user_with_no_organisation_memberships_spec.rb
+++ b/spec/features/user_with_no_organisation_memberships_spec.rb
@@ -7,21 +7,32 @@ describe 'A confirmed user with no organisation memberships logs in', type: :fea
       visit root_path
     end
 
-    it 'redirects to the change organisation path' do
-      expect(current_path).to eq(new_organisation_path)
+    it 'redirects to the help path' do
+      expect(page).to have_current_path(signed_in_new_help_path)
     end
 
     it 'prints an instruction' do
-      expect(page).to have_content("Please select your organisation")
+      expect(page).to have_content("You do not belong to an organisation")
     end
 
-    context 'when the user opts to contact support' do
+    context 'when the user selects a specific type of support' do
+      let(:zendesk_client) { instance_double(Gateways::ZendeskSupportTickets) }
+
       before do
-        visit technical_support_new_help_path
+        allow(Gateways::ZendeskSupportTickets).to receive(:new)
+          .and_return(zendesk_client)
+        allow(zendesk_client).to receive(:create)
       end
 
-      it 'presents the user with a support form' do
-        expect(page).to have_content("Network administrator technical support")
+      it 'presents the user with a support request form' do
+        expect(page).to have_content('Get support')
+      end
+
+      it 'allows the user to submit a support request' do
+        fill_in 'Tell us about your issue', with: 'Help!'
+        click_on 'Send support request'
+
+        expect(page).to have_http_status(200)
       end
     end
   end

--- a/spec/features/user_with_no_organisation_memberships_spec.rb
+++ b/spec/features/user_with_no_organisation_memberships_spec.rb
@@ -1,0 +1,28 @@
+describe 'A confirmed user with no organisation memberships logs in', type: :feature do
+  let(:user) { create(:user, organisations: []) }
+
+  context 'with an existing confirmed user' do
+    before do
+      sign_in_user user
+      visit root_path
+    end
+
+    it 'redirects to the change organisation path' do
+      expect(current_path).to eq(new_organisation_path)
+    end
+
+    it 'prints an instruction' do
+      expect(page).to have_content("Please select your organisation")
+    end
+
+    context 'when the user opts to contact support' do
+      before do
+        visit technical_support_new_help_path
+      end
+
+      it 'presents the user with a support form' do
+        expect(page).to have_content("Network administrator technical support")
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/0g3MYHja/28-allow-a-orphaned-user-to-login

![Screenshot from 2019-06-06 09-15-41](https://user-images.githubusercontent.com/93511/59017566-bacdac80-883b-11e9-9475-28a431a30e12.png)


When a user is no longer associated with any organisation (this is possible if an admin deletes a user's only org) we need to ensure that, once authenticated, they associate themselves with an organisation.
This PR makes sure the orphaned user is redirected to the support form with an additional explanation of why they are there.