### PR TITLE
Use Rails view context to construct link in flash message

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -27,7 +27,7 @@ protected
 
   def set_user_object_with_errors
     @user = User.new(sign_up_params)
-    @user.errors.add(:email, "address must be from a government or a public sector domain. If you're having trouble signing up, <a href='/help/new'>contact us</a>.")
+    @user.errors.add(:email, "address must be from a government or a public sector domain. If you're having trouble signing up, #{view_context.link_to('contact us', new_help_path)}.")
   end
 
   def return_user_to_registration_page


### PR DESCRIPTION
Replace raw HTML in flash message with call to Rails view helper `link_to` method.