### PR TITLE
Use autocomplete for organisations on signup page

### DIFF
--- a/app/views/users/confirmations/show.html.erb
+++ b/app/views/users/confirmations/show.html.erb
@@ -13,7 +13,7 @@
           <div class="govuk-form-group <%= field_error(resource, "organisation.name") %>">
             <%= organisation_form.label :name, "Organisation name", class: "govuk-label" %>
             <div class="govuk-hint">If your organisation name does not appear below <%= link_to "contact us", technical_support_new_help_path, class: "govuk-link" %>.</div>
-            <%= organisation_form.select :name, options_for_select(@register_organisations << '', ''), {}, class: "govuk-select" %>
+            <%= organisation_form.select :name, options_for_select(@register_organisations << '', ''), {}, class: "govuk-select", id: 'organisations_register' %>
           </div>
 
           <div class="govuk-form-group <%= field_error(resource, "organisation.service_email") %>">

--- a/app/views/users/confirmations/show.html.erb
+++ b/app/views/users/confirmations/show.html.erb
@@ -12,7 +12,7 @@
         <%= f.fields_for :organisations, resource.organisations.build do |organisation_form| %>
           <div class="govuk-form-group <%= field_error(resource, "organisation.name") %>">
             <%= organisation_form.label :name, "Organisation name", class: "govuk-label" %>
-            <div class="govuk-hint">If your organisation name does not appear below <%= link_to "contact us", technical_support_new_help_path, class: "govuk-link" %></div>
+            <div class="govuk-hint">If your organisation name does not appear below <%= link_to "contact us", technical_support_new_help_path, class: "govuk-link" %>.</div>
             <%= organisation_form.select :name, options_for_select(@register_organisations << '', ''), {}, class: "govuk-select" %>
           </div>
 


### PR DESCRIPTION
# Description 
See 37ebfd. A missing ID was getting the auto-complete confused.

## Before

User has to scroll/guess through ~1000 organisations.

<img width="300" alt="Screenshot 2019-12-11 at 18 55 12" src="https://user-images.githubusercontent.com/107635/70651260-640cb980-1c48-11ea-9c25-bf03795c82f7.png">

## After

User can find "District" even though it's not the first word.

<img width="300" alt="after" src="https://user-images.githubusercontent.com/107635/70651076-185a1000-1c48-11ea-8ae9-ffbc5573309b.png">

# Ticket
https://trello.com/c/bDJoUWHR/225-when-an-administrator-sign-up-use-an-auto-complete-to-find-their-organisation