### PR TITLE
config: disable css_compressor

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,9 @@ module GovwifiAdmin
       }
     }
 
+    # https://github.com/alphagov/govuk-frontend/issues/1350
+    config.assets.css_compressor = nil
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
There is an issue with `govuk-frontend` and `libsass`[1] (caused by
the min/max macros) so implement the suggested fix on all
environments.

Also see [2] for similar fix.

[1] https://github.com/alphagov/govuk-frontend/issues/1350#issuecomment-493129270
[2]: https://github.com/DFE-Digital/dfe-teachers-payment-service/commit/25403df7409659ff352d28dcc938d0004b01621b