### PR TITLE
Fix new IP addresses not being published

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -13,7 +13,6 @@ class LocationsController < ApplicationController
     )
 
     if @location.save
-      Facades::Ips::Publish.new.execute
       redirect_to(
         @location.ips.any? ? created_location_with_ip_ips_path : created_location_ips_path,
         notice: "Added #{@location.full_address}"
@@ -38,6 +37,7 @@ class LocationsController < ApplicationController
     @location = Location.find(params[:location_id])
     length_of_ips_before = @location.ips.length
     if !present_ips.empty? && @location.update(ips_attributes: present_ips)
+      Facades::Ips::Publish.new.execute
       length_of_ips_added = @location.ips.length - length_of_ips_before
       redirect_to(
         created_ips_path,

--- a/spec/features/ips/add_ip_to_existing_location_spec.rb
+++ b/spec/features/ips/add_ip_to_existing_location_spec.rb
@@ -18,7 +18,10 @@ describe 'Adding an IP to an existing location', type: :feature do
   end
 
   context 'when entering an IP address' do
+    let(:publish_ip) { instance_spy(Facades::Ips::Publish, execute: nil) }
+
     before do
+      allow(Facades::Ips::Publish).to receive(:new).and_return(publish_ip)
       sign_in_user user
       visit location_add_ips_path(location_id: location.id)
       fill_in 'location[ips_attributes][0][address]', with: ip_address
@@ -40,6 +43,10 @@ describe 'Adding an IP to an existing location', type: :feature do
 
       it 'redirects to the "after IP created" path for Analytics' do
         expect(page).to have_current_path('/ips/created')
+      end
+
+      it 'triggers the publishing of the config file' do
+        expect(publish_ip).to have_received(:execute)
       end
     end
 


### PR DESCRIPTION
We’ve had a couple of users report that changes users have made to their IP addresses haven’t taken effect.

As far as I can tell this line of code sets off a process of re-publishing some kind of configuration file which contains all the IP addresses (see here: https://github.com/alphagov/govwifi-admin/blob/master/lib/use_cases/radius/generate_radius_ip_whitelist.rb#L15-L20). So I’m fairly sure that the reason for the bug is that the process is not being triggered when someone changes or adds an IP address.

This happened because adding the IP addresses used to happen at the same time as adding the location, and the code to publish the changes still lives there.

I’m not sure why this bug wasn’t present before, because the publishing looks like it wasn’t happening in the old `update` method: https://github.com/alphagov/govwifi-admin/pull/831/files#diff-54b4e4f2b562d74dad3af78e66e74e4fR26