### PR TITLE
test: improve RSpec boot time by +400%

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,11 @@ inherit_gem:
   govuk-lint: configs/rubocop/all.yml
 require: rubocop-rspec
 
+AllCops:
+  Exclude:
+    - 'bin/*'
+    - 'db/schema.rb'
+
 # The suggested alignment is awful so disable this cop
 Layout/AlignArguments:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -50,4 +50,5 @@ group :development, :test do
   gem 'listen', '~> 3'
   gem 'pry'
   gem 'rack-mini-profiler', require: false
+  gem 'spring-commands-rspec'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,6 @@ gem 'zendesk_api'
 
 group :test do
   gem 'capybara'
-  gem 'capybara-screenshot'
   gem 'erb_lint', require: false
   gem 'factory_bot_rails', '~> 5.0'
   gem 'faker'

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ gem 'zendesk_api'
 group :test do
   gem 'capybara'
   gem 'capybara-screenshot'
-  gem 'database_cleaner'
   gem 'erb_lint', require: false
   gem 'factory_bot_rails', '~> 5.0'
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,6 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
-    database_cleaner (1.7.0)
     devise (4.6.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -371,7 +370,6 @@ DEPENDENCIES
   byebug (~> 11)
   capybara
   capybara-screenshot
-  database_cleaner
   devise (~> 4.6.2)
   devise_invitable (~> 2.0.1)
   erb_lint

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,9 +88,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
-    capybara-screenshot (1.0.23)
-      capybara (>= 1.0, < 4)
-      launchy
     chunky_png (1.3.11)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
@@ -161,8 +158,6 @@ GEM
     jmespath (1.4.0)
     json (2.2.0)
     jwt (2.2.1)
-    launchy (2.4.3)
-      addressable (~> 2.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -369,7 +364,6 @@ DEPENDENCIES
   bullet (~> 6.0)
   byebug (~> 11)
   capybara
-  capybara-screenshot
   devise (~> 4.6.2)
   devise_invitable (~> 2.0.1)
   erb_lint

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,6 +314,9 @@ GEM
       terminal-table
     simplecov-html (0.10.2)
     smart_properties (1.13.1)
+    spring (2.1.0)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (4.0.0.beta10)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -393,6 +396,7 @@ DEPENDENCIES
   shoulda-matchers (~> 4.1)
   simplecov
   simplecov-console
+  spring-commands-rspec
   sprockets (= 4.0.0beta10)
   timecop (~> 0.9.1)
   two_factor_authentication

--- a/Guardfile
+++ b/Guardfile
@@ -1,5 +1,5 @@
 # rubocop:disable Metrics/BlockLength
-guard :rspec, cmd: "bundle exec rspec" do
+guard :rspec, cmd: "bundle exec bin/rspec" do
   require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)
 

--- a/Guardfile
+++ b/Guardfile
@@ -35,11 +35,4 @@ guard :rspec, cmd: "bundle exec bin/rspec" do
   # Capybara features specs
   watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
   watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
-
-  # Turnip features and steps
-  watch(%r{^spec/acceptance/(.+)\.feature$})
-  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
-    Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
-  end
 end
-# rubocop:enable Metrics/BlockLength

--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/BlockLength
 guard :rspec, cmd: "bundle exec bin/rspec" do
   require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+# This file loads Spring without using Bundler, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
+unless defined?(Spring)
+  require 'rubygems'
+  require 'bundler'
+
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect { |spec| spec.name == 'spring' }
+  if spring
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
+    require 'spring/binstub'
+  end
+end

--- a/ci/tasks/test.yml
+++ b/ci/tasks/test.yml
@@ -10,6 +10,7 @@ inputs:
 
 params:
   ON_CONCOURSE: true
+  COVERAGE: true
 
 run:
   path: docker-wrapper

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,29 +23,10 @@ ActiveRecord::Migration.maintain_test_schema!
 RSpec.configure do |config|
   config.include Warden::Test::Helpers
 
-  config.use_transactional_fixtures = false
+  config.use_transactional_fixtures = true
 
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
-
-  config.before(:suite) do
-    DatabaseCleaner.add_cleaner(:active_record)
-    DatabaseCleaner.add_cleaner(:active_record, model: ReadReplicaBase)
-    DatabaseCleaner.add_cleaner(:active_record, model: WifiUser)
-    DatabaseCleaner.strategy = :transaction
-
-    DatabaseCleaner.clean_with(:truncation)
-  end
-
-  # This block must be here, do not combine with the other `before(:each)` block.
-  # This makes it so Capybara can see the database.
-  config.before do
-    DatabaseCleaner.start
-  end
-  config.after do
-    Warden.test_reset!
-    DatabaseCleaner.clean
-  end
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,15 @@
-require 'simplecov'
-require 'simplecov-console'
+if ENV["COVERAGE"]
+  require 'simplecov'
+  require 'simplecov-console'
 
-SimpleCov.start 'rails'
-SimpleCov.minimum_coverage 100
+  SimpleCov.start 'rails'
+  SimpleCov.minimum_coverage 100
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-  SimpleCov::Formatter::HTMLFormatter,
-  SimpleCov::Formatter::Console,
-])
-
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::Console,
+  ])
+end
 
 RSpec.configure do |config|
   config.filter_run focus: true


### PR DESCRIPTION
# Description 
Improve the RSpec start time to enable a proper feedback loop, namely by using [Spring](https://github.com/rails/spring) to preload RSpec and not running coverage on every single run.

From the commit log:

Commit 1:
> feature: use rails/spring to preload RSpec
>
> There is probably a lot more to fix for us to achieve near-instant
> boot times, but this is by far the most yielding performance
> improvement across the board. From a quick benchmark using hyperfine:
>
> ```bash
> bash-5.0# hyperfine --warmup=3 -i 'bundle exec rspec spec/empty_spec.rb'
> Benchmark #1: bundle exec rspec spec/empty_spec.rb
>   Time (mean ± σ):     17.861 s ±  2.544 s    [User: 4.104 s, System: 1.943 s]
>   Range (min … max):   12.748 s … 21.520 s    10 runs
> ```
> 
> compare with the new version:
> 
> ```bash
> bash-5.0# hyperfine --warmup=3 -i 'bundle exec bin/rspec spec/empty_spec.rb'
> Benchmark #1: bundle exec bin/rspec spec/empty_spec.rb
>   Time (mean ± σ):      6.614 s ±  1.287 s    [User: 314.0 ms, System: 49.0 ms]
>   Range (min … max):    5.121 s …  9.107 s    10 runs
> ```
> 
> That's 270% faster.

Commit 2:

> fix: only run coverage when ENV["COVERAGE"] exists
> 
> It feels like CI should monitor coverage, not individual developers
> iterating on new code. Set a COVERAGE environement variable in the CI
> test pipeline to make sure it keeps running there, whilst enabling
> more RSpec performance gains on our side.

Commit 3:
> fix: remove unnecessary usage of DatabaseCleaner
> 
> See this very interesting article[1] for the rationale here. The test
> suite is still green so we can definitely do without and hopefully
> glean more RSPec speed improvements.
> 
> [1]: https://anti-pattern.com/transactional-fixtures-in-rails

Commit 4:

> fix: remove unused capybara-screenshot gem
> 
> It looks like the acceptance specs that used to require this gem are
> now gone so retire the gem and the corresponding Guardfile
> configuration.
>
> One last benchmark gives:
> 
> ```
> bash-4.4# hyperfine --warmup=3 -i 'bundle exec bin/rspec spec/empty_spec.rb'
> Benchmark #1: bundle exec bin/rspec spec/empty_spec.rb
>   Time (mean ± σ):      3.793 s ±  0.739 s    [User: 303.0 ms, System: 48.0 ms]
>   Range (min … max):    2.990 s …  5.095 s    10 runs
> ```
> Which is now 470% faster than the previous situation.
> 