### PR TITLE
Filter organisations list

### DIFF
--- a/app/assets/stylesheets/components/filter_form.scss
+++ b/app/assets/stylesheets/components/filter_form.scss
@@ -1,0 +1,11 @@
+.filter-input {
+  height: 38px;
+}
+
+.filter-text-input {
+  width: 69%;
+}
+
+.filter-field-input {
+  width: 30%;
+}

--- a/app/controllers/super_admin/organisations_controller.rb
+++ b/app/controllers/super_admin/organisations_controller.rb
@@ -3,9 +3,7 @@ class SuperAdmin::OrganisationsController < SuperAdminController
   CSV_HEADER = "email address".freeze
 
   def index
-    @organisations = Organisation
-      .includes(:signed_mou_attachment)
-      .order("#{sort_column} #{sort_direction}")
+    @organisations = Organisation.sortable_with_child_counts(sort_column, sort_direction)
 
     @location_count = Location.count
 
@@ -53,7 +51,7 @@ private
   end
 
   def sortable_columns
-    %w[name created_at active_storage_attachments.created_at]
+    %w[name created_at locations_count ips_count active_storage_attachments.created_at]
   end
 
   def sort_column

--- a/app/views/shared/_filter_search.html.erb
+++ b/app/views/shared/_filter_search.html.erb
@@ -1,18 +1,28 @@
 <script>
-  var filterInput = document.getElementById('filter-input');
+  var filterInput = document.getElementById('filter-text-input');
+  var filterFieldInput = document.getElementById('filter-field-input');
   filterInput.addEventListener('keyup', filterResults);
   filterInput.addEventListener('search', filterResults);
+  filterFieldInput.addEventListener('change', updatePlaceholderText);
 
   function filterResults() {
     var filterValue = filterInput.value.toUpperCase();
+    var selectedFilterOption = filterFieldInput.options[filterFieldInput.selectedIndex];
+    var filterFieldIndex = parseInt(selectedFilterOption.value);
     var rows = document.querySelectorAll('.result-row');
 
     for(var i = 0; i < rows.length; i++) {
-      var text = rows[i].querySelectorAll('.filter-by')[0].innerHTML.toUpperCase();
+      var text = rows[i].querySelectorAll('.filter-by')[filterFieldIndex].innerHTML.toUpperCase();
       rows[i].style.display = text.indexOf(filterValue) > -1 ? '' : 'none';
     }
 
     displayResultsMessage(rows);
+  }
+
+  function updatePlaceholderText() {
+    var selectedFilterOption = filterFieldInput.options[filterFieldInput.selectedIndex];
+    var filterFieldLabel = selectedFilterOption.text;
+    filterInput.setAttribute('placeholder', 'Search by ' + filterFieldLabel);
   }
 
   function displayResultsMessage(results) {

--- a/app/views/super_admin/organisations/index.html.erb
+++ b/app/views/super_admin/organisations/index.html.erb
@@ -19,8 +19,8 @@
       <th class="govuk-table__header govuk-!-width-one-half"><%= sort_link "name" %></th>
       <th class="govuk-table__header"><%= sort_link "created_at", "Created on" %></th>
       <th class="govuk-table__header govuk-table__header"><%= sort_link "active_storage_attachments.created_at", "MoU Signed" %></th>
-      <th class="govuk-table__header govuk-table__header--numeric">Locations</th>
-      <th class="govuk-table__header govuk-table__header--numeric">IPs</th>
+      <th class="govuk-table__header govuk-table__header--numeric"><%= sort_link "locations_count", "Locations" %></th>
+      <th class="govuk-table__header govuk-table__header--numeric"><%= sort_link "ips_count", "IPs" %></th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">

--- a/app/views/super_admin/organisations/index.html.erb
+++ b/app/views/super_admin/organisations/index.html.erb
@@ -11,7 +11,16 @@
 </h3>
 
 <div class="govuk-!-margin-top-1"><%= link_to 'Download all service emails', super_admin_organisations_path(format: 'csv'), class: "govuk-link" %></div>
-<p><input type="search" id="filter-input" placeholder="Search by organisation name" class="govuk-input"></p>
+<p>
+  <input type="search" id="filter-text-input" placeholder="Search by Organisation name" class="govuk-input filter-input filter-text-input">
+  <select id="filter-field-input" class="govuk-input filter-input filter-field-input">
+    <option value="0">Organisation name</option>
+    <option value="1">Created on</option>
+    <option value="2">MOU signed</option>
+    <option value="3">Locations</option>
+    <option value="4">IPs</option>
+  </select>
+</p>
 
 <table class="govuk-table">
   <thead class="govuk-table__head">
@@ -29,20 +38,20 @@
         <td class="govuk-table__cell govuk-!-width-one-half" scope="row">
           <%= link_to organisation.name, super_admin_organisation_path(organisation), class: "govuk-link filter-by" %>
         </td>
-        <td class="govuk-table__cell" scope="row">
+        <td class="govuk-table__cell filter-by" scope="row">
           <%= organisation.created_at.strftime('%e %b %Y') %>
         </td>
-        <td class="govuk-table__cell govuk-table__cell" scope="row">
+        <td class="govuk-table__cell govuk-table__cell filter-by" scope="row">
           <% if organisation.signed_mou.attached? %>
             <%= organisation.signed_mou.attachment.created_at.strftime('%e %b %Y') %>
           <% else %>
             -
           <% end %>
         </td>
-        <td class="govuk-table__cell govuk-table__cell--numeric" scope="row">
+        <td class="govuk-table__cell govuk-table__cell--numeric filter-by" scope="row">
           <%= organisation.locations.count %>
         </td>
-        <td class="govuk-table__cell govuk-table__cell--numeric" scope="row">
+        <td class="govuk-table__cell govuk-table__cell--numeric filter-by" scope="row">
           <%= organisation.ips.count %>
         </td>
       </tr>

--- a/spec/features/super_admin/locations/locations_spec.rb
+++ b/spec/features/super_admin/locations/locations_spec.rb
@@ -6,7 +6,7 @@ describe 'View and search locations', type: :feature do
     create(:location, address: '69 Garry Street, London', postcode: 'HA7 2BL', organisation: organisation)
     sign_in_user user
     visit root_path
-    click_on 'Locations'
+    within('.subnav') { click_on 'Locations' }
   end
 
   it 'takes the user to the locations page' do

--- a/spec/features/super_admin/organisations/sort_organisation_list_spec.rb
+++ b/spec/features/super_admin/organisations/sort_organisation_list_spec.rb
@@ -63,5 +63,50 @@ describe 'Sorting the organisations list', type: :feature do
         expect(page.body).to match(/Gov Org 3.*Gov Org 1.*Gov Org 4/m)
       end
     end
+
+    context 'when sorting by location count' do
+      before do
+        create(:location, organisation: Organisation.find_by(name: 'Gov Org 1'))
+        org3 = Organisation.find_by(name: 'Gov Org 3')
+        create(:location, organisation: org3)
+        create(:location, organisation: org3)
+      end
+
+      it 'sorts the list by number of locations ascending' do
+        within('.govuk-table__head') { click_link 'Locations' }
+
+        expect(page.text).to match(/Gov Org 2.*Gov Org 1.*Gov Org 3/)
+      end
+
+      it 'sorts the list by number of locations descending' do
+        within('.govuk-table__head') { 2.times { click_link 'Locations' } }
+
+        expect(page.text).to match(/Gov Org 3.*Gov Org 1.*Gov Org 2/)
+      end
+    end
+
+    context 'when sorting by ip count' do
+      before do
+        location1 = create(:location, organisation: Organisation.find_by(name: 'Gov Org 1'))
+        org3 = Organisation.find_by(name: 'Gov Org 3')
+        create(:location, organisation: org3)
+        location3 = create(:location, organisation: org3)
+        create(:ip, location: location1)
+        create(:ip, location: location1)
+        create(:ip, location: location3)
+      end
+
+      it 'sorts the list by number of ips ascending' do
+        within('.govuk-table__head') { click_link 'IPs' }
+
+        expect(page.text).to match(/Gov Org 2.*Gov Org 3.*Gov Org 1/)
+      end
+
+      it 'sorts the list by number of ips descending' do
+        within('.govuk-table__head') { 2.times { click_link 'IPs' } }
+
+        expect(page.text).to match(/Gov Org 1.*Gov Org 3.*Gov Org 2/)
+      end
+    end
   end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -98,4 +98,89 @@ describe Organisation do
       ])
     end
   end
+
+  describe 'sortable_with_child_counts scope' do
+    subject(:sorted_results) { described_class.sortable_with_child_counts(sort_column, sort_direction) }
+
+    let(:first_organisation) { create(:organisation, name: 'An org', created_at: 1.day.ago) }
+    let(:second_organisation) { create(:organisation, name: 'This org', created_at: 2.days.ago) }
+    let(:first_location) { create(:location, organisation: first_organisation) }
+    let(:second_location) { create(:location, organisation: second_organisation) }
+    let(:third_location) { create(:location, organisation: second_organisation) }
+    let(:first_ip) { create(:ip, location: first_location) }
+    let(:second_ip) { create(:ip, location: first_location) }
+    let(:third_ip) { create(:ip, location: second_location) }
+    let(:fourth_ip) { create(:ip, location: third_location) }
+    let(:sort_direction) { 'asc' }
+
+    before do
+      allow(described_class).to receive(:fetch_organisations_from_register)
+        .and_return(['An org', 'This org'])
+
+      first_location.ips = [first_ip, second_ip]
+      second_location.ips << third_ip
+      third_location.ips << fourth_ip
+
+      first_organisation.locations << first_location
+      second_organisation.locations = [second_location, third_location]
+
+      first_organisation.signed_mou.attach(
+        io: File.open(Rails.root + "spec/fixtures/mou.pdf"), filename: "mou.pdf"
+      )
+      second_organisation.signed_mou.attach(
+        io: File.open(Rails.root + "spec/fixtures/mou.pdf"), filename: "mou.pdf"
+      )
+
+      second_organisation.signed_mou_attachment.update(created_at: 3.months.ago)
+    end
+
+    context 'when sorting by name' do
+      let(:sort_column) { 'name' }
+
+      it 'orders results alphabetically' do
+        expect(sorted_results).to eq([first_organisation, second_organisation])
+      end
+    end
+
+    context 'when sorting by created_at' do
+      let(:sort_column) { 'created_at' }
+
+      it 'orders results by date' do
+        expect(sorted_results).to eq([second_organisation, first_organisation])
+      end
+    end
+
+    context 'when sorting by signed mou' do
+      let(:sort_column) { 'active_storage_attachments.created_at' }
+
+      it 'orders results by date mou was signed' do
+        expect(sorted_results).to eq([second_organisation, first_organisation])
+      end
+    end
+
+    context 'when sorting by locations_count' do
+      let(:sort_column) { 'locations_count' }
+
+      it 'orders results by number of locations' do
+        expect(sorted_results).to eq([first_organisation, second_organisation])
+      end
+    end
+
+    context 'when sorting by ips_count' do
+      let(:sort_column) { 'ips_count' }
+
+      it 'orders results by number of ips' do
+        expect(sorted_results).to eq([first_organisation, second_organisation])
+      end
+    end
+
+    context 'when sorting in descending order' do
+      let(:sort_column) { 'locations_count' }
+      let(:sort_direction) { 'desc' }
+
+      it 'orders results in descending order' do
+        expect(sorted_results).to eq([first_organisation, second_organisation])
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/wOXIzpOb/42-make-super-admin-organisations-view-of-organisations-list-sortable-filterable

Makes all table cells filterable by the specified field.

![Screenshot from 2019-07-16 16-20-37](https://user-images.githubusercontent.com/93511/61307130-ab9c3000-a7e5-11e9-877a-234e2fb0009d.png)
