### PR TITLE
fix: restrict session lifetime to 30 minutes

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -225,7 +225,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 1.hour
+  config.timeout_in = 30.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/spec/features/logout_user_after_inactivity_spec.rb
+++ b/spec/features/logout_user_after_inactivity_spec.rb
@@ -3,11 +3,11 @@ require 'timecop'
 describe 'Logout users after period of inactivity', type: :feature do
   let(:user) { create(:user, :with_organisation) }
 
-  context 'when a signed in user has been inactive for 59 minutes' do
+  context 'when a signed in user has been inactive for 29 minutes' do
     before do
       sign_in_user user
       visit root_path
-      Timecop.travel(Time.now + 59.minutes) { visit root_path }
+      Timecop.travel(Time.now + 29.minutes) { visit root_path }
     end
 
     after { Timecop.return }
@@ -19,11 +19,11 @@ describe 'Logout users after period of inactivity', type: :feature do
     end
   end
 
-  context 'when a signed in user has been inactive for an hour' do
+  context 'when a signed in user has been inactive for half an hour' do
     before do
       sign_in_user user
       visit root_path
-      Timecop.travel(Time.now + 1.hour) { visit root_path }
+      Timecop.travel(Time.now + 30.minutes) { visit root_path }
     end
 
     after { Timecop.return }


### PR DESCRIPTION
# Description
We were allowing session lasting a full hour, which isn't optimal with regards to security. Downgrade back 30 minutes and update the relevant tests.