### PR TITLE
Add an authenticated URL to download the poster 

### DIFF
--- a/app/controllers/setup_instructions_controller.rb
+++ b/app/controllers/setup_instructions_controller.rb
@@ -8,6 +8,15 @@ class SetupInstructionsController < ApplicationController
     @current_org_signed_mou = current_organisation.signed_mou.attachment
   end
 
+  def poster
+    send_file(
+      Rails.root.join("app", "assets", "images", "govwifi-poster.png"),
+      type: "image/png",
+      disposition: "inline",
+      filename: "GovWifi-poster.png",
+    )
+  end
+
 private
 
   def radius_ips

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   get '/healthcheck', to: 'monitoring#healthcheck'
   get 'change_organisation', to: 'current_organisation#edit'
   patch 'change_organisation', to: 'current_organisation#update'
+  get '/setup_instructions/poster', to: 'setup_instructions#poster'
 
   resources :status, only: %i[index]
   resources :ips, only: %i[index new create destroy] do

--- a/spec/features/download_poster_spec.rb
+++ b/spec/features/download_poster_spec.rb
@@ -1,0 +1,34 @@
+describe 'Downloading the poster', type: :feature do
+  let(:user) { create(:user, :with_organisation) }
+
+  context "when signed in" do
+    before do
+      sign_in_user user
+      visit setup_instructions_poster_path
+    end
+
+    it 'sends an OK status' do
+      expect(page).to have_http_status(200)
+    end
+
+    it 'sets the filename of the download' do
+      expect(page.response_headers["Content-Disposition"]).to eq(
+        "inline; filename=\"GovWifi-poster.png\""
+      )
+    end
+
+    it 'sets the content type of the download' do
+      expect(page.response_headers["Content-Type"]).to eq(
+        "image/png"
+      )
+    end
+  end
+
+  context 'when signed out' do
+    before do
+      visit setup_instructions_poster_path
+    end
+
+    it_behaves_like 'not signed in'
+  end
+end


### PR DESCRIPTION
We need to link to the poster from a public place, but we still only want people who are signed in to be able to download it. So we can’t link to the asset directly.

What we can do instead is add an endpoint which serves the asset but has authentication.