### PR TITLE
Highlight to organisations if MOU has not been signed yet

### DIFF
--- a/app/controllers/overview_controller.rb
+++ b/app/controllers/overview_controller.rb
@@ -3,5 +3,6 @@ class OverviewController < ApplicationController
     @ips = current_organisation.ips
     @locations = current_organisation.locations
     @team_members = current_organisation.users
+    @current_org_signed_mou = current_organisation.signed_mou.attachment
   end
 end

--- a/app/views/overview/index.html.erb
+++ b/app/views/overview/index.html.erb
@@ -4,8 +4,7 @@
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
     <strong class="govuk-warning-text__text">
       <span class="govuk-warning-text__assistive">Warning</span>
-      Your organisation has not yet signed the
-      <%= link_to "memorandum of understanding", mou_index_path, class: "govuk-link govuk-link--no-visited-state" %>.
+      You must sign the GovWifi <%= link_to "memorandum of understanding", mou_index_path, class: "govuk-link govuk-link--no-visited-state" %> to use this service.
     </strong>
   </div>
 </div>

--- a/app/views/overview/index.html.erb
+++ b/app/views/overview/index.html.erb
@@ -1,6 +1,6 @@
 <% unless @current_org_signed_mou %>
 <div class="govuk-grid-row">
-  <div class="govuk-warning-text">
+  <div class="govuk-warning-text" id="mou-warning">
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
     <strong class="govuk-warning-text__text">
       <span class="govuk-warning-text__assistive">Warning</span>

--- a/app/views/overview/index.html.erb
+++ b/app/views/overview/index.html.erb
@@ -1,3 +1,15 @@
+<% unless @current_org_signed_mou %>
+<div class="govuk-grid-row">
+  <div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-warning-text__assistive">Warning</span>
+      Your organisation has not yet signed the
+      <%= link_to "memorandum of understanding", mou_index_path, class: "govuk-link govuk-link--no-visited-state" %>.
+    </strong>
+  </div>
+</div>
+<% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full overview-section-alignment" id="overview">
     <h2 class="govuk-heading-l govuk-grid-column-full">Overview</h2>

--- a/spec/features/overview/view_overview_page_spec.rb
+++ b/spec/features/overview/view_overview_page_spec.rb
@@ -84,6 +84,25 @@ describe 'Viewing the overview page', type: :feature do
         end
         expect(page).to have_current_path(ips_path)
       end
+
+      context 'if mou has not been uploaded' do
+        it 'shows warning that mou must be uploaded' do
+          expect(page).to have_selector("#mou-warning")
+        end
+      end
+
+      context 'if mou has already been uploaded' do
+        before do
+          visit mou_index_path
+          attach_file("signed_mou", Rails.root + "spec/fixtures/mou.pdf")
+          click_on 'Upload'
+          visit root_path
+        end
+
+        it 'does not show mou warning' do
+          expect(page).not_to have_selector("#mou-warning")
+        end
+      end
     end
   end
 end

--- a/spec/features/overview/view_overview_page_spec.rb
+++ b/spec/features/overview/view_overview_page_spec.rb
@@ -10,6 +10,32 @@ describe 'Viewing the overview page', type: :feature do
     it_behaves_like 'shows the setup instructions page'
   end
 
+  context 'when viewing the overview section' do
+    before do
+      sign_in_user user
+      visit overview_index_path
+    end
+
+    context 'without having mou uploaded' do
+      it 'shows warning that mou must be uploaded' do
+        expect(page).to have_selector("#mou-warning")
+      end
+    end
+
+    context 'with having mou already uploaded' do
+      before do
+        visit mou_index_path
+        attach_file("signed_mou", Rails.root + "spec/fixtures/mou.pdf")
+        click_on 'Upload'
+        visit overview_index_path
+      end
+
+      it 'does not show mou warning' do
+        expect(page).not_to have_selector("#mou-warning")
+      end
+    end
+  end
+
   context 'with at least one IP' do
     let(:ip_one) { '141.0.149.130' }
     let(:ip_two) { '141.0.149.131' }
@@ -83,25 +109,6 @@ describe 'Viewing the overview page', type: :feature do
           click_link 'IP addresses'
         end
         expect(page).to have_current_path(ips_path)
-      end
-
-      context 'if mou has not been uploaded' do
-        it 'shows warning that mou must be uploaded' do
-          expect(page).to have_selector("#mou-warning")
-        end
-      end
-
-      context 'if mou has already been uploaded' do
-        before do
-          visit mou_index_path
-          attach_file("signed_mou", Rails.root + "spec/fixtures/mou.pdf")
-          click_on 'Upload'
-          visit root_path
-        end
-
-        it 'does not show mou warning' do
-          expect(page).not_to have_selector("#mou-warning")
-        end
       end
     end
   end


### PR DESCRIPTION
## What

We should highlight to organisations if they haven't submitted the MOU, and provide an action item for them to remediate the situation.

## Why

Quite often, organisation admins forget about or do not understand the need for signing an MOU. We need to make it more prominent if an org hasn't signed the MOU, and encourage them to sign it.

## How

Add a warning text at the top of the dashboard that warns org admin users, after logging in, that an MOU must be signed, if it hasn't been uploaded yet. The text should include an action item, which the admin user could then click to go to a place where they can download the MOU for signing and upload it back.

---

### End result

This is how the warning will look like:

<img width="992" alt="GovWifi_Admin" src="https://user-images.githubusercontent.com/3193694/67201137-811dcc80-f3fd-11e9-9091-2b187b930a02.png">