### PR TITLE
Ensure memberships are confirmed when creating organisations

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -47,7 +47,10 @@ private
   end
 
   def assign_user_to_organisation(organisation)
-    current_user.organisations << organisation
+    current_user.memberships.create(
+      organisation: organisation,
+      confirmed_at: Time.zone.now
+    )
   end
 
   def set_as_current_organisation(organisation)

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -9,7 +9,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   def update
     with_unconfirmed_confirmable do
       if @confirmable.update(user_params)
-        confirm_user
+        confirm_user_and_membership
       else
         render_show_page
       end
@@ -49,8 +49,9 @@ protected
     render 'users/confirmations/new'
   end
 
-  def confirm_user
+  def confirm_user_and_membership
     @confirmable.confirm
+    @confirmable.default_membership.confirm!
     set_flash_message :notice, :confirmed
     sign_in_and_redirect(resource_name, @confirmable)
   end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -109,7 +109,7 @@ private
   end
 
   def confirm_new_user_membership
-    current_user.memberships.first.confirm!
+    current_user.default_membership.confirm!
   end
 
   # Overrides https://github.com/scambra/devise_invitable/blob/master/app/controllers/devise/invitations_controller.rb#L105

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,4 +40,8 @@ class User < ApplicationRecord
   def membership_for(organisation)
     memberships.where(organisation: organisation).first
   end
+
+  def default_membership
+    memberships.first
+  end
 end

--- a/spec/features/register_an_additional_organisation_spec.rb
+++ b/spec/features/register_an_additional_organisation_spec.rb
@@ -45,6 +45,24 @@ describe 'Register an additional organisation', type: :feature do
         expect(page).to have_content(organisation_2_name)
       end
     end
+
+    it 'confirms the membership that joins the user to the organisation' do
+      click_on 'Create organisation'
+      organisation = user.organisations.find_by(name: organisation_2_name)
+      expect(user.membership_for(organisation)).to be_confirmed
+    end
+
+    it 'gives the user can_manage_team privileges' do
+      click_on 'Create organisation'
+      organisation = user.organisations.find_by(name: organisation_2_name)
+      expect(user.can_manage_team?(organisation)).to eq(true)
+    end
+
+    it 'gives the user can_manage_locations privileges' do
+      click_on 'Create organisation'
+      organisation = user.organisations.find_by(name: organisation_2_name)
+      expect(user.can_manage_locations?(organisation)).to eq(true)
+    end
   end
 
   context 'when submitting the form with invalid data' do

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -40,8 +40,10 @@ describe 'Sign up as an organisation', type: :feature do
         expect(page).to have_content 'Sign out'
       end
 
-      it 'creates an organisation for the user' do
-        expect(User.last.organisations.first.name).to eq('Gov Org 1')
+      it 'creates a confirmed membership joining the user to the org' do
+        user = User.find_by(email: email)
+        organisation = Organisation.find_by(name: 'Gov Org 1')
+        expect(user.membership_for(organisation)).to be_confirmed
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,4 +14,28 @@ describe User do
       expect(user.pending_membership_for?(organisation: organisation)).to eq(true)
     end
   end
+
+  describe '.default_membership' do
+    context 'with no memberships' do
+      let(:user) { create(:user) }
+
+      it 'returns nil' do
+        expect(user.default_membership).to eq(nil)
+      end
+    end
+
+    context 'with memberships' do
+      let(:organisation_1) { create(:organisation) }
+      let(:organisation_2) { create(:organisation) }
+      let(:user) { create(:user, organisations: [organisation_1]) }
+
+      before do
+        user.organisations << organisation_2
+      end
+
+      it 'returns the first one' do
+        expect(user.default_membership).to eq(user.membership_for(organisation_1))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Memberships need to be confirmed when:
- Creating the first organisation for a new user
- Creating a subsequent organisation for an existing user