### PR TITLE
Export organisations list as csv

### DIFF
--- a/app/controllers/super_admin/organisations_controller.rb
+++ b/app/controllers/super_admin/organisations_controller.rb
@@ -1,6 +1,5 @@
 class SuperAdmin::OrganisationsController < SuperAdminController
   helper_method :sort_column, :sort_direction
-  CSV_HEADER = "email address".freeze
 
   def index
     @organisations = Organisation.sortable_with_child_counts(sort_column, sort_direction)
@@ -9,7 +8,13 @@ class SuperAdmin::OrganisationsController < SuperAdminController
 
     respond_to do |format|
       format.html
-      format.csv { send_data service_emails_csv, filename: "service_emails.csv" }
+      format.csv { send_data Organisation.all_as_csv, filename: "organisations.csv" }
+    end
+  end
+
+  def service_emails
+    respond_to do |format|
+      format.csv { send_data Organisation.service_emails_as_csv, filename: "service_emails.csv" }
     end
   end
 
@@ -27,11 +32,6 @@ class SuperAdmin::OrganisationsController < SuperAdminController
   end
 
 private
-
-  def service_emails_csv
-    service_emails = Organisation.pluck(:service_email)
-    service_emails.prepend(CSV_HEADER).join("\n")
-  end
 
   def sorted_team_members(organisation)
     UseCases::Administrator::SortUsers.new(

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -34,9 +34,20 @@ class Organisation < ApplicationRecord
   def self.all_as_csv
     CSV.generate do |csv|
       csv << CSV_HEADER
-      Organisation.sortable_with_child_counts('name', 'asc').map do |o|
+      Organisation.sortable_with_child_counts('name', 'asc').each do |o|
         mou_signed_at = o.signed_mou.attached? ? o.signed_mou.attachment.created_at : '-'
         csv << [o.name, o.created_at, mou_signed_at, o.locations_count, o.ips_count]
+      end
+    end
+  end
+
+  def self.service_emails_as_csv
+    CSV.generate do |csv|
+      csv << ['Service email address', 'Org name', 'User name', 'Created at']
+      Organisation
+        .select('organisations.*, users.name AS user_name')
+        .joins('LEFT OUTER JOIN users ON users.email = organisations.service_email').each do |o|
+        csv << [o.service_email, o.name, o.user_name, o.created_at]
       end
     end
   end

--- a/app/views/super_admin/organisations/index.html.erb
+++ b/app/views/super_admin/organisations/index.html.erb
@@ -10,7 +10,15 @@
   </span>
 </h3>
 
-<div class="govuk-!-margin-top-1"><%= link_to 'Download all service emails', super_admin_organisations_path(format: 'csv'), class: "govuk-link" %></div>
+<div class="govuk-!-margin-top-1">
+  <%= link_to 'Download all organisations in CSV format',
+      super_admin_organisations_path(format: 'csv'),
+      class: "govuk-link" %>
+  <br />
+  <%= link_to 'Download all service emails in CSV format',
+      service_emails_super_admin_organisations_path(format: 'csv'),
+      class: "govuk-link" %>
+</div>
 <p><input type="search" id="filter-input" placeholder="Search by organisation name" class="govuk-input"></p>
 
 <table class="govuk-table">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,11 @@ Rails.application.routes.draw do
       end
     end
     resources :mou, only: %i[index update create]
-    resources :organisations, only: %i[index show destroy]
+    resources :organisations, only: %i[index show destroy] do
+      collection do
+        get 'service_emails', to: 'organisations#service_emails', constraints: { format: 'csv' }
+      end
+    end
     resource :whitelist, only: %i[new create] do
       scope module: 'whitelists' do
         resources :email_domains, only: %i[index new create destroy]

--- a/spec/features/super_admin/organisations/view_organisation_list_spec.rb
+++ b/spec/features/super_admin/organisations/view_organisation_list_spec.rb
@@ -62,6 +62,14 @@ describe 'View a list of signed up organisations', type: :feature do
           expect(page).to have_content(org.signed_mou.attachment.created_at.strftime('%e %b %Y'))
         end
       end
+
+      it 'shows a link to download as CSV' do
+        expect(page).to have_link('Download all organisations in CSV format')
+      end
+
+      it 'shows a link to download service emails as CSV' do
+        expect(page).to have_link('Download all service emails in CSV format')
+      end
     end
 
     context 'with multiple organisations with multiple locations each' do

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -183,4 +183,64 @@ describe Organisation do
       end
     end
   end
+
+  describe '.all_as_csv' do
+    subject(:csv) { CSV.parse(described_class.all_as_csv, headers: true) }
+
+    let(:org1) { create(:organisation) }
+    let(:org2) { create(:organisation) }
+    let(:location1) { create(:location, organisation: org1) }
+    let(:location2) { create(:location, organisation: org1) }
+    let(:location3) { create(:location, organisation: org2) }
+    let(:ip1) { create(:ip, location: location1) }
+    let(:ip2) { create(:ip, location: location1) }
+    let(:ip3) { create(:ip, location: location1) }
+    let(:ip4) { create(:ip, location: location2) }
+    let(:ip5) { create(:ip, location: location3) }
+
+    before { ip1; ip2; ip3; ip4; ip5 }
+
+    it 'exports organisation names' do
+      expect(csv.first["Name"]).to eq(org1.name)
+    end
+
+    it 'exports organisation created dates' do
+      expect(csv.first["Created At"]).to eq(org1.created_at.to_s)
+    end
+
+    it 'exports location counts' do
+      expect(csv.first["Locations"]).to eq('2')
+    end
+
+    it 'exports IP counts' do
+      expect(csv.first["IPs"]).to eq('4')
+    end
+  end
+
+  describe '.service_emails_as_csv' do
+    subject(:csv) { CSV.parse(described_class.service_emails_as_csv, headers: true) }
+
+    let(:org1) { create(:organisation) }
+    let(:org2) { create(:organisation) }
+    let(:user1) { create(:user, email: org1.service_email) }
+    let(:user2) { create(:user, email: org2.service_email) }
+
+    before { user1; user2 }
+
+    it 'exports service email addresses for each organisation' do
+      expect(csv.first["Service email address"]).to eq(org1.service_email)
+    end
+
+    it 'exports organisation names' do
+      expect(csv.first["Org name"]).to eq(org1.name)
+    end
+
+    it 'exports the service admin user name' do
+      expect(csv.first["User name"]).to eq(user1.name)
+    end
+
+    it 'exports the organisation created date' do
+      expect(csv.first["Created at"]).to eq(org1.created_at.to_s)
+    end
+  end
 end

--- a/spec/requests/admin/organisations/get_spec.rb
+++ b/spec/requests/admin/organisations/get_spec.rb
@@ -1,17 +1,28 @@
 describe "GET /admin/organisations", type: :request do
-  let!(:organisation_1) { create(:organisation) }
-  let!(:organisation_2) { create(:organisation) }
+  let(:organisation_1) { create(:organisation) }
+  let(:organisation_2) { create(:organisation) }
   let(:user) { create(:user, :super_admin) }
+  let(:another_user) { create(:user, email: organisation_1.service_email) }
 
   before do
+    another_user; organisation_1; organisation_2
     login_as(user, scope: :user)
     https!
   end
 
   context 'when request format is CSV' do
-    it "gets all the service emails" do
+    it "gets all the organisations" do
       get super_admin_organisations_path(format: 'csv')
-      expect(response.body).to eq("email address\n#{organisation_1.service_email}\n#{organisation_2.service_email}\n#{user.organisations.first.service_email}")
+      csv_response = CSV.parse(response.body, headers: true)
+      expect(csv_response.first["Name"]).to eq(organisation_1.name)
+    end
+  end
+
+  context 'when requesting service emails as csv' do
+    it 'gets all the service emails' do
+      get service_emails_super_admin_organisations_path(format: 'csv')
+      csv_response = CSV.parse(response.body, headers: true)
+      expect(csv_response.first["Service email address"]).to eq(organisation_1.service_email)
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/4iIBUDdC/71-allow-superadmins-to-export-govwifi-organisations-information-as-csv

- Adds a link to export organisations list in CSV format
- Amends service email CSV to include useful fields for use with Notify

![Screenshot from 2019-07-19 17-08-29](https://user-images.githubusercontent.com/93511/61549421-dc7b9f80-aa47-11e9-9a83-636b5a79fa44.png)
