### PR TITLE
Rationalise the locations page

### DIFF
--- a/app/assets/stylesheets/components/ip_address.scss
+++ b/app/assets/stylesheets/components/ip_address.scss
@@ -1,0 +1,14 @@
+.ip-address {
+
+  @include govuk-font($size: false, $tabular: true);
+  letter-spacing: 0.03em;
+
+  &-separator {
+    @include govuk-font($size: false, $tabular: true, $weight: bold);
+    display: inline-block;
+    padding: 0 2px;
+    position: relative;
+    top: -0.05em;
+  }
+
+}

--- a/app/assets/stylesheets/components/key.scss
+++ b/app/assets/stylesheets/components/key.scss
@@ -1,0 +1,11 @@
+.secret-key {
+
+  @include govuk-font($size: false, $tabular: true);
+  letter-spacing: 0.03em;
+
+  &-rotate-link {
+    display: inline-block;
+    padding-left: 15px;
+  }
+
+}

--- a/app/assets/stylesheets/components/result_row.scss
+++ b/app/assets/stylesheets/components/result_row.scss
@@ -2,4 +2,11 @@
   tbody {
     border-top: 1px solid $govuk-border-colour;
   }
+
+  &-empty {
+    border-top: 1px solid $govuk-border-colour;
+    border-bottom: 1px solid $govuk-border-colour;
+    padding: 10px 20px 10px 0;
+    color: $govuk-secondary-text-colour;
+  }
 }

--- a/app/assets/stylesheets/components/result_row.scss
+++ b/app/assets/stylesheets/components/result_row.scss
@@ -1,0 +1,5 @@
+.result-row {
+  tbody {
+    border-top: 1px solid $govuk-border-colour;
+  }
+}

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -17,6 +17,10 @@ class Location < ApplicationRecord
     "#{address}, #{postcode}"
   end
 
+  def sorted_ip_addresses
+    ips.sort_by { |ip| ip.address.split('.').map(&:to_i) }
+  end
+
 private
 
   def validate_postcode

--- a/app/views/application/_left_navigation.html.erb
+++ b/app/views/application/_left_navigation.html.erb
@@ -30,7 +30,7 @@
         </li>
       <% end %>
       <li>
-        <%= link_to 'IP addresses', ips_path, id: 'nav-ips', class: active_tab(ips_path) + active_tab('locations') %>
+        <%= link_to 'Locations', ips_path, id: 'nav-ips', class: active_tab(ips_path) + active_tab('locations') %>
       </li>
       <li>
         <%= link_to 'Team members', memberships_path, class: active_tab(memberships_path) + active_tab('/users') %>

--- a/app/views/application/_radius_details.html.erb
+++ b/app/views/application/_radius_details.html.erb
@@ -18,14 +18,14 @@
     <h3> London: </h3>
     <ul class="plain-list" id="london-radius-ips">
       <% london_ips.each do |ip| %>
-        <li><p class="govuk-body"><span class="ip-address"><% ip.split('.')[0...-1].each do |chunk| -%><%= chunk -%><span class="ip-address-separator">.</span><% end -%><%= ip.split('.').last %></span></li>
+        <li><p class="govuk-body"><%= render partial: 'ips/ip_address', locals: { ip: ip } %></li>
       <% end %>
     </ul>
 
     <h3> Dublin: </h3>
     <ul class="plain-list" id="dublin-radius-ips">
       <% dublin_ips.each do |ip| %>
-        <li><p class="govuk-body"><span class="ip-address"><% ip.split('.')[0...-1].each do |chunk| -%><%= chunk -%><span class="ip-address-separator">.</span><% end -%><%= ip.split('.').last %></span></li>
+        <li><p class="govuk-body"><%= render partial: 'ips/ip_address', locals: { ip: ip } %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/application/_radius_details.html.erb
+++ b/app/views/application/_radius_details.html.erb
@@ -18,14 +18,14 @@
     <h3> London: </h3>
     <ul class="plain-list" id="london-radius-ips">
       <% london_ips.each do |ip| %>
-        <li><p class="govuk-body"> <%= ip %></li>
+        <li><p class="govuk-body"><span class="ip-address"><% ip.split('.')[0...-1].each do |chunk| -%><%= chunk -%><span class="ip-address-separator">.</span><% end -%><%= ip.split('.').last %></span></li>
       <% end %>
     </ul>
 
     <h3> Dublin: </h3>
     <ul class="plain-list" id="dublin-radius-ips">
       <% dublin_ips.each do |ip| %>
-        <li><p class="govuk-body"> <%= ip %></li>
+        <li><p class="govuk-body"><span class="ip-address"><% ip.split('.')[0...-1].each do |chunk| -%><%= chunk -%><span class="ip-address-separator">.</span><% end -%><%= ip.split('.').last %></span></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/ips/_confirm_remove_ip.html.erb
+++ b/app/views/ips/_confirm_remove_ip.html.erb
@@ -8,7 +8,7 @@
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <td class="govuk-table__cell govuk-!-width-one-third">IP Address</td>
-          <td class="govuk-table__cell govuk-!-width-one-third"><%= @ip_to_delete.address %></td>
+          <td class="govuk-table__cell govuk-!-width-one-third"><span class="ip-address"><% @ip_to_delete.address.split('.')[0...-1].each do |chunk| -%><%= chunk -%><span class="ip-address-separator">.</span><% end -%><%= @ip_to_delete.address.split('.').last %></span></td>
         </tr>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell govuk-!-width-one-third">From Location</td>

--- a/app/views/ips/_confirm_remove_ip.html.erb
+++ b/app/views/ips/_confirm_remove_ip.html.erb
@@ -8,7 +8,9 @@
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <td class="govuk-table__cell govuk-!-width-one-third">IP Address</td>
-          <td class="govuk-table__cell govuk-!-width-one-third"><span class="ip-address"><% @ip_to_delete.address.split('.')[0...-1].each do |chunk| -%><%= chunk -%><span class="ip-address-separator">.</span><% end -%><%= @ip_to_delete.address.split('.').last %></span></td>
+          <td class="govuk-table__cell govuk-!-width-one-third">
+            <%= render partial: 'ip_address', locals: { ip: @ip_to_delete.address } %>
+          </td>
         </tr>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell govuk-!-width-one-third">From Location</td>

--- a/app/views/ips/_ip_address.html.erb
+++ b/app/views/ips/_ip_address.html.erb
@@ -1,0 +1,1 @@
+<span class="ip-address"><% ip.split('.')[0...-1].each do |chunk| -%><%= chunk -%><span class="ip-address-separator">.</span><% end -%><%= ip.split('.').last %></span>

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -25,29 +25,28 @@
   <tbody class="govuk-table__body" id="ips-table">
     <% location.ips.each do |ip| %>
       <tr class="govuk-table__row" id="ips-row-<%= ip.id %>">
-        <td class="govuk-table__cell govuk-!-width-one-quarter">
+        <td class="govuk-table__cell govuk-!-width-one-third">
           <span class="ip-address"><% ip.address.split('.')[0...-1].each do |chunk| -%><%= chunk -%><span class="ip-address-separator">.</span><% end -%><%= ip.address.split('.').last %></span>
         </td>
         <% if ip.available? %>
-          <td class="govuk-table__cell govuk-!-width-one-quarter">Available</td>
+          <td class="govuk-table__cell ">
+            <% if ip.unused? %>
+              No traffic received yet
+            <% elsif ip.inactive? %>
+              No traffic in the last 10 days
+            <% else %>
+              Receiving traffic (<%= link_to 'view logs', logs_path(ip: ip.address), class: "govuk-link" %>)
+            <% end %>
+          </td>
         <% else %>
-          <td class="govuk-table__cell govuk-!-width-one-quarter text-red">Not available until 6am tomorrow
+          <td class="govuk-table__cell text-light-grey">
+            Available at 6am tomorrow
           </td>
         <% end %>
-        <td class="govuk-table__cell govuk-!-width-one-quarter text-red">
-          <% if ip.unused? %>
-            No traffic received yet
-          <% elsif ip.inactive? %>
-            No traffic for the last 10 days
-          <% end %>
-        </td>
         <td class="govuk-table__cell text-right">
           <% if current_user.can_manage_locations?(current_organisation) %>
             <%= link_to 'Remove', ip_remove_path(ip), class: "govuk-link" %>
           <% end %>
-        </td>
-        <td class="govuk-table__cell text-right">
-          <%= link_to 'View logs', logs_path(ip: ip.address), class: "govuk-link" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -29,7 +29,7 @@
     <% location.sorted_ip_addresses.each do |ip| %>
       <tr class="govuk-table__row" id="ips-row-<%= ip.id %>">
         <td class="govuk-table__cell govuk-!-width-one-third">
-          <span class="ip-address"><% ip.address.split('.')[0...-1].each do |chunk| -%><%= chunk -%><span class="ip-address-separator">.</span><% end -%><%= ip.address.split('.').last %></span>
+          <%= render partial: 'ip_address', locals: { ip: ip.address } %>
         </td>
         <% if ip.available? %>
           <td class="govuk-table__cell ">

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -43,7 +43,7 @@
         <% end %>
         <td class="govuk-table__cell text-right">
           <% if current_user.can_manage_locations?(current_organisation) %>
-            <%= link_to 'Remove', ip_remove_path(ip), class: "govuk-link" %>
+            <%= link_to 'Remove', ip_remove_path(ip), class: "govuk-link govuk-link--no-visited-state" %>
           <% end %>
         </td>
       </tr>

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -21,7 +21,7 @@
   </caption>
 
   <tbody class="govuk-table__body" id="ips-table">
-    <% location.ips.each do |ip| %>
+    <% location.sorted_ip_addresses.each do |ip| %>
       <tr class="govuk-table__row" id="ips-row-<%= ip.id %>">
         <td class="govuk-table__cell govuk-!-width-one-third">
           <span class="ip-address"><% ip.address.split('.')[0...-1].each do |chunk| -%><%= chunk -%><span class="ip-address-separator">.</span><% end -%><%= ip.address.split('.').last %></span>

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -6,11 +6,10 @@
     <div class="govuk-body govuk-!-margin-bottom-2">
       RADIUS secret key:
       <div class="inline-block">
-        <%= location.radius_secret_key %>
+        <%= location.radius_secret_key %><% if current_user.can_manage_locations?(current_organisation) %>&ensp;<%= link_to 'Rotate secret key', location_rotate_key_path(location, rotate: true), class: "red-link" %><% end %>
       </div>
     </div>
     <% if current_user.can_manage_locations?(current_organisation) %>
-      <%= link_to 'Rotate secret key', location_rotate_key_path(location, rotate: true), class: "govuk-button red-button" %>
       <p class="govuk-body govuk-!-margin-bottom-1">
         <%= link_to "Add IP to this location", new_ip_path(location: location), class: "govuk-link" %>
       </p>

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -6,11 +6,11 @@
     <div class="govuk-body govuk-!-margin-bottom-2">
       RADIUS secret key:
       <div class="inline-block">
-        <%= location.radius_secret_key %><% if current_user.can_manage_locations?(current_organisation) %>&ensp;<%= link_to 'Rotate secret key', location_rotate_key_path(location, rotate: true), class: "red-link" %><% end %>
+        <span class="secret-key"><%= location.radius_secret_key %></span><% if current_user.can_manage_locations?(current_organisation) %><%= link_to 'Rotate secret key', location_rotate_key_path(location, rotate: true), class: "red-link secret-key-rotate-link" %><% end %>
       </div>
     </div>
     <% if current_user.can_manage_locations?(current_organisation) %>
-      <%= link_to "Add an IP addresss to this location", new_ip_path(location: location), class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-4" %>
+      <%= link_to "Add an IP addresss to this location", new_ip_path(location: location), class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-5" %>
     <% end %>
 
     <% if current_user.can_manage_locations?(current_organisation) && location.ips.empty? %>

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -17,7 +17,7 @@
 
     <% if current_user.can_manage_locations?(current_organisation) && location.ips.empty? %>
       <p class="govuk-body govuk-!-margin-bottom-1">
-        <%= link_to 'Remove this location', location_remove_path(location, remove: true), class: "govuk-link" %>
+        <%= link_to 'Remove this location', location_remove_path(location, remove: true), class: "red-link" %>
       </p>
     <% end %>
   </caption>

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -10,9 +10,7 @@
       </div>
     </div>
     <% if current_user.can_manage_locations?(current_organisation) %>
-      <p class="govuk-body govuk-!-margin-bottom-1">
-        <%= link_to "Add IP to this location", new_ip_path(location: location), class: "govuk-link" %>
-      </p>
+      <%= link_to "Add an IP addresss to this location", new_ip_path(location: location), class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-4" %>
     <% end %>
 
     <% if current_user.can_manage_locations?(current_organisation) && location.ips.empty? %>

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -10,7 +10,12 @@
       </div>
     </div>
     <% if current_user.can_manage_locations?(current_organisation) %>
-      <%= link_to "Add an IP addresss to this location", new_ip_path(location: location), class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-5" %>
+      <%= link_to "Add IP addressses", new_ip_path(location: location), class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-5" %>
+      <% if location.ips.empty? %>
+        <p class="result-row-empty govuk-body">
+          Add the IP addresses of your authenticators to offer GovWifi at this location
+        </p>
+      <% end %>
     <% end %>
 
     <% if current_user.can_manage_locations?(current_organisation) && location.ips.empty? %>

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -26,7 +26,9 @@
   <tbody class="govuk-table__body" id="ips-table">
     <% location.ips.each do |ip| %>
       <tr class="govuk-table__row" id="ips-row-<%= ip.id %>">
-        <td class="govuk-table__cell govuk-!-width-one-quarter"><%= ip.address %></td>
+        <td class="govuk-table__cell govuk-!-width-one-quarter">
+          <% ip.address.split('.')[0...-1].each do |chunk| -%><%= chunk -%>.<% end -%><%= ip.address.split('.').last %>
+        </td>
         <% if ip.available? %>
           <td class="govuk-table__cell govuk-!-width-one-quarter">Available</td>
         <% else %>

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -27,7 +27,7 @@
     <% location.ips.each do |ip| %>
       <tr class="govuk-table__row" id="ips-row-<%= ip.id %>">
         <td class="govuk-table__cell govuk-!-width-one-quarter">
-          <% ip.address.split('.')[0...-1].each do |chunk| -%><%= chunk -%>.<% end -%><%= ip.address.split('.').last %>
+          <span class="ip-address"><% ip.address.split('.')[0...-1].each do |chunk| -%><%= chunk -%><span class="ip-address-separator">.</span><% end -%><%= ip.address.split('.').last %></span>
         </td>
         <% if ip.available? %>
           <td class="govuk-table__cell govuk-!-width-one-quarter">Available</td>

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -1,6 +1,6 @@
-<table class="govuk-table result-row">
+<table class="govuk-table result-row govuk-!-margin-bottom-7">
   <caption class="govuk-table__caption text-left govuk-!-font-size-24">
-    <div class="filter-by">
+    <div class="filter-by govuk-!-margin-bottom-2">
       <%= location.full_address %>
     </div>
     <div class="govuk-body govuk-!-margin-bottom-2">

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -18,9 +18,11 @@
     </div>
   </div>
 
-  <div class="govuk-!-padding-bottom-7">
-    <input type="search" id="filter-input" placeholder="Search by location or postcode" class="govuk-input">
-  </div>
+  <% if current_organisation.locations.length > 1 %>
+    <div class="govuk-!-padding-bottom-7">
+      <input type="search" id="filter-input" placeholder="Search by location or postcode" class="govuk-input">
+    </div>
+  <% end %>
 
   <% if current_organisation.locations.empty? %>
     <p class="govuk-body">

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -5,7 +5,7 @@
     <%= render "confirm_rotate_radius_key" if @key_to_rotate && current_user.can_manage_locations?(current_organisation) %>
 
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">IP addresses</h1>
+      <h1 class="govuk-heading-l">Locations</h1>
     </div>
     <div class="govuk-grid-column-one-third text-right">
       <% if current_user.can_manage_locations?(current_organisation) %>

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -5,18 +5,21 @@
     <%= render "confirm_rotate_radius_key" if @key_to_rotate && current_user.can_manage_locations?(current_organisation) %>
 
     <div class="govuk-grid-column-two-thirds">
-      <input type="search" id="filter-input" placeholder="Search by location or postcode" class="govuk-input">
-      <h1 class="govuk-heading-l  govuk-!-padding-top-5">IP addresses</h1>
+      <h1 class="govuk-heading-l">IP addresses</h1>
     </div>
     <div class="govuk-grid-column-one-third text-right">
       <% if current_user.can_manage_locations?(current_organisation) %>
         <% if current_organisation.locations.empty? %>
-          <%= link_to 'Add IP address', new_location_path, class: "govuk-button" %>
+          <%= link_to 'Add IP address', new_location_path, class: "govuk-button govuk-!-margin-bottom-0" %>
         <% else %>
-          <%= link_to 'Add IP address', new_ip_path, class: "govuk-button" %>
+          <%= link_to 'Add IP address', new_ip_path, class: "govuk-button govuk-!-margin-bottom-0" %>
         <% end %>
       <% end %>
     </div>
+  </div>
+
+  <div class="govuk-!-padding-bottom-6">
+    <input type="search" id="filter-input" placeholder="Search by location or postcode" class="govuk-input">
   </div>
 
   <% if current_organisation.locations.empty? %>

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -21,11 +21,9 @@
   <% end %>
 
   <% if current_organisation.locations.empty? %>
-    <p class="govuk-body">
-      You need to add the IPs of your authenticator(s).
+    <p class="govuk-body result-row-empty">
+      You need to add at least one location to offer GovWifi
     </p>
-    <p class="govuk-body">If your authenticators are allocated IPs dynamically, you can use Firewall NAT rules, so that your requests come from consistent IPs.</p>
-
   <% else %>
     <p class="govuk-body" id="no-results" style="display: none">
       <strong>No results found</strong>

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -18,7 +18,7 @@
     </div>
   </div>
 
-  <div class="govuk-!-padding-bottom-6">
+  <div class="govuk-!-padding-bottom-7">
     <input type="search" id="filter-input" placeholder="Search by location or postcode" class="govuk-input">
   </div>
 

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -9,11 +9,7 @@
     </div>
     <div class="govuk-grid-column-one-third text-right">
       <% if current_user.can_manage_locations?(current_organisation) %>
-        <% if current_organisation.locations.empty? %>
-          <%= link_to 'Add IP address', new_location_path, class: "govuk-button govuk-!-margin-bottom-0" %>
-        <% else %>
-          <%= link_to 'Add IP address', new_ip_path, class: "govuk-button govuk-!-margin-bottom-0" %>
-        <% end %>
+        <%= link_to 'Add a location', new_location_path, class: "govuk-button govuk-!-margin-bottom-0" %>
       <% end %>
     </div>
   </div>

--- a/app/views/locations/new.erb
+++ b/app/views/locations/new.erb
@@ -24,10 +24,10 @@
     <% if current_organisation.locations.empty? %>
       <h2 class='govuk-heading-l'>Add your first location and IP addresses</h2>
     <% else %>
-      <h2 class='govuk-heading-l'>Add a new location</h2>
+      <h2 class='govuk-heading-l'>Add a location</h2>
     <% end %>
   </div>
-  <div class='govuk-grid-column-two-thirds'>
+  <div class='govuk-grid-column-full'>
     <%= form_for @location, html: { autocomplete: "off" } do |f| %>
       <div class="govuk-form-group">
         <%= f.label :address, class: 'govuk-label' %>

--- a/app/views/locations/new.erb
+++ b/app/views/locations/new.erb
@@ -31,10 +31,13 @@
     <%= form_for @location, html: { autocomplete: "off" } do |f| %>
       <div class="govuk-form-group">
         <%= f.label :address, class: 'govuk-label' %>
+        <span class="govuk-hint">
+          For example, 10 High Street, London
+        </span>
         <% if @location.errors.keys.include?(:address) %>
-          <%= f.text_field :address, placeholder: "10 Example Street, London", class: 'govuk-input govuk-input--error' %>
+          <%= f.text_field :address, class: 'govuk-input govuk-input--error' %>
         <% else %>
-          <%= f.text_field :address, placeholder: "10 Example Street, London", class: 'govuk-input' %>
+          <%= f.text_field :address, class: 'govuk-input' %>
         <% end %>
       </div>
       <div class="govuk-form-group">

--- a/spec/features/ips/permissions_spec.rb
+++ b/spec/features/ips/permissions_spec.rb
@@ -23,7 +23,7 @@ describe 'Add an IP', type: :feature do
 
     it 'displays the add new IP link' do
       visit ips_path
-      expect(page).to have_link('Add IP address')
+      expect(page).to have_link('Add a location')
     end
 
     context 'when viewing homepage instructions' do

--- a/spec/features/ips/view_ip_address_readiness_spec.rb
+++ b/spec/features/ips/view_ip_address_readiness_spec.rb
@@ -16,7 +16,7 @@ describe 'Wiew whether IPs are ready', type: :feature do
       before { visit ips_path }
 
       it 'shows it is activating tomorrow' do
-        expect(page).to have_content('Not available until 6am tomorrow')
+        expect(page).to have_content('Available at 6am tomorrow')
       end
     end
 
@@ -30,7 +30,7 @@ describe 'Wiew whether IPs are ready', type: :feature do
       end
 
       it 'shows it as available' do
-        expect(page).to have_content('Available')
+        expect(page).to have_content('No traffic received yet')
       end
 
       it 'does not shpow any IPs as available tomorrow' do

--- a/spec/features/ips/view_ip_addresses_spec.rb
+++ b/spec/features/ips/view_ip_addresses_spec.rb
@@ -10,7 +10,7 @@ describe 'Viewing IP addresses', type: :feature do
 
     it 'shows no IPs' do
       visit ips_path
-      expect(page).to have_content 'You need to add the IPs of your authenticator(s)'
+      expect(page).to have_content 'You need to add at least one location to offer GovWifi'
     end
 
     it 'redirects the user to the setting up page' do

--- a/spec/features/ips/view_ip_addresses_spec.rb
+++ b/spec/features/ips/view_ip_addresses_spec.rb
@@ -51,7 +51,7 @@ describe 'Viewing IP addresses', type: :feature do
 
       it 'labels the IP as inactive' do
         within("#ips-row-#{ip.id}") do
-          expect(page).to have_content('No traffic for the last 10 days')
+          expect(page).to have_content('No traffic in the last 10 days')
         end
       end
     end

--- a/spec/features/locations/add_new_location_spec.rb
+++ b/spec/features/locations/add_new_location_spec.rb
@@ -8,7 +8,7 @@ describe 'Add new location', type: :feature do
   before do
     sign_in_user user
     visit ips_path
-    click_on 'Add IP address'
+    click_on 'Add a location'
   end
 
   it 'displays an instruction to add the first location' do

--- a/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
@@ -6,7 +6,7 @@ describe 'View authentication requests for an IP', type: :feature do
 
   before do
     create(:session, start: 3.days.ago, username: username, siteIP: ip, success: true)
-    create(:ip, location_id: location.id, address: ip)
+    create(:ip, location_id: location.id, address: ip, created_at: 5.days.ago)
     sign_in_user admin_user
   end
 
@@ -15,7 +15,7 @@ describe 'View authentication requests for an IP', type: :feature do
       visit ips_path
 
       within('#ips-table') do
-        click_on 'View logs'
+        click_on 'view logs'
       end
     end
 

--- a/spec/features/overview/view_overview_page_spec.rb
+++ b/spec/features/overview/view_overview_page_spec.rb
@@ -71,7 +71,9 @@ describe 'Viewing the overview page', type: :feature do
       end
 
       it 'redirects to the IPs page when Locations is clicked on' do
-        click_link 'Locations'
+        within('div#locations') do
+          click_link 'Locations'
+        end
 
         expect(page).to have_current_path(ips_path)
       end


### PR DESCRIPTION
See individual commits for each specific change.

The overall aims of this pull request is to make the locations page clearer by:
- removing redundant information
- changing the prominence of the actions on the page 
- changing the spacing of elements of the page so related things group together more strongly

# Before 

<img width="926" alt="Screen Shot 2019-07-24 at 15 30 11" src="https://user-images.githubusercontent.com/355079/61802278-18d44480-ae28-11e9-88f0-69d4e9931b18.png">

# After 

<img width="931" alt="Screen Shot 2019-07-24 at 15 19 41" src="https://user-images.githubusercontent.com/355079/61802279-18d44480-ae28-11e9-9faf-fdb546287340.png">
