### PR TITLE
Fix error summary shown before entering IPs bug

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -31,7 +31,7 @@ class Location < ApplicationRecord
   end
 
   def ips_unable_to_be_persisted
-    blank_ips.reject(&:address)
+    blank_ips.select(&:address)
   end
 
 private

--- a/app/views/locations/add_ips.html.erb
+++ b/app/views/locations/add_ips.html.erb
@@ -1,13 +1,13 @@
 <%= render "layouts/form_errors", resource: @ip %>
 
-<% if @location.ips_unable_to_be_persisted || @location.errors.any? %>
+<% if action_name == 'update_ips' %>
   <div class="govuk-error-summary">
     <h2 class="govuk-error-summary__title">There is a problem</h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
-        <% if @location.ips_unable_to_be_persisted %>
+        <% if @location.ips_unable_to_be_persisted.empty? %>
           <li>Enter at least one IP address</li>
-        <% elsif @location.errors.keys.include?(:"ips.address") %>
+        <% else %>
           <li>There’s a problem with these IP addresses</li>
         <% end %>
       </ul>

--- a/spec/features/ips/add_ip_to_existing_location_spec.rb
+++ b/spec/features/ips/add_ip_to_existing_location_spec.rb
@@ -2,7 +2,22 @@ describe 'Adding an IP to an existing location', type: :feature do
   let(:user) { create(:user, :with_organisation) }
   let(:location) { create(:location, organisation: user.organisations.first) }
 
-  context 'when selecting a location' do
+  context 'when viewing the form' do
+    before do
+      sign_in_user user
+      visit location_add_ips_path(location_id: location.id)
+    end
+
+    it 'shows no error summary' do
+      page.assert_no_selector('.govuk-error-summary')
+    end
+
+    it 'shows no individual errors' do
+      page.assert_no_selector('.govuk-error-message')
+    end
+  end
+
+  context 'when entering an IP address' do
     before do
       sign_in_user user
       visit location_add_ips_path(location_id: location.id)


### PR DESCRIPTION
The error summary should only show if there are IP addresses which couldn’t be persisted. It’s supposed to do this by filtering out blank ones and seeing if there are any left. It was doing the opposite, leaving only the blank ones. In other word the presence of any blank IP addresses (like the 5 we create when you view the page) was causing the error to show.

However this confuses the page if the user hasn’t submitted anything, because the model doesn’t know whether there’s a `GET` or a `POST` going on. So I’ve had to put a bit of logic in the view as well to check which controller method is rendering the page.

# Before 

![image](https://user-images.githubusercontent.com/355079/64246975-c9446680-cf05-11e9-9e7c-83e4c8d2c2db.png)

# After 

![image](https://user-images.githubusercontent.com/355079/64250381-e41ad900-cf0d-11e9-8bbc-a50f08a28904.png)
![image](https://user-images.githubusercontent.com/355079/64250418-fb59c680-cf0d-11e9-923b-6b89591fa5e5.png)

