### PR TITLE
app: add a link to our accessibility statement in the footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -150,6 +150,9 @@
               <li class="govuk-footer__list-item">
                 <%= link_to 'Performance', 'https://www.gov.uk/performance/govwifi', class: "govuk-footer__link" %>
               </li>
+              <li class="govuk-footer__list-item">
+                <%= link_to 'Accessibility statement', 'https://www.wifi.service.gov.uk/accessibility-statement', class: "govuk-footer__link" %>
+              </li>
             </ul>
           </div>
           <div class="govuk-footer__section">


### PR DESCRIPTION
# Description 
As soon as our [accessibility statement](https://github.com/alphagov/govwifi-product-page/pull/218) is merged, we should link to it from the Admin.