### PR TITLE
Redirect to newly joined organisation on confirmation

### DIFF
--- a/app/controllers/users/memberships_controller.rb
+++ b/app/controllers/users/memberships_controller.rb
@@ -3,6 +3,7 @@ class Users::MembershipsController < ApplicationController
     invitation = current_user.memberships.find_by(invitation_token: params.fetch(:token))
     invitation.confirm!
 
+    session[:organisation_id] = invitation.organisation.id
     redirect_to root_path, notice: "You have successfully joined #{invitation.organisation.name}"
   end
 end

--- a/spec/features/invite_user_to_join_organisation_spec.rb
+++ b/spec/features/invite_user_to_join_organisation_spec.rb
@@ -33,7 +33,7 @@ describe 'Inviting an existing user', type: :feature do
       before do
         sign_out
         sign_in_user betty
-        visit confirm_new_membership_url(token: betty.membership_for(inviter_organisation).invitation_token) 
+        visit confirm_new_membership_url(token: betty.membership_for(inviter_organisation).invitation_token)
       end
 
       it "changes your current organisation to this organisation" do

--- a/spec/features/invite_user_to_join_organisation_spec.rb
+++ b/spec/features/invite_user_to_join_organisation_spec.rb
@@ -3,7 +3,8 @@ require 'support/notifications_service'
 require 'support/confirmation_use_case'
 
 describe 'Inviting an existing user', type: :feature do
-  let(:betty) { create(:user, :with_organisation) }
+  let(:inviter_organisation) { create(:organisation) }
+  let(:betty) { create(:user, organisations: [inviter_organisation]) }
   let(:confirmed_user) { create(:user, :with_organisation) }
 
   include_examples 'when sending a membership invite email'
@@ -26,6 +27,20 @@ describe 'Inviting an existing user', type: :feature do
 
     it 'notifies the user with a success message' do
       expect(page).to have_content("#{betty.email} has been invited to join #{confirmed_user.organisations.first.name}")
+    end
+
+    context 'when I confirm the invitation' do
+      before do
+        sign_out
+        sign_in_user betty
+        visit confirm_new_membership_url(token: betty.membership_for(inviter_organisation).invitation_token) 
+      end
+
+      it "changes your current organisation to this organisation" do
+        within('.govuk-header') do
+          expect(page.html).to include(inviter_organisation.name)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
After confirming an invite, it should log me into the organisation that I just joined