### PR TITLE
Add more realistic seed data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,8 +4,8 @@ require 'faker'
 
 CustomOrganisationName.create(name: 'GovWifi Super Administrators')
 
-def create_user_for_organisation(
-  organisation,
+def create_user_for_organisations(
+  organisations,
   email: nil,
   confirmed_at: nil
 )
@@ -17,48 +17,42 @@ def create_user_for_organisation(
     password: "password",
     name: first_name + " " + last_name,
     confirmed_at:  confirmed_at,
-    organisations: [organisation]
+    organisations: organisations
   )
 end
 
 super_admin_organisation = Organisation.create!(
   name: 'GovWifi Super Administrators', service_email: 'it@gds.com', super_admin: true
 )
+organisation = Organisation.create(
+  name: 'UKTI Education', service_email: 'it@parks.com'
+)
+empty_organisation = Organisation.create(
+  name: 'Academy for Social Justice Commissioning', service_email: 'empty@example.net'
+)
 
-create_user_for_organisation(
-  super_admin_organisation,
+create_user_for_organisations(
+  [super_admin_organisation],
   email: 'admin@gov.uk',
   confirmed_at: Time.zone.now
 )
 
-organisation = Organisation.create(
-  name: 'UKTI Education', service_email: 'it@parks.com'
-)
-
-create_user_for_organisation(
-  organisation,
+create_user_for_organisations(
+  [organisation, empty_organisation],
   email: 'test@gov.uk',
   confirmed_at: Time.zone.now
 )
 
 3.times do
-  create_user_for_organisation(organisation, confirmed_at: Time.zone.now)
+  create_user_for_organisations([organisation], confirmed_at: Time.zone.now)
 end
 
 2.times do
-  create_user_for_organisation(organisation)
+  create_user_for_organisations([organisation])
 end
 
-empty_organisation = Organisation.create(
-  name: 'Empty organisation', service_email: 'empty@example.net'
-)
-create_user_for_organisation(
-  empty_organisation,
-  email: 'empty@gov.uk',
-  confirmed_at: Time.zone.now
-)
-
-location_zero = Location.create!(
+# Location with no IP addresses
+Location.create!(
   address: 'The White Chapel Building, London',
   postcode: 'E1 8QS',
   organisation_id: organisation.id

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,65 +4,100 @@ require 'faker'
 
 CustomOrganisationName.create(name: 'GovWifi Super Administrators')
 
+def create_user_for_organisation(
+  organisation,
+  email: nil,
+  confirmed_at: nil
+)
+  first_name = Faker::Name.first_name
+  last_name = Faker::Name.last_name
+  email = email || first_name + "." + last_name + "@example.gov.uk"
+  User.create(
+    email: email,
+    password: "password",
+    name: first_name + " " + last_name,
+    confirmed_at:  confirmed_at,
+    organisations: [organisation]
+  )
+end
+
 super_admin_organisation = Organisation.create!(
   name: 'GovWifi Super Administrators', service_email: 'it@gds.com', super_admin: true
 )
 
-super_admin_organisation.users.create(
-  email: "admin@gov.uk",
-  password: "password",
-  name: "Steve",
+create_user_for_organisation(
+  super_admin_organisation,
+  email: 'admin@gov.uk',
   confirmed_at: Time.zone.now
 )
 
 organisation = Organisation.create(
   name: 'UKTI Education', service_email: 'it@parks.com'
 )
-organisation.users.create(
-  email: "test@gov.uk",
-  password: "password",
-  name: "Steve",
+
+create_user_for_organisation(
+  organisation,
+  email: 'test@gov.uk',
   confirmed_at: Time.zone.now
 )
 
 3.times do
-  User.create(
-    email: Faker::Name.first_name + "@gov.uk",
-    password: "password",
-    name: Faker::Name.name,
-    confirmed_at: Time.zone.now,
-    organisations: [organisation]
-  )
+  create_user_for_organisation(organisation, confirmed_at: Time.zone.now)
 end
 
 2.times do
-  User.create(
-    email: Faker::Name.first_name + "@gov.uk",
-    password: "password",
-    name: Faker::Name.name,
-    confirmed_at: nil,
-    organisations: [organisation]
-  )
+  create_user_for_organisation(organisation)
 end
+
+empty_organisation = Organisation.create(
+  name: 'Empty organisation', service_email: 'empty@example.net'
+)
+create_user_for_organisation(
+  empty_organisation,
+  email: 'empty@gov.uk',
+  confirmed_at: Time.zone.now
+)
+
+location_zero = Location.create!(
+  address: 'The White Chapel Building, London',
+  postcode: 'E1 8QS',
+  organisation_id: organisation.id
+)
 
 location_one = Location.create!(
   address: 'Momentum Centre, London',
-  postcode: 'SE10SX',
+  postcode: 'SE1 0SX',
   organisation_id: organisation.id
 )
 
 location_two = Location.create!(
   address: '136 Southwark Street, London',
-  postcode: 'E33EH',
+  postcode: 'E3 3EH',
   organisation_id: organisation.id
 )
 
-20.times do
-  Ip.create!(address: Faker::Internet.unique.public_ip_v4_address, location: location_one)
+10.times do
+  Ip.create!(
+    address: Faker::Internet.unique.public_ip_v4_address,
+    location: location_one,
+    created_at: [Time.now, (Time.now - 1.day)].sample
+  )
 end
 
-20.times do
-  Ip.create!(address: Faker::Internet.unique.public_ip_v4_address, location: location_two)
+3.times do
+  Ip.create!(
+    address: Faker::Internet.unique.public_ip_v4_address,
+    location: location_two
+  )
+end
+
+location_one.ips.each_with_index do |ip, index|
+  Session.create(
+    start: (Time.now - (index + 5).day).to_s,
+    success: index.even?,
+    username: "Gerry",
+    siteIP: ip.address
+  )
 end
 
 location_two.ips.each_with_index do |ip, index|


### PR DESCRIPTION
In order to make some design changes to the locations page I need to be able to see all the various states of the page. This can be done by adding some more variety to the script that seeds the database.

This pull request:
- adds a user with no locations or IP addresses to show what it’s like when a user first signs up (switch to the _Academy for Social Justice Commissioning_ organisation to see this)
- adds a new, empty location to the existing organisation
- adds a more realistic number of IP addresses per location (based on looking at how many IP addresses real users create)
- creates some of the IP addresses in the past so they don’t all say ‘Available at 6am tomorrow’

Before | After 
---|---
![localhost_8080_ips(iPad) (1)](https://user-images.githubusercontent.com/355079/61446397-f71a1f80-a946-11e9-9a03-a4d02965b6fa.png) | ![localhost_8080_ips(iPad)](https://user-images.githubusercontent.com/355079/61446411-fed9c400-a946-11e9-8053-1ae3c09b9ccc.png)
