### PR TITLE
Fix the grid on the new organisation page

### DIFF
--- a/app/views/organisations/new.html.erb
+++ b/app/views/organisations/new.html.erb
@@ -1,30 +1,24 @@
 <%= render "layouts/form_errors", resource: @organisation %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Register an organisation for GovWifi</h2>
 
-    <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-      <%= form_for @organisation, url: organisations_path do |form| %>
-        <div class="govuk-form-group <%= field_error(@organisation, "name") %>">
-          <%= form.label :name, "Organisation name", class: "govuk-label" %>
-          <div class="govuk-hint">If your organisation name does not appear below <%= link_to "contact us", technical_support_new_help_path, class: "govuk-link" %></div>
-          <%= form.select :name, options_for_select(@register_organisations << '', ''), {}, class: "govuk-select" %>
-        </div>
-
-        <div class="govuk-form-group <%= field_error(@organisation, "service_email") %>">
-          <%= form.label :service_email, "Service email", class: "govuk-label" %>
-          <div class="govuk-hint">A shared and monitored email so we can contact your organisation about GovWifi</div>
-          <%= form.text_field :service_email,
-            class: 'govuk-input',
-            value: (params || {}).dig(:user, :organisation_attributes, :service_email) %>
-        </div>
-
-        <div class="actions">
-          <%= form.submit "Create organisation", class: "govuk-button govuk-!-margin-top-2" %>
-        </div>
-      <% end %>
-    </div>
+<h2 class="govuk-heading-l">Register an organisation for GovWifi</h2>
+<%= form_for @organisation, url: organisations_path do |form| %>
+  <div class="govuk-form-group <%= field_error(@organisation, "name") %>">
+    <%= form.label :name, "Organisation name", class: "govuk-label" %>
+    <div class="govuk-hint">If your organisation name does not appear below <%= link_to "contact us", technical_support_new_help_path, class: "govuk-link" %></div>
+    <%= form.select :name, options_for_select(@register_organisations << '', ''), {}, class: "govuk-select" %>
   </div>
-</div>
+
+  <div class="govuk-form-group <%= field_error(@organisation, "service_email") %>">
+    <%= form.label :service_email, "Service email", class: "govuk-label" %>
+    <div class="govuk-hint">A shared and monitored email so we can contact your organisation about GovWifi</div>
+    <%= form.text_field :service_email,
+      class: 'govuk-input',
+      value: (params || {}).dig(:user, :organisation_attributes, :service_email) %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit "Create organisation", class: "govuk-button govuk-!-margin-top-2" %>
+  </div>
+<% end %>
 
 <%= render "shared/organisation_register_dropdown" %>


### PR DESCRIPTION
The page had a two-thirds column inside a two-thirds column inside a three quarters column, resulting in a one-thirds column, which is too narrow.

The commit removes the superfluous two thirds columns, for a normal three quarters-thirds column width on the page.

This gives more space for long email addresses and organisation names, but doesn’t make the measure of the text too long.

Originally attempted in 7d0c9e412317ced431d9ecd31a1638d89999975f

# Before

![image](https://user-images.githubusercontent.com/355079/71915920-a5738480-3174-11ea-864d-09f2e4e2fed9.png)

# After

![image](https://user-images.githubusercontent.com/355079/71915876-9391e180-3174-11ea-8432-cf60a25964ed.png)
