### PR TITLE
Hide 'Add team member' button conditional

### DIFF
--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -23,7 +23,9 @@
     <% end %>
 
     <%= render 'section', heading: 'Team' do %>
+    <% if current_user.can_manage_team?(current_organisation)%>
       <%= link_to "Add team member", new_user_invitation_path(organisation_id: @organisation.id), class: "govuk-button" %>
+    <% end %>
       <%= render 'team', team: @team %>
     <% end %>
 

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -23,9 +23,9 @@
     <% end %>
 
     <%= render 'section', heading: 'Team' do %>
-    <% if current_user.can_manage_team?(current_organisation)%>
-      <%= link_to "Add team member", new_user_invitation_path(organisation_id: @organisation.id), class: "govuk-button" %>
-    <% end %>
+      <% if current_user.can_manage_team?(current_organisation) %>
+        <%= link_to "Add team member", new_user_invitation_path(organisation_id: @organisation.id), class: "govuk-button" %>
+      <% end %>
       <%= render 'team', team: @team %>
     <% end %>
 

--- a/spec/features/invite_user_to_join_organisation_spec.rb
+++ b/spec/features/invite_user_to_join_organisation_spec.rb
@@ -2,7 +2,7 @@ require 'support/membership_invite_use_case'
 require 'support/notifications_service'
 require 'support/confirmation_use_case'
 
-describe 'Inviting an existing user', type: :feature, focus: true do
+describe 'Inviting an existing user', type: :feature do
   let(:inviter_organisation) { create(:organisation) }
   let(:betty) { create(:user, organisations: [inviter_organisation]) }
   let(:confirmed_user) { create(:user, :with_organisation) }
@@ -45,16 +45,16 @@ describe 'Inviting an existing user', type: :feature, focus: true do
   end
 
   context 'when a super admin does not have can_manage_team permissions' do
-    let(:admin_without_permission) { create(:user, :super_admin) }
+    let(:super_admin_without_permission) { create(:user, :super_admin) }
 
     before do
-      admin_without_permission.memberships.update(can_manage_team: false)
-      sign_in_user admin_without_permission
+      super_admin_without_permission.memberships.update(can_manage_team: false)
+      sign_in_user super_admin_without_permission
       visit admin_organisation_path(inviter_organisation)
     end
 
     it 'will not show the add team member button' do
-      expect(page).to_not have_content("Add team member")
+      expect(page).not_to have_content("Add team member")
     end
   end
 end

--- a/spec/features/invite_user_to_join_organisation_spec.rb
+++ b/spec/features/invite_user_to_join_organisation_spec.rb
@@ -2,7 +2,7 @@ require 'support/membership_invite_use_case'
 require 'support/notifications_service'
 require 'support/confirmation_use_case'
 
-describe 'Inviting an existing user', type: :feature do
+describe 'Inviting an existing user', type: :feature, focus: true do
   let(:inviter_organisation) { create(:organisation) }
   let(:betty) { create(:user, organisations: [inviter_organisation]) }
   let(:confirmed_user) { create(:user, :with_organisation) }
@@ -41,6 +41,20 @@ describe 'Inviting an existing user', type: :feature do
           expect(page.html).to include(inviter_organisation.name)
         end
       end
+    end
+  end
+
+  context 'when a super admin does not have can_manage_team permissions' do
+    let(:admin_without_permission) { create(:user, :super_admin) }
+
+    before do
+      admin_without_permission.memberships.update(can_manage_team: false)
+      sign_in_user admin_without_permission
+      visit admin_organisation_path(inviter_organisation)
+    end
+
+    it 'will not show the add team member button' do
+      expect(page).to_not have_content("Add team member")
     end
   end
 end


### PR DESCRIPTION
This PR hides the 'Add team member' button if a super admin does not have the `can_manage_team` permission.