### PR TITLE
Lookup user contact details from username

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,11 @@ ENV \
   RR_DB_USER=root \
   RR_DB_PASS=root \
   RR_DB_HOST=rr_db \
-  RR_DB_NAME=rr_govwifi
+  RR_DB_NAME=rr_govwifi \
+  USER_DB_USER=root \
+  USER_DB_PASS=root \
+  USER_DB_HOST=wifi_user_db \
+  USER_DB_NAME=wifi_user_govwifi
 
 WORKDIR /usr/src/app
 

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,10 @@ prebuild:
 	$(DOCKER_COMPOSE) up --no-start
 
 serve: stop build
-	$(DOCKER_COMPOSE) up -d govuk-fake-registers db rr_db
+	$(DOCKER_COMPOSE) up -d govuk-fake-registers db rr_db wifi_user_db
 	./mysql/bin/wait_for_mysql
 	./mysql/bin/wait_for_rr_db
+	./mysql_user/bin/wait_for_wifi_user_db
 	$(DOCKER_COMPOSE) run --rm app ./bin/rails db:create db:schema:load db:seed
 	$(DOCKER_COMPOSE) up -d app
 
@@ -46,9 +47,10 @@ autocorrect-erb: build
 	$(DOCKER_COMPOSE) run --rm app bundle exec erblint --lint-all --autocorrect
 
 test: stop build
-	$(DOCKER_COMPOSE) up -d db rr_db
+	$(DOCKER_COMPOSE) up -d db rr_db wifi_user_db
 	./mysql/bin/wait_for_mysql
 	./mysql/bin/wait_for_rr_db
+	./mysql_user/bin/wait_for_wifi_user_db
 	$(DOCKER_COMPOSE) run -e RACK_ENV=test --rm app ./bin/rails db:create db:schema:load db:migrate
 	$(DOCKER_COMPOSE) run --rm app bundle exec rspec
 

--- a/app/controllers/admin/wifi_user_search_controller.rb
+++ b/app/controllers/admin/wifi_user_search_controller.rb
@@ -1,0 +1,17 @@
+class Admin::WifiUserSearchController < AdminController
+  def search
+    if search_term.blank?
+      flash.now[:alert] = "Search term can't be blank"
+    else
+      @wifi_user = WifiUser.search(search_term.gsub(' ', ''))
+    end
+
+    render action: 'lookup'
+  end
+
+private
+
+  def search_term
+    params[:search_term]
+  end
+end

--- a/app/models/wifi_user.rb
+++ b/app/models/wifi_user.rb
@@ -1,0 +1,10 @@
+class WifiUser < ApplicationRecord
+  establish_connection WIFI_USER_DB
+  self.table_name = "userdetails"
+
+  def self.search(search_term)
+    search_attr = search_term =~ /^[a-z]{5,6}$/i ? :username : :contact
+
+    find_by(search_attr => search_term)
+  end
+end

--- a/app/views/admin/wifi_user_search/lookup.html.erb
+++ b/app/views/admin/wifi_user_search/lookup.html.erb
@@ -1,0 +1,29 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: admin_wifi_user_search_path do |f| %>
+      <p>
+        <%= f.label :search_term, 'Username or contact details', class: 'govuk-label', for: :search_term %>
+        <%= f.text_field :search_term, class: 'govuk-input govuk-input--width-50' %>
+      </p>
+      <p>
+        <%= f.submit 'Find user details', class: 'govuk-button' %>
+      </p>
+    <% end %>
+
+    <div class="govuk-body">
+      <% if @wifi_user %>
+        <h3>User details for '<%= params[:search_term] %>'</h3>
+        <p>
+          Username: <%= link_to @wifi_user.username,
+                        logs_path(username: @wifi_user.username),
+                        title: "Search logs for '#{@wifi_user.username}'" %>
+        </p>
+        <p>
+          Contact: <%= @wifi_user.contact %>
+        </p>
+      <% elsif !params[:search_term].blank? %>
+        <h3>Nothing found for '<%= params[:search_term] %>'</h3>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/database.yml
+++ b/config/database.yml
@@ -30,3 +30,12 @@ read_replica:
   username: <%= ENV.fetch('RR_DB_USER') %>
   password: <%= ENV.fetch('RR_DB_PASS') %>
   database: <%= ENV.fetch('RR_DB_NAME') %>
+
+wifi_user:
+  adapter: mysql2
+  encoding: utf8
+  host: <%= ENV.fetch('USER_DB_HOST') %>
+  port: 3306
+  username: <%= ENV.fetch('USER_DB_USER') %>
+  password: <%= ENV.fetch('USER_DB_PASS') %>
+  database: <%= ENV.fetch('USER_DB_NAME') %>

--- a/config/initializers/wifi_user_database.rb
+++ b/config/initializers/wifi_user_database.rb
@@ -1,0 +1,4 @@
+config = File.read(File.join(Rails.root, 'config', 'database.yml'))
+# rubocop:disable Security/YAMLLoad
+WIFI_USER_DB = YAML.load(ERB.new(config).result).fetch('wifi_user')
+# rubocop:enable Security/YAMLLoad

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,9 @@ Rails.application.routes.draw do
         resources :organisation_names, only: %i[index create destroy]
       end
     end
+
+    post 'wifi_user_search', to: 'wifi_user_search#search'
+    get 'wifi_user_search', to: 'wifi_user_search#lookup'
   end
 
   %w(404 422 500).each do |code|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,15 @@ services:
     expose:
       - "3306"
 
+  wifi_user_db:
+    build: ./mysql_user
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: root
+      MYSQL_DATABASE: wifi_user_govwifi
+    expose:
+      - "3306"
+
   govuk-fake-registers:
     build:
       context: govuk_fake_register
@@ -32,6 +41,7 @@ services:
     links:
       - db
       - rr_db
+      - wifi_user_db
     expose:
     - "3000"
     depends_on:

--- a/mysql_user/Dockerfile
+++ b/mysql_user/Dockerfile
@@ -1,0 +1,3 @@
+FROM mysql:5.7
+
+ADD wifi_user_schema.sql /docker-entrypoint-initdb.d

--- a/mysql_user/bin/wait_for_mysql
+++ b/mysql_user/bin/wait_for_mysql
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# The Jenkins runner doesn't support TTY sessions meaning docker-compose exec commands
+# failed to execute properly and would hang the CI
+# https://github.com/docker/compose/issues/5696
+until docker-compose exec -T db mysql -hdb -uroot -proot -e 'SELECT 1' &> /dev/null
+do
+  printf "."
+  sleep 1
+done

--- a/mysql_user/bin/wait_for_wifi_user_db
+++ b/mysql_user/bin/wait_for_wifi_user_db
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "waiting for wifi_user_db"
+until docker-compose exec -T rr_db mysql -hwifi_user_db -uroot -proot -e 'SELECT 1' &> /dev/null
+do
+  printf "."
+  sleep 1
+done

--- a/mysql_user/wifi_user_schema.sql
+++ b/mysql_user/wifi_user_schema.sql
@@ -1,0 +1,40 @@
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+DROP TABLE IF EXISTS `userdetails`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `userdetails` (
+  `username` varchar(10) NOT NULL DEFAULT '',
+  `contact` varchar(100) DEFAULT NULL,
+  `sponsor` varchar(100) DEFAULT NULL,
+  `password` varchar(64) DEFAULT NULL,
+  `email` varchar(100) DEFAULT NULL,
+  `mobile` varchar(20) DEFAULT NULL,
+  `notifications_opt_out` tinyint(1) NOT NULL DEFAULT '0',
+  `survey_opt_out` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `last_login` datetime DEFAULT NULL,
+  PRIMARY KEY (`username`),
+  KEY `userdetails_created_at` (`created_at`),
+  KEY `userdetails_contact` (`contact`),
+  KEY `userdetails_last_login` (`last_login`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;

--- a/spec/factories/wifi_users.rb
+++ b/spec/factories/wifi_users.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :wifi_user do
+    sequence :contact do |n|
+      "test#{n}@gov.uk"
+    end
+
+    username { ('a'..'z').to_a.sample(6).join }
+
+    trait :phone_contact do
+      sequence :contact do |n|
+        "+44#{Array.new(10, n)}"
+      end
+    end
+  end
+end

--- a/spec/features/super_admin/lookup_wifi_user_contact_details_spec.rb
+++ b/spec/features/super_admin/lookup_wifi_user_contact_details_spec.rb
@@ -1,0 +1,60 @@
+describe 'Lookup wifi user contact details', type: :feature do
+  let(:user) { create(:user, :super_admin) }
+  let(:search_term) { '' }
+  let(:contact) { 'wifi.user@govwifi.org' }
+
+  after { WifiUser.destroy_all }
+
+  before do
+    create(:wifi_user, username: 'zZyYxX', contact: contact)
+
+    sign_in_user user
+    visit admin_wifi_user_search_path
+
+    fill_in 'search_term', with: search_term
+    click_on 'Find user details'
+  end
+
+  context 'with no search term' do
+    it 'presents an error message' do
+      expect(page).to have_content("Search term can't be blank")
+    end
+  end
+
+  context 'with a username search term' do
+    let(:search_term) { 'ZZYYXX' }
+
+    it 'presents the end user contact details' do
+      expect(page).to have_content('wifi.user@govwifi.org')
+    end
+
+    it 'provides a link to search logs by username' do
+      expect(page).to have_link('zZyYxX', href: logs_path(username: 'zZyYxX'))
+    end
+  end
+
+  context 'with an unknown username' do
+    let(:search_term) { 'AAAAAA' }
+
+    it 'presents the end user contact details' do
+      expect(page).to have_content("Nothing found for 'AAAAAA'")
+    end
+  end
+
+  context 'with a phone number search term' do
+    let(:search_term) { '+44 7891 234567' }
+    let(:contact) { '+447891234567' }
+
+    it 'presents the end user username' do
+      expect(page).to have_content('zZyYxX')
+    end
+  end
+
+  context 'with an email address search term' do
+    let(:search_term) { 'wifi.user@govwifi.org' }
+
+    it 'presents the end user username' do
+      expect(page).to have_content('zZyYxX')
+    end
+  end
+end

--- a/spec/models/wifi_user_spec.rb
+++ b/spec/models/wifi_user_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe WifiUser do
+  describe 'search' do
+    context 'with username as search term' do
+      before { create(:wifi_user, username: 'CfxYtb') }
+
+      it 'finds a wifi user' do
+        expect(described_class.search('CFXYTB')).not_to be_nil
+      end
+    end
+
+    context 'with contact details as search term' do
+      before { create(:wifi_user, contact: 'wifi.user@govwifi.org') }
+
+      it 'finds a wifi user' do
+        expect(described_class.search('wIfI.uSEr@govWIFI.org')).not_to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/ydPR0kkx/33-l-allow-gds-super-admin-to-find-user-details-of-a-username-and-vice-versa-7

![Screenshot from 2019-06-06 13-24-01](https://user-images.githubusercontent.com/93511/59033247-288bcf80-8860-11e9-84bc-675f34ba7ff5.png)

Allows a super admin to search for users by email, phone number or username and retrieve useful contact information.
Provides a link to search logs for the resulting user.

See https://github.com/alphagov/govwifi-terraform/pull/259 for terraform changes to allow connection to user db.

### TODO

This search feature doesn't have any navigation yet, we need to decide where it lives.