### PR TITLE
Move sub navigation to left hand side

### DIFF
--- a/app/assets/stylesheets/components/left_nav.scss
+++ b/app/assets/stylesheets/components/left_nav.scss
@@ -1,0 +1,38 @@
+.leftnav {
+
+  ul {
+
+    margin: 0;
+    padding: govuk-spacing(3) 0 0 0;
+
+    li {
+      list-style: none;
+      margin: 0;
+    }
+
+  }
+
+  a {
+
+    @include govuk-link-common;
+    @include govuk-link-style-no-visited-state;
+    padding: govuk-spacing(1) 0 govuk-spacing(1) 0;
+    display: block;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &.active {
+      font-weight: bold;
+      // These three lines stop the width of the item jumping so much
+      // between selected and unselected states
+      position: relative;
+      left: -0.5px;
+      letter-spacing: -0.01em;
+    }
+
+  }
+
+}

--- a/app/assets/stylesheets/components/sub_nav.scss
+++ b/app/assets/stylesheets/components/sub_nav.scss
@@ -1,64 +1,41 @@
 .subnav {
-  border-bottom: 1px solid $colour-black;
 
-  // Flexbox used at desktop widths to keep the subnav links anchored to the
-  // bottom of their div.
-  @media (min-width: 640px) {
-    display: flex;
-  }
+  border-bottom: 1px solid $govuk-border-colour;
 
   .organisation-name {
     // Organisation name centred on mobile
     text-align: center;
-    margin-top: 14px;
+    margin: 14px 0 11px 0;
+    font-weight: bold;
+
+    .govuk-body {
+      font-weight: bold;
+    }
 
     // Organisation name aligned left on desktop and top margin reduced.
     @media (min-width: 640px) {
       text-align: left;
-      margin: 10px 0;
-    }
-  }
-
-  .nav-links {
-    // Subnav links centred on mobile
-    display: flex;
-    justify-content: space-around;
-
-    // Subnav links aligned right on desktop
-    @media (min-width: 640px) {
-      justify-content: flex-end;
-      align-self: flex-end;
     }
   }
 
   nav {
-    text-align: right;
-    // This margin is required to keep the left and right columns the same height.
-    // Flexbox cannot be used on mobile as it breaks the design system styles.
-    margin-top: 4px;
 
-    // Margin that separates subnav links is not required on first link
-    > :first-child {
-      margin-left: 0;
-    }
+    text-align: right;
 
     a {
-      // Margin bottom replaced by bottom border when active
-      margin-bottom: 5px;
-      // Spacing between subnav links
-      margin-left: 15px;
-      padding-top: 10px;
-      padding-bottom: 5px;
+
+      @include govuk-link-common;
+      @include govuk-link-style-no-visited-state;
+      @include govuk-responsive-padding(3, "top", $adjustment: -1px);
+      @include govuk-responsive-padding(2, "bottom", $adjustment: 1px);
       display: inline-block;
       text-decoration: none;
-      font-size: 16px;
+      margin: 0;
 
-      // Active state conveys the current page to the user. Bottom margin is
-      // replaced with a thick black bottom border
-      &.active {
-        border-bottom: 5px solid $colour-black;
-        margin-bottom: 0;
+      &:hover {
+        text-decoration: underline;
       }
+
     }
   }
 }

--- a/app/views/application/_left_navigation.html.erb
+++ b/app/views/application/_left_navigation.html.erb
@@ -1,0 +1,43 @@
+<nav class='govuk-body leftnav'>
+  <ul>
+    <% if super_admin? %>
+      <li>
+        <%= link_to 'Locations', super_admin_locations_path, class: active_tab(super_admin_locations_path) %>
+      </li>
+      <li>
+        <%= link_to 'Organisations', super_admin_organisations_path, class: active_tab(super_admin_organisations_path) %>
+      </li>
+      <li>
+        <%= link_to 'Whitelist', new_super_admin_whitelist_path, class: active_tab('whitelist') %>
+      </li>
+      <li>
+        <%= link_to 'MOU', super_admin_mou_index_path, class: active_tab(super_admin_mou_index_path) %>
+      </li>
+      <li>
+        <%= link_to 'Logs', new_logs_search_path, class: active_tab('logs') %>
+      </li>
+    <% else %>
+      <li>
+        <%= link_to 'Overview', overview_index_path, class: active_tab(overview_index_path) %>
+      </li>
+      <% if current_organisation&.ips&.empty? %>
+        <li>
+          <%= link_to 'Setup', new_organisation_setup_instructions_path, class: active_tab(new_organisation_setup_instructions_path) + active_tab('mou') %>
+        </li>
+      <% else %>
+        <li>
+          <%= link_to 'Setup', setup_instructions_path, class: active_tab(setup_instructions_path) + active_tab('mou') %>
+        </li>
+      <% end %>
+      <li>
+        <%= link_to 'IP addresses', ips_path, id: 'nav-ips', class: active_tab('ips') + active_tab('locations') %>
+      </li>
+      <li>
+        <%= link_to 'Team members', memberships_path, class: active_tab('team') + active_tab('user') %>
+      </li>
+      <li>
+        <%= link_to 'Logs', new_logs_search_path, class: active_tab('logs') %>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/app/views/application/_subnavigation.html.erb
+++ b/app/views/application/_subnavigation.html.erb
@@ -1,32 +1,10 @@
-<div class='govuk-grid-row subnav govuk-!-margin-0'>
-  <div class='govuk-grid-column-one-third govuk-grid-column-one-half-from-desktop govuk-!-padding-left-0 organisation-name'>
-    <p class='govuk-body govuk-!-margin-0 govuk-!-padding-0'>
-      <strong class="govuk-!-margin-right-1"><%= current_organisation.name if current_organisation %></strong>
-      <%= link_to 'switch', change_organisation_path, class: "govuk-link govuk-body-s" %>
-    </p>
-  </div>
-
-  <div class='govuk-grid-column-two-thirds govuk-!-padding-0 nav-links'>
-    <nav class='govuk-body govuk-!-margin-bottom-0'>
-      <% if super_admin? %>
-        <%= link_to 'Locations', super_admin_locations_path, class: active_tab(super_admin_locations_path) %>
-        <%= link_to 'Organisations', super_admin_organisations_path, class: active_tab(super_admin_organisations_path) %>
-        <%= link_to 'Whitelist', new_super_admin_whitelist_path, class: active_tab('whitelist') %>
-        <%= link_to 'MOU', super_admin_mou_index_path, class: active_tab(super_admin_mou_index_path) %>
-        <%= link_to 'Logs', new_logs_search_path, class: active_tab('logs') %>
-        <%= link_to 'Admin Support', signed_in_new_help_path, class: active_tab('support') %>
-      <% else %>
-        <%= link_to 'Overview', overview_index_path, class: active_tab(overview_index_path) %>
-        <% if current_organisation&.ips&.empty? %>
-          <%= link_to 'Setup', new_organisation_setup_instructions_path, class: active_tab(new_organisation_setup_instructions_path) + active_tab('mou') %>
-        <% else %>
-          <%= link_to 'Setup', setup_instructions_path, class: active_tab(setup_instructions_path) + active_tab('mou') %>
-        <% end %>
-        <%= link_to 'IPs', ips_path, id: 'nav-ips', class: active_tab('ips') + active_tab('locations') %>
-        <%= link_to 'Logs', new_logs_search_path, class: active_tab('logs') %>
-        <%= link_to 'Team', memberships_path, class: active_tab('team') + active_tab('user') %>
-        <%= link_to 'Admin Support', signed_in_new_help_path, class: active_tab('support') %>
-      <% end %>
+<div class='subnav'>
+  <div class='govuk-grid-row'>
+    <div class='govuk-grid-column-one-half organisation-name'>
+      <strong class="govuk-body"><%= current_organisation.name if current_organisation %></strong>
+    </div>
+    <nav class='govuk-grid-column-one-half'>
+      <%= link_to 'Switch organisation', change_organisation_path, class: "govuk-link govuk-body" %>
     </nav>
   </div>
 </div>

--- a/app/views/help/signed_in.html.erb
+++ b/app/views/help/signed_in.html.erb
@@ -1,8 +1,8 @@
 <%= render "layouts/form_errors", resource: @support_form %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Get support</h2>
+  <div class="govuk-grid-column-three-quarters">
+    <h2 class="govuk-heading-l">Support</h2>
 
     <p class="govuk-body">
       If an <strong>individual user</strong> is having trouble connecting to GovWifi:
@@ -50,7 +50,7 @@
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
     <p class="govuk-body">
-      If you <strong> can't resolve your issue</strong>, send us a support request.
+      If you <strong> can’t resolve your issue</strong>, send us a support request.
     </p>
     <%= form_for @support_form, url: { action: "create" }  do |f| %>
       <div class="govuk-form-group <%= field_error(@support_form, :details) %>">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -103,11 +103,25 @@
     </header>
 
     <div class="govuk-width-container">
-      <%= render "subnavigation" if user_signed_in? %>
-      <main class="govuk-main-wrapper govuk-!-padding-top-8" id="main-content" role="main">
-        <%= render "layouts/flash_notices" %>
-        <%= yield %>
-      </main>
+      <% if user_signed_in? %>
+        <%= render "subnavigation" %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-one-quarter">
+            <%= render "left_navigation" %>
+          </div>
+          <div class="govuk-grid-column-three-quarters">
+            <main class="govuk-main-wrapper govuk-!-padding-top-8" id="main-content" role="main">
+              <%= render "layouts/flash_notices" %>
+              <%= yield %>
+            </main>
+          </div>
+        </div>
+      <% else %>
+        <main class="govuk-main-wrapper govuk-!-padding-top-8" id="main-content" role="main">
+          <%= render "layouts/flash_notices" %>
+          <%= yield %>
+        </main>
+      <% end %>
     </div>
 
     <footer class="govuk-footer " role="contentinfo">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -84,9 +84,15 @@
               <li class="govuk-header__navigation-item">
                 <%= link_to 'Offer GovWifi', SITE_CONFIG['organisation_docs_link'], class: "govuk-header__link" %>
               </li>
-              <li class="govuk-header__navigation-item">
-                <%= link_to 'Support', SITE_CONFIG['support_link'], class: "govuk-header__link" %>
-              </li>
+              <% if user_signed_in? %>
+                <li class="govuk-header__navigation-item">
+                  <%= link_to 'Support', signed_in_new_help_path, class: "govuk-header__link" %>
+                </li>
+              <% else %>
+                <li class="govuk-header__navigation-item">
+                  <%= link_to 'Support', SITE_CONFIG['support_link'], class: "govuk-header__link" %>
+                </li>
+              <% end %>
               <% if user_signed_in? %>
                 <li class="govuk-header__navigation-item">
                   <%= link_to 'Sign out', destroy_user_session_path, method: :delete, class: "govuk-header__link" %>

--- a/app/views/memberships/_service_email.html.erb
+++ b/app/views/memberships/_service_email.html.erb
@@ -10,8 +10,8 @@
     </p>
   </div>
   <div class="govuk-grid-column-one-third govuk-list govuk-!-padding-right-4 text-right">
-    <%= link_to "Change", edit_organisation_path(current_organisation.id), class: "govuk-link" %>
+    <%= link_to "Change", edit_organisation_path(current_organisation.id), class: "govuk-link govuk-link--no-visited-state" %>
   </div>
 </div>
 
-<hr class='govuk-section-break--l govuk-!-margin-top-0'>
+<div class='govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0 govuk-!-margin-bottom-3'></div>

--- a/app/views/memberships/_table.html.erb
+++ b/app/views/memberships/_table.html.erb
@@ -1,19 +1,19 @@
 <ul class='govuk-list govuk-width-container govuk-!-margin-left-0'>
   <% team_members.each do |member| %>
-    <li>
+    <li class='govuk-!-margin-bottom-1'>
       <div class='govuk-grid-row'>
         <div class='govuk-grid-column-two-thirds'>
           <% if member.invitation_pending? || member.pending_membership_for?(organisation: current_organisation) %>
-            <h3 class='govuk-heading-m text-light-grey govuk-!-margin-bottom-0'><%= member.name %>
+            <h3 class='govuk-heading-s govuk-!-margin-bottom-0'><%= member.name %>
               <span class='govuk-!-padding-left-1 govuk-body text-light-grey'><%= member.email %> (invited)</span>
             </h3>
             <% else %>
-            <h3 class='govuk-heading-m govuk-!-margin-bottom-0'><%= member.name %>
+            <h3 class='govuk-heading-s govuk-!-margin-bottom-0'><%= member.name %>
               <span class='govuk-!-padding-left-1 govuk-body text-light-grey'><%= member.email %></span>
             </h3>
           <% end %>
 
-          <ul class='govuk-list' id='member-<%= member.id %>-permissions'>
+          <ul class='govuk-list govuk-!-margin-bottom-2 govuk-!-margin-top-1' id='member-<%= member.id %>-permissions'>
             <li>
               <%= image_tag 'tick.svg', class: 'list-item-padding', height: '30', alt: 'allowed' %>
               <span class='govuk-!-padding-left-1'>View logs</span>
@@ -47,19 +47,19 @@
           </ul>
         </div>
 
-        <div class='govuk-grid-column-one-third govuk-list govuk-!-padding-right-4 text-right'>
+        <div class='govuk-grid-column-one-third govuk-list govuk-!-padding-right-4 govuk-!-margin-top-0 text-right'>
           <% if current_user.can_manage_team?(current_organisation) && member.id != current_user.id %>
-            <%= link_to 'Edit permissions', edit_membership_path(member.membership_for(current_organisation)), class: "govuk-link govuk-!-padding-right-1" %>
+            <%= link_to 'Edit permissions', edit_membership_path(member.membership_for(current_organisation)), class: "govuk-link govuk-link--no-visited-state" %>
 
             <% if member.invitation_pending? && current_user.can_manage_team?(current_organisation) %>
             <%= button_to("Resend invite",
               user_invitation_path(user: { email: member.email }, resend: true),
-              method: :post, class: 'button-as-link govuk-body govuk-!-padding-right-1') %>
+              method: :post, class: 'button-as-link govuk-body') %>
             <% end %>
           <% end %>
       </div>
-      </li>
+    </li>
 
-    <hr class='govuk-section-break--l govuk-!-margin-top-0'>
+    <div class='govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0 govuk-!-margin-bottom-4'></div>
   <% end %>
 </ul>

--- a/app/views/memberships/edit.html.erb
+++ b/app/views/memberships/edit.html.erb
@@ -1,13 +1,13 @@
 <%= link_to "Back to list", memberships_path, class: "govuk-back-link" %>
 <%= render "confirm_remove_team_member" if params[:remove_team_member] %>
 
-<h1 class="govuk-heading-l govuk-!-margin-bottom-2"><%= @membership.user.name %></h1>
-<p class="govuk-body"> <%= @membership.user.email %> </p>
+<h1 class="govuk-heading-l govuk-!-margin-top-2 govuk-!-margin-bottom-3"><%= @membership.user.name %></h1>
+<p class="govuk-body govuk-!-margin-bottom-4"> <%= @membership.user.email %> </p>
 
 <div class="actions">
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m"><span class="govuk-label">Permissions </span></legend>
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-1"><span class="govuk-label">Permissions </span></legend>
       <div class="govuk-checkboxes">
           <%= form_for @membership, url: membership_path(@membership), method: :patch do |form| %>
            <div class="govuk-checkboxes__item">
@@ -30,8 +30,8 @@
               <%= form.check_box :can_manage_locations, class: 'govuk-checkboxes__input' %>
               <label class="govuk-label govuk-checkboxes__label"><%= form.label :can_manage_locations, 'Add and remove locations and IPs' %></label>
             </div>
-          <div class="govuk-!-margin-top-8">
-            <%= form.submit 'Save', class: "govuk-button govuk-!-margin-0 govuk-!-margin-right-8 inline-block" %>
+          <div class="govuk-!-margin-top-6">
+            <%= form.submit 'Save', class: "govuk-button govuk-!-margin-0 govuk-!-margin-right-4 inline-block" %>
 
             <% unless params[:remove_team_member] %>
               <div class="govuk-body govuk-!-margin-top-2 inline-block">

--- a/app/views/memberships/index.html.erb
+++ b/app/views/memberships/index.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Team settings</h1>
+    <h1 class="govuk-heading-l">Team members</h1>
   </div>
 
   <div class="govuk-grid-column-one-third text-right">

--- a/app/views/overview/index.html.erb
+++ b/app/views/overview/index.html.erb
@@ -7,7 +7,7 @@
           <%= @team_members.count %>
         </h1>
         <p class="govuk-panel__body text-left govuk-!-font-size-27">
-          <%= link_to "Team Members", memberships_path, class: "govuk-link govuk-link--no-visited-state summary-link-colour" %>
+          <%= link_to "Team members", memberships_path, class: "govuk-link govuk-link--no-visited-state summary-link-colour" %>
         </p>
       </div>
     </div>
@@ -27,7 +27,7 @@
           <%= @ips.count %>
         </h1>
         <p class="govuk-panel__body text-left govuk-!-font-size-27">
-          <%= link_to "IPs", ips_path, class: "govuk-link govuk-link--no-visited-state summary-link-colour" %>
+          <%= link_to "IP addresses", ips_path, class: "govuk-link govuk-link--no-visited-state summary-link-colour" %>
         </p>
       </div>
     </div>

--- a/app/views/setup_instructions/index.html.erb
+++ b/app/views/setup_instructions/index.html.erb
@@ -1,38 +1,38 @@
 <div class="govuk-grid-row">
   <h2 class="govuk-heading-l govuk-grid-column-full" id="setup-header">Get GovWifi access in your organisation</h2>
-  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-three-quarters">
     <h3 class="govuk-heading-m"> 1. Sign the GovWifi Memorandum of understanding </h3>
     <p class="govuk-body">
       <%= link_to "Sign the memorandum of understanding (MOU)", mou_index_path, class: "govuk-link" %> with the Government Digital Service (GDS).
     </p>
     <p class="govuk-body">This must be done by someone in your organisation who has permission to sign off and procure services.</p>
 
-    <hr class="govuk-section-break--m govuk-section-break--visible">
+    <div class="govuk-section-break--m govuk-section-break--visible"></div>
 
-    <h3 class="govuk-heading-m"> 2. Add IPs </h3>
+    <h3 class="govuk-heading-m"> 2. Add IP addresses </h3>
       <% if @locations.empty? %>
         <% if current_user.can_manage_locations?(current_organisation) %>
           <p class="govuk-body">
-            You need to <%= link_to "add the IPs", new_location_path, class: "govuk-link" %> of your authenticator(s).
+            You need to <%= link_to "add the IP addresses", new_location_path, class: "govuk-link" %> of your authenticator(s).
           </p>
         <% end %>
       <% elsif @ips.empty? %>
         <% if current_user.can_manage_locations?(current_organisation) %>
           <p class="govuk-body">
-            You need to <%= link_to "add the IPs", new_ip_path, class: "govuk-link" %> of your authenticator(s).
+            You need to <%= link_to "add the IP addresses", new_ip_path, class: "govuk-link" %> of your authenticator(s).
           </p>
         <% end %>
       <% else %>
         <p class="govuk-body">
-          You have <%= link_to "#{pluralize(@ips.count, 'IP')} configured.", ips_path, class: "govuk-link" %>
+          You have <%= link_to "#{pluralize(@ips.count, 'IP address')} configured.", ips_path, class: "govuk-link" %>
         </p>
       <% end %>
-      <p class="govuk-body">If your authenticators are allocated IPs dynamically, you can use Firewall NAT rules, so that your requests come from consistent IPs.</p>
+      <p class="govuk-body">If your authenticators are allocated IP addresses dynamically, you can use Firewall NAT rules, so that your requests come from consistent IPs.</p>
       <p class="govuk-body">
-        New IPs will not be activated until<strong class="govuk-!-font-weight-bold"> the next day. </strong>
+        New IP addresses will not be activated until<strong class="govuk-!-font-weight-bold"> the next day. </strong>
       </p>
 
-    <hr class="govuk-section-break--m govuk-section-break--visible">
+    <div class="govuk-section-break--m govuk-section-break--visible"></div>
 
     <h3 class="govuk-heading-m"> 3. Configure your authenticator(s) </h3>
 
@@ -46,13 +46,13 @@
 
     <%= render "radius_details", london_ips: @london_radius_ips, dublin_ips: @dublin_radius_ips %>
 
-    <hr class="govuk-section-break--m govuk-section-break--visible">
+    <div class="govuk-section-break--m govuk-section-break--visible"></div>
 
     <h3 class="govuk-heading-m"> 4. Check authentication requests from your network can reach GovWifi </h3>
     <p class="govuk-body"> You must check your firewall allows traffic on UDP ports 1812/1813. </p>
     <p class="govuk-body"> There may also be additional configuration to allow outbound traffic, depending on your local network. </p>
 
-    <hr class="govuk-section-break--m govuk-section-break--visible">
+    <div class="govuk-section-break--m govuk-section-break--visible"></div>
 
     <h3 class="govuk-heading-m"> 5. Create and name the 'GovWifi' network </h3>
     <p class="govuk-body"> You must create an SSID using these details</p>
@@ -62,7 +62,7 @@
       <li>Inner Encryption: <strong>MsChapV2</strong> </li>
     </ul>
 
-    <hr class="govuk-section-break--m govuk-section-break--visible">
+    <div class="govuk-section-break--m govuk-section-break--visible"></div>
 
     <h3 class="govuk-heading-m"> 6. Check the connection works </h3>
     <p class="govuk-body"> Connect to your new GovWifi network, and sign in with an individual account. </p>
@@ -81,7 +81,7 @@
       </div>
     </details>
 
-    <hr class="govuk-section-break--m govuk-section-break--visible">
+    <div class="govuk-section-break--m govuk-section-break--visible"></div>
 
     <h3 class="govuk-heading-m"> 7. Advertise GovWifi in your organisation </h3>
     <p class=govuk-body>
@@ -89,7 +89,7 @@
     </p>
     <p class="govuk-body">The posters provide information for end users on how they can connect to GovWifi in your organisation.</p>
 
-    <hr class="govuk-section-break--m govuk-section-break--visible">
+    <div class="govuk-section-break--m govuk-section-break--visible"></div>
     <p class="govuk-body">
       If you have trouble setting up GovWifi, <%= link_to "contact us", signed_in_new_help_path, class: 'govuk-link govuk-body' %>.
     </p>

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -1,73 +1,55 @@
 <%= render "layouts/form_errors" %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% if super_admin? %>
-      <%= link_to "Back to organisation", super_admin_organisation_path(@target_organisation.id), class: "govuk-back-link" %>
-      <h2 class="govuk-heading-l">Invite a team member to <%= @target_organisation.name %> </h2>
-      <div class="govuk-details">
-        <div class="govuk-details__text">
-          <p class="govuk-body">
-            Team members will receive an email invitation to join <%= @target_organisation.name %>'s GovWifi admin account.
-          </p>
-        </div>
-      </div>
-    <% else %>
-      <%= link_to "Back to list", memberships_path, class: "govuk-back-link" %>
-      <h2 class="govuk-heading-l">Invite a team member</h2>
-      <div class="govuk-details">
-        <div class="govuk-details__text">
-          <p class="govuk-body">
-            Team members will receive an email invitation to join your organisation's GovWifi admin dashboard.
-          </p>
-        </div>
-      </div>
-    <% end %>
-    <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-      <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post, novalidate: '' } do |f| %>
+<% if super_admin? %>
+  <%= link_to "Back to organisation", super_admin_organisation_path(@target_organisation.id), class: "govuk-back-link" %>
+  <h2 class="govuk-heading-l">Invite a team member to <%= @target_organisation.name %> </h2>
+<% else %>
+  <%= link_to "Back to list", memberships_path, class: "govuk-back-link" %>
+  <h2 class="govuk-heading-l">Invite a team member</h2>
+<% end %>
+<div class="govuk-grid-column-full govuk-!-padding-left-0">
+  <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post, novalidate: '' } do |f| %>
 
-        <div class="govuk-form-group <%= field_error(resource, :email) %>">
-          <%= f.label :email, "Email address", class: "govuk-label" %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input" %>
-        </div>
-
-        <div class="actions">
-          <div class="govuk-form-group">
-            <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
-              <legend class="govuk-fieldset__legend govuk-fieldset__legend--m"><span class="govuk-label">Permissions </span></legend>
-              <div class="govuk-checkboxes">
-                  <div class="govuk-checkboxes__item">
-                    <input type="checkbox" class='govuk-checkboxes__input' checked disabled>
-                    <label class="govuk-label govuk-checkboxes__label">View logs</label>
-                  </div>
-                  <div class="govuk-checkboxes__item">
-                    <input type="checkbox" class='govuk-checkboxes__input' checked disabled>
-                    <label class="govuk-label govuk-checkboxes__label">View team members</label>
-                  </div>
-                  <div class="govuk-checkboxes__item">
-                    <%= check_box_tag :can_manage_team, true, true, class: 'govuk-checkboxes__input' %>
-                  <label class="govuk-label govuk-checkboxes__label"><%= label_tag :can_manage_team, 'Add and remove team members' %></label>
-                  </div>
-                  <div class="govuk-checkboxes__item">
-                    <input type="checkbox" class='govuk-checkboxes__input' checked disabled>
-                    <label class="govuk-label govuk-checkboxes__label">View locations and IPs</label>
-                  </div>
-                  <div class="govuk-checkboxes__item">
-                    <%= check_box_tag :can_manage_locations, true, true, class: 'govuk-checkboxes__input' %>
-                    <label class="govuk-label govuk-checkboxes__label"><%= label_tag :can_manage_locations, 'Add and remove locations and IPs' %></label>
-                  </div>
-                  <% if super_admin? %>
-                    <%= hidden_field_tag :organisation_id, @target_organisation.id %>
-                <% end %>
-              </div>
-            </fieldset>
-          </div>
-        </div>
-
-        <div class="actions">
-          <%= f.submit "Send invitation email", class: "govuk-button govuk-!-margin-top-4" %>
-        </div>
-      <% end %>
+    <div class="govuk-form-group <%= field_error(resource, :email) %>">
+      <%= f.label :email, "Email address", class: "govuk-label" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input" %>
     </div>
-  </div>
+
+    <div class="actions">
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-1"><span class="govuk-label">Permissions </span></legend>
+          <div class="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+                <input type="checkbox" class='govuk-checkboxes__input' checked disabled>
+                <label class="govuk-label govuk-checkboxes__label">View logs</label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input type="checkbox" class='govuk-checkboxes__input' checked disabled>
+                <label class="govuk-label govuk-checkboxes__label">View team members</label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <%= check_box_tag :can_manage_team, true, true, class: 'govuk-checkboxes__input' %>
+              <label class="govuk-label govuk-checkboxes__label"><%= label_tag :can_manage_team, 'Add and remove team members' %></label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <input type="checkbox" class='govuk-checkboxes__input' checked disabled>
+                <label class="govuk-label govuk-checkboxes__label">View locations and IPs</label>
+              </div>
+              <div class="govuk-checkboxes__item">
+                <%= check_box_tag :can_manage_locations, true, true, class: 'govuk-checkboxes__input' %>
+                <label class="govuk-label govuk-checkboxes__label"><%= label_tag :can_manage_locations, 'Add and remove locations and IPs' %></label>
+              </div>
+              <% if super_admin? %>
+                <%= hidden_field_tag :organisation_id, @target_organisation.id %>
+            <% end %>
+          </div>
+        </fieldset>
+      </div>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "Send invitation email", class: "govuk-button govuk-!-margin-top-0 govuk-!-margin-bottom-8" %>
+    </div>
+  <% end %>
 </div>

--- a/spec/features/guidance_after_sign_in_spec.rb
+++ b/spec/features/guidance_after_sign_in_spec.rb
@@ -28,7 +28,7 @@ describe 'Guidance after sign in', type: :feature do
       before do
         create(:ip, address: ip_address, location: location)
         visit setup_instructions_path
-        click_on '1 IP'
+        click_on '1 IP address'
       end
 
       it 'displays the IP address' do
@@ -38,7 +38,7 @@ describe 'Guidance after sign in', type: :feature do
 
     context 'with no IPs' do
       it 'allows user to add new IPs' do
-        click_on 'add the IPs'
+        click_on 'add the IP addresses'
         expect(page).to have_content('Enter IP address')
       end
     end

--- a/spec/features/ips/permissions_spec.rb
+++ b/spec/features/ips/permissions_spec.rb
@@ -33,7 +33,7 @@ describe 'Add an IP', type: :feature do
 
       it 'has a link to add new IP addresses' do
         visit root_path
-        expect(page).to have_link('add the IPs')
+        expect(page).to have_link('add the IP addresses')
       end
     end
   end

--- a/spec/features/locations/rotate_radius_secret_key_spec.rb
+++ b/spec/features/locations/rotate_radius_secret_key_spec.rb
@@ -2,7 +2,7 @@ describe 'Rotate RADIUS secret key', type: :feature do
   context 'when it is a company that I belong to' do
     let(:user_1) { create(:user, :with_organisation) }
     let!(:location_1) { create(:location, organisation: user_1.organisations.first) }
-    let(:radius_key) { "ABC" }
+    let(:radius_key) { "AAAAAAAAAA1111111111" }
     let(:set_secret_key) { location_1.update!(radius_secret_key: radius_key) }
 
     before do

--- a/spec/features/overview/view_overview_page_spec.rb
+++ b/spec/features/overview/view_overview_page_spec.rb
@@ -63,7 +63,9 @@ describe 'Viewing the overview page', type: :feature do
       end
 
       it 'redirects to the team members page when Team Members is clicked on' do
-        click_link 'Team Members'
+        within('.leftnav') do
+          click_link 'Team members'
+        end
 
         expect(page).to have_current_path(memberships_path)
       end
@@ -76,7 +78,7 @@ describe 'Viewing the overview page', type: :feature do
 
       it 'redirects to the IPs page when IPs is clicked on' do
         within('div#ips') do
-          click_link 'IPs'
+          click_link 'IP addresses'
         end
         expect(page).to have_current_path(ips_path)
       end

--- a/spec/features/switch_organisation_spec.rb
+++ b/spec/features/switch_organisation_spec.rb
@@ -14,7 +14,7 @@ describe 'Multiple organisations', type: :feature do
     before do
       user.organisations << organisation_2
       visit root_path
-      click_on 'switch'
+      click_on 'Switch organisation'
     end
 
     it 'displays a button for organisation one' do

--- a/spec/features/user_with_no_organisation_memberships_spec.rb
+++ b/spec/features/user_with_no_organisation_memberships_spec.rb
@@ -25,7 +25,7 @@ describe 'A confirmed user with no organisation memberships logs in', type: :fea
       end
 
       it 'presents the user with a support request form' do
-        expect(page).to have_content('Get support')
+        expect(page).to have_content('Support')
       end
 
       it 'allows the user to submit a support request' do


### PR DESCRIPTION
This is consistent with what GOV.UK Notify does, and what GOV.UK Pay is moving towards.

Our research has shown it has two main advantages:
- more clearly associates which navigation items are associated with the organisation, and which are about the platform generally
- the vertical arrangement is quicker to scan, so new users can get an idea of what they can do once signed in

This commit also makes a bunch of spacing and style tweaks to generally tidy things up and make them clearer. Sorry I couldn’t split them into cleaner, atomic commits.

# Before 

![image](https://user-images.githubusercontent.com/355079/61285934-b0e38580-a7b9-11e9-8d15-e5dbcb5946d5.png)

# After 

![image](https://user-images.githubusercontent.com/355079/61285871-927d8a00-a7b9-11e9-960e-7e8174f554c3.png)