### PR TITLE
Include the issuer in the 2FA QR code

### DIFF
--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -28,7 +28,9 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
 
   def qr_code_uri
     provisioning_uri = current_user.provisioning_uri(
-      current_user.email, otp_secret_key: @otp_secret_key
+      current_user.email,
+      otp_secret_key: @otp_secret_key,
+      issuer: "GovWifi (#{ENV['RACK_ENV']})"
     )
     qr_code = RQRCode::QRCode.new(provisioning_uri, level: :m)
     qr_code.as_png(size: 180, fill: ChunkyPNG::Color::TRANSPARENT).to_data_url

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -110,7 +110,6 @@ describe Organisation do
     let(:first_ip) { create(:ip, location: first_location) }
     let(:second_ip) { create(:ip, location: first_location) }
     let(:third_ip) { create(:ip, location: second_location) }
-    let(:fourth_ip) { create(:ip, location: third_location) }
     let(:sort_direction) { 'asc' }
 
     before do
@@ -119,7 +118,6 @@ describe Organisation do
 
       first_location.ips = [first_ip, second_ip]
       second_location.ips << third_ip
-      third_location.ips << fourth_ip
 
       first_organisation.locations << first_location
       second_organisation.locations = [second_location, third_location]
@@ -170,7 +168,7 @@ describe Organisation do
       let(:sort_column) { 'ips_count' }
 
       it 'orders results by number of ips' do
-        expect(sorted_results).to eq([first_organisation, second_organisation])
+        expect(sorted_results).to eq([second_organisation, first_organisation])
       end
     end
 


### PR DESCRIPTION
This helps users identify which service the TOTP code is for
and also includes the Rack environment.