### PR TITLE
Add link for super admins to user details lookup

### DIFF
--- a/app/views/logs_searches/new.html.erb
+++ b/app/views/logs_searches/new.html.erb
@@ -40,5 +40,14 @@
       <input type='hidden' name='logs_search[first_step]' value='true'>
       <%= form.submit 'Go to search', class: 'govuk-button' %>
     <% end %>
+
+    <% if super_admin? %>
+      <div>
+        <p class="govuk-body">
+          You can also <%= link_to "search for a username or user contact details.",
+            admin_wifi_user_search_path, class: "govuk-link" %>
+        </p>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/spec/features/logging/choosing_how_to_filter_spec.rb
+++ b/spec/features/logging/choosing_how_to_filter_spec.rb
@@ -29,4 +29,23 @@ describe 'Choosing how to filter', type: :feature do
       end
     end
   end
+
+  context 'when viewing the link to the username and user details search' do
+    context 'with admin privileges' do
+      it 'hides then link' do
+        expect(page).not_to have_link('search for a username or user contact details.')
+      end
+    end
+
+    context 'with super admin privileges' do
+      before do
+        sign_in_user create(:user, :super_admin)
+        visit new_logs_search_path
+      end
+
+      it 'shows me the link to the username and user details search' do
+        expect(page).to have_link('search for a username or user contact details.')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds link to the new feature worked on by Steve and Paula. Link is for super admins only.

<img width="909" alt="Screenshot 2019-06-10 at 16 43 04" src="https://user-images.githubusercontent.com/2160769/59208008-226b5b00-8ba0-11e9-806b-fabdd32692e9.png">
