### PR TITLE
Fix selected state in left hand navigation

### DIFF
--- a/app/views/application/_left_navigation.html.erb
+++ b/app/views/application/_left_navigation.html.erb
@@ -30,10 +30,10 @@
         </li>
       <% end %>
       <li>
-        <%= link_to 'IP addresses', ips_path, id: 'nav-ips', class: active_tab('ips') + active_tab('locations') %>
+        <%= link_to 'IP addresses', ips_path, id: 'nav-ips', class: active_tab(ips_path) + active_tab('locations') %>
       </li>
       <li>
-        <%= link_to 'Team members', memberships_path, class: active_tab('team') + active_tab('user') %>
+        <%= link_to 'Team members', memberships_path, class: active_tab(memberships_path) + active_tab('/users') %>
       </li>
       <li>
         <%= link_to 'Logs', new_logs_search_path, class: active_tab('logs') %>


### PR DESCRIPTION
Because the word `memberships` contains the characters `ips` the _IP addresses_ navigation item was being selected when on the team members page.

This adds the leading slash to the matching string to make things a bit more strict and make sure the right navigation item is selected for the right URL.