### PR TITLE
Add admin support link for logged in admins

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -64,7 +64,7 @@ class HelpController < ApplicationController
 private
 
   def redirect_signed_in_user
-    return redirect_to signed_in_new_help_path if current_user
+    redirect_to signed_in_new_help_path if current_user
   end
 
   def support_form_params

--- a/app/views/application/_subnavigation.html.erb
+++ b/app/views/application/_subnavigation.html.erb
@@ -6,7 +6,7 @@
     </p>
   </div>
 
-  <div class='govuk-grid-column-two-thirds govuk-grid-column-one-half-from-desktop govuk-!-padding-0 nav-links'>
+  <div class='govuk-grid-column-two-thirds govuk-!-padding-0 nav-links'>
     <nav class='govuk-body govuk-!-margin-bottom-0'>
       <% if super_admin? %>
         <%= link_to 'Locations', super_admin_locations_path, class: active_tab(super_admin_locations_path) %>
@@ -14,6 +14,7 @@
         <%= link_to 'Whitelist', new_super_admin_whitelist_path, class: active_tab('whitelist') %>
         <%= link_to 'MOU', super_admin_mou_index_path, class: active_tab(super_admin_mou_index_path) %>
         <%= link_to 'Logs', new_logs_search_path, class: active_tab('logs') %>
+        <%= link_to 'Admin Support', signed_in_new_help_path, class: active_tab('support') %>
       <% else %>
         <%= link_to 'Overview', overview_index_path, class: active_tab(overview_index_path) %>
         <% if current_organisation&.ips&.empty? %>
@@ -24,6 +25,7 @@
         <%= link_to 'IPs', ips_path, id: 'nav-ips', class: active_tab('ips') + active_tab('locations') %>
         <%= link_to 'Logs', new_logs_search_path, class: active_tab('logs') %>
         <%= link_to 'Team', memberships_path, class: active_tab('team') + active_tab('user') %>
+        <%= link_to 'Admin Support', signed_in_new_help_path, class: active_tab('support') %>
       <% end %>
     </nav>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,6 +68,7 @@
                 <strong class="govuk-tag govuk-phase-banner__content__tag beta-logo">
                   beta
                 </strong>
+              </span>
             </span>
           <% end %>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -85,11 +85,7 @@
                 <%= link_to 'Offer GovWifi', SITE_CONFIG['organisation_docs_link'], class: "govuk-header__link" %>
               </li>
               <li class="govuk-header__navigation-item">
-                <% if user_signed_in? %>
-                  <%= link_to 'Support', signed_in_new_help_path, class: "govuk-header__link #{active_tab(signed_in_new_help_path)}" %>
-                <% else %>
-                  <%= link_to 'Support', new_help_path, class: "govuk-header__link #{active_tab(new_help_path)}" %>
-                <% end %>
+                <%= link_to 'Support', SITE_CONFIG['support_link'], class: "govuk-header__link" %>
               </li>
               <% if user_signed_in? %>
                 <li class="govuk-header__navigation-item">

--- a/config/site.yml
+++ b/config/site.yml
@@ -2,6 +2,7 @@ default: &default
   end_user_docs_link: 'https://www.gov.uk/government/collections/connect-to-govwifi'
   end_user_troubleshooting_link: 'https://www.gov.uk/guidance/solve-problems-with-connecting-to-govwifi'
   organisation_docs_link: 'https://docs.wifi.service.gov.uk'
+  support_link: 'https://www.wifi.service.gov.uk/support'
   connect_to_govwifi_link: 'https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi'
   cookies_docs_link: 'https://www.wifi.service.gov.uk/cookies'
   product_page_link: 'https://wifi.service.gov.uk'


### PR DESCRIPTION
## What

The black top navigation bar for GovWifi has a link titled "Support". Currently, it works in a confusing way:

#### Expected behaviour
If you're logged in as an admin, the link is supposed to take you to the **support contact form** (i.e. https://admin.wifi.service.gov.uk/help/new/signed_in). Otherwise, it is supposed to take you to the **product support page** (https://www.wifi.service.gov.uk/support/).

#### Actual behaviour
The link works as per the expected flow, except when you're **not** logged in as an admin but on the admin login page where it still takes you to the **support contact form**.

## Task

Make the "Support" link on the black top navigation bar always take you to the **product support page**, regardless of whether a user is logged in as an admin or not.

Add a new "Admin Support" link specifically for logged in admins, to the end of the current admin portal navigation (see screenshot), which would take you to **support contact form**.

**Before**
<img width="986" alt="GovWifi_Admin" src="https://user-images.githubusercontent.com/3193694/61448026-0484d900-a94a-11e9-9819-b5473a668f51.png">

**After**
<img width="986" alt="GovWifi_Admin" src="https://user-images.githubusercontent.com/3193694/61448534-f4b9c480-a94a-11e9-9e2b-9aae055f82eb.png">
