### PR TITLE
Sort by Location and IP count

### DIFF
--- a/app/controllers/super_admin/organisations_controller.rb
+++ b/app/controllers/super_admin/organisations_controller.rb
@@ -3,9 +3,7 @@ class SuperAdmin::OrganisationsController < SuperAdminController
   CSV_HEADER = "email address".freeze
 
   def index
-    @organisations = Organisation
-      .includes(:signed_mou_attachment)
-      .order("#{sort_column} #{sort_direction}")
+    @organisations = Organisation.sortable_with_child_counts(sort_column, sort_direction)
 
     @location_count = Location.count
 
@@ -53,7 +51,7 @@ private
   end
 
   def sortable_columns
-    %w[name created_at active_storage_attachments.created_at]
+    %w[name created_at locations_count ips_count active_storage_attachments.created_at]
   end
 
   def sort_column

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -9,6 +9,15 @@ class Organisation < ApplicationRecord
   validates :service_email, format: { with: Devise.email_regexp, message: "must be a valid email address" }
   validate :validate_in_register?, unless: Proc.new { |org| org.name.blank? }
 
+  scope :sortable_with_child_counts, ->(sort_column, sort_direction) {
+    select("organisations.*, COUNT(DISTINCT(locations.id)) AS locations_count, COUNT(DISTINCT(ips.id)) AS ips_count")
+    .joins("LEFT OUTER JOIN locations ON locations.organisation_id = organisations.id")
+    .joins("LEFT OUTER JOIN ips ON ips.location_id = locations.id")
+    .joins("LEFT OUTER JOIN active_storage_attachments ON active_storage_attachments.record_id = organisations.id")
+    .group("organisations.id, active_storage_attachments.created_at")
+    .order("#{sort_column} #{sort_direction}")
+  }
+
   def validate_in_register?
     unless Organisation.fetch_organisations_from_register.include?(name)
       errors.add(:base, "#{name} isn't a whitelisted organisation")

--- a/app/views/super_admin/organisations/index.html.erb
+++ b/app/views/super_admin/organisations/index.html.erb
@@ -19,8 +19,8 @@
       <th class="govuk-table__header govuk-!-width-one-half"><%= sort_link "name" %></th>
       <th class="govuk-table__header"><%= sort_link "created_at", "Created on" %></th>
       <th class="govuk-table__header govuk-table__header"><%= sort_link "active_storage_attachments.created_at", "MoU Signed" %></th>
-      <th class="govuk-table__header govuk-table__header--numeric">Locations</th>
-      <th class="govuk-table__header govuk-table__header--numeric">IPs</th>
+      <th class="govuk-table__header govuk-table__header--numeric"><%= sort_link "locations_count", "Locations" %></th>
+      <th class="govuk-table__header govuk-table__header--numeric"><%= sort_link "ips_count", "IPs" %></th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">

--- a/spec/features/super_admin/locations/locations_spec.rb
+++ b/spec/features/super_admin/locations/locations_spec.rb
@@ -6,7 +6,7 @@ describe 'View and search locations', type: :feature do
     create(:location, address: '69 Garry Street, London', postcode: 'HA7 2BL', organisation: organisation)
     sign_in_user user
     visit root_path
-    click_on 'Locations'
+    within('.leftnav') { click_on 'Locations' }
   end
 
   it 'takes the user to the locations page' do

--- a/spec/features/super_admin/organisations/sort_organisation_list_spec.rb
+++ b/spec/features/super_admin/organisations/sort_organisation_list_spec.rb
@@ -63,5 +63,50 @@ describe 'Sorting the organisations list', type: :feature do
         expect(page.body).to match(/Gov Org 3.*Gov Org 1.*Gov Org 4/m)
       end
     end
+
+    context 'when sorting by location count' do
+      before do
+        create(:location, organisation: Organisation.find_by(name: 'Gov Org 1'))
+        org3 = Organisation.find_by(name: 'Gov Org 3')
+        create(:location, organisation: org3)
+        create(:location, organisation: org3)
+      end
+
+      it 'sorts the list by number of locations ascending' do
+        within('.govuk-table__head') { click_link 'Locations' }
+
+        expect(page.text).to match(/Gov Org 2.*Gov Org 1.*Gov Org 3/)
+      end
+
+      it 'sorts the list by number of locations descending' do
+        within('.govuk-table__head') { 2.times { click_link 'Locations' } }
+
+        expect(page.text).to match(/Gov Org 3.*Gov Org 1.*Gov Org 2/)
+      end
+    end
+
+    context 'when sorting by ip count' do
+      before do
+        location1 = create(:location, organisation: Organisation.find_by(name: 'Gov Org 1'))
+        org3 = Organisation.find_by(name: 'Gov Org 3')
+        create(:location, organisation: org3)
+        location3 = create(:location, organisation: org3)
+        create(:ip, location: location1)
+        create(:ip, location: location1)
+        create(:ip, location: location3)
+      end
+
+      it 'sorts the list by number of ips ascending' do
+        within('.govuk-table__head') { click_link 'IPs' }
+
+        expect(page.text).to match(/Gov Org 2.*Gov Org 3.*Gov Org 1/)
+      end
+
+      it 'sorts the list by number of ips descending' do
+        within('.govuk-table__head') { 2.times { click_link 'IPs' } }
+
+        expect(page.text).to match(/Gov Org 1.*Gov Org 3.*Gov Org 2/)
+      end
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/wOXIzpOb/42-make-super-admin-organisations-view-of-organisations-list-sortable-filterable

First part of sorting and filtering by Location and IP count.

![Screenshot from 2019-07-15 14-31-48](https://user-images.githubusercontent.com/93511/61220011-58ef4500-a70d-11e9-9026-e831b0c75922.png)
