### PR TITLE
Fix duplicate email sent on first invite

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -31,17 +31,19 @@ private
   def add_user_to_organisation(organisation)
     membership = invited_user.memberships.find_or_create_by(invited_by_id: current_user.id, organisation: organisation)
     membership.update_attributes(can_manage_team: params[:can_manage_team], can_manage_locations: params[:can_manage_locations])
-    send_membership_invite_to_confirmed_users_only(membership)
+    send_invite_email(membership) if user_has_confirmed_account?
   end
 
-  def send_membership_invite_to_confirmed_users_only(membership)
-    if invited_user.confirmed?
-      AuthenticationMailer.membership_instructions(
-        invited_user,
-        membership.invitation_token,
-        organisation: current_organisation
-      ).deliver_now
-    end
+  def send_invite_email(membership)
+    AuthenticationMailer.membership_instructions(
+      invited_user,
+      membership.invitation_token,
+      organisation: current_organisation
+    ).deliver_now
+  end
+
+  def user_has_confirmed_account?
+    invited_user.confirmed?
   end
 
   def after_path(organisation)

--- a/spec/features/memberships/invite_user_to_their_first_organisation_spec.rb
+++ b/spec/features/memberships/invite_user_to_their_first_organisation_spec.rb
@@ -29,14 +29,15 @@ describe "Inviting a user to their first organisation", type: :feature do
     end
 
     context 'when the invited user accepts the invitation' do
-      let(:user) { User.find_by(email: invitee_email) }
-
       before do
-        membership = user.membership_for(organisation)
         visit InviteUseCaseSpy.last_invite_url
         fill_in "Your name", with: "Invitee"
         fill_in "Password", with: "password"
         click_on "Create my account"
+      end
+
+      it 'confirms the user' do
+        expect(User.find_by(email: invitee_email)).to be_confirmed
       end
 
       it 'allows the user to sign in successfully' do

--- a/spec/features/memberships/invite_user_to_their_first_organisation_spec.rb
+++ b/spec/features/memberships/invite_user_to_their_first_organisation_spec.rb
@@ -1,0 +1,47 @@
+require 'support/invite_use_case'
+require 'support/notifications_service'
+require 'support/membership_invite_use_case'
+
+describe "Inviting a user to their first organisation", type: :feature do
+  let(:organisation) { create(:organisation) }
+  let(:invitor) { create(:user, organisations: [organisation]) }
+
+  context 'when the user does not exist yet' do
+    let(:invitee_email) { 'newuser@gov.uk' }
+
+    include_context 'when using the notifications service'
+    include_context 'when sending a membership invite email'
+    include_context 'when sending an invite email'
+
+    before do
+      sign_in_user invitor
+      visit new_user_invitation_path
+      fill_in 'Email', with: invitee_email
+      click_on 'Send invitation email'
+    end
+
+    it 'sends a invitation to confirm the users account' do
+      expect(InviteUseCaseSpy.invite_count).to eq(1)
+    end
+
+    it 'does not send an additional membership invitation' do
+      expect(MembershipInviteUseCaseSpy.invite_count).to eq(0)
+    end
+
+    context 'when the invited user accepts the invitation' do
+      let(:user) { User.find_by(email: invitee_email) }
+
+      before do
+        membership = user.membership_for(organisation)
+        visit confirm_new_membership_path(token: membership.invitation_token)
+        fill_in "name", with: "Invitee"
+        fill_in "password", with: "password"
+        click_on "Save"
+      end
+
+      it 'allows the user to sign in successfully' do
+        expect(page).to have_content 'Sign out'
+      end
+    end
+  end
+end

--- a/spec/features/memberships/invite_user_to_their_first_organisation_spec.rb
+++ b/spec/features/memberships/invite_user_to_their_first_organisation_spec.rb
@@ -33,10 +33,10 @@ describe "Inviting a user to their first organisation", type: :feature do
 
       before do
         membership = user.membership_for(organisation)
-        visit confirm_new_membership_path(token: membership.invitation_token)
-        fill_in "name", with: "Invitee"
-        fill_in "password", with: "password"
-        click_on "Save"
+        visit InviteUseCaseSpy.last_invite_url
+        fill_in "Your name", with: "Invitee"
+        fill_in "Password", with: "password"
+        click_on "Create my account"
       end
 
       it 'allows the user to sign in successfully' do


### PR DESCRIPTION
Fixes the issue where a new user was receiving both an invitation email based on them being a new user and a membership invitation email based on them being invited to an organisation.

Eventually it would be nice to only have one way of being invited to an organisation. Currently you can either be invited via the `User` (devise, for new users) or via the `Membership` (ours, for existing users). But that can be another PR 