### PR TITLE
Ensure a membership is confirmed for a new user

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,6 +1,7 @@
 class Users::InvitationsController < Devise::InvitationsController
   before_action :set_target_organisation, if: :super_admin?, only: %i(create new)
   before_action :delete_user_record, if: :user_should_be_cleared?, only: :create
+  after_action :confirm_new_user_membership, only: :update
 
   def create
     if user_is_invalid?
@@ -98,6 +99,10 @@ private
 
   def invited_user_has_no_org?
     invited_user.organisations.empty?
+  end
+
+  def confirm_new_user_membership
+    current_user.memberships.first.confirm!
   end
 
   # Overrides https://github.com/scambra/devise_invitable/blob/master/app/controllers/devise/invitations_controller.rb#L105

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -12,4 +12,8 @@ class Membership < ApplicationRecord
   def set_invitation_token
     self.invitation_token = Devise.friendly_token[0, 20]
   end
+
+  def confirmed?
+    !!confirmed_at
+  end
 end

--- a/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
+++ b/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
@@ -4,7 +4,8 @@ require 'support/notifications_service'
 
 describe "Sign up from invitation", type: :feature do
   let(:invited_user_email) { "invited@gov.uk" }
-  let(:user) { create(:user, :with_organisation) }
+  let(:organisation) { create(:organisation) }
+  let(:user) { create(:user, organisations: [organisation]) }
 
   include_context 'when sending an invite email'
   include_context 'when using the notifications service'
@@ -36,6 +37,10 @@ describe "Sign up from invitation", type: :feature do
 
       it "confirms the user" do
         expect(invited_user.confirmed?).to eq(true)
+      end
+
+      it "confirms the membership" do
+        expect(invited_user.membership_for(organisation).confirmed?).to eq(true)
       end
 
       it "sets the users name" do

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -1,25 +1,24 @@
 describe Membership do
+  let(:inviter) { create(:user) }
+  let(:user) { create(:user) }
+  let(:organisation) { create(:organisation) }
+  let(:membership) do
+    create(:membership,
+           user: user,
+           organisation: organisation,
+           invitation_token: 'some_token',
+           invited_by_id: inviter.id)
+  end
+
   it { is_expected.to belong_to(:organisation) }
   it { is_expected.to belong_to(:user) }
 
   describe '.confirm!' do
-    let(:inviter) { create(:user) }
-    let(:user) { create(:user) }
-    let(:organisation) { create(:organisation) }
-
-    let(:invitation) do
-      create(:membership,
-             user: user,
-             organisation: organisation,
-             invitation_token: 'some_token',
-             invited_by_id: inviter.id)
-    end
-
     before do
-      invitation.confirm!
+      membership.confirm!
     end
 
-    it 'converts the invitation to an organisation' do
+    it 'converts the membership to an organisation' do
       expect(user.organisations.first).to eq(organisation)
     end
 
@@ -27,8 +26,20 @@ describe Membership do
       expect(user.organisations.length).to eq(1)
     end
 
-    it 'confirms the invitation' do
-      expect(invitation.confirmed_at).not_to be_nil
+    it 'confirms the membership' do
+      expect(membership.confirmed_at).not_to be_nil
+    end
+  end
+
+  describe '.confirmed?' do
+    it 'is unconfirmed' do
+      membership.update(confirmed_at: nil)
+      expect(membership.confirmed?).to eq(false)
+    end
+
+    it 'is confirmed' do
+      membership.update(confirmed_at: Date.today)
+      expect(membership.confirmed?).to eq(true)
     end
   end
 end


### PR DESCRIPTION
When a user confirms their account, we want to confirm the membership as well.
All users have memberships for all the organisations they belong to, so keep
this consistent.