### PR TITLE
Implement the ability for admins to be able to reset 2FA for others

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :test do
   gem 'guard-rspec'
   gem 'nokogiri'
   gem 'rack_session_access'
+  gem 'rails-controller-testing'
   gem 'rspec-rails', '~> 3'
   gem 'shoulda-matchers', '~> 4.1'
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,6 +226,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.3)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.4)
+      actionpack (>= 5.0.1.x)
+      actionview (>= 5.0.1.x)
+      activesupport (>= 5.0.1.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -390,6 +394,7 @@ DEPENDENCIES
   rack-mini-profiler
   rack_session_access
   rails (~> 5.2.3)
+  rails-controller-testing
   rqrcode
   rspec-rails (~> 3)
   sass-rails (~> 5.1)

--- a/app/assets/stylesheets/components/team_members.scss
+++ b/app/assets/stylesheets/components/team_members.scss
@@ -1,3 +1,15 @@
 .list-item-padding {
   margin-bottom: -5px;
 }
+
+.govuk-link {
+  display: block;
+}
+
+.govuk-table__row {
+  border-bottom: 1px solid $govuk-border-colour;
+}
+
+.govuk-table__cell:last-child {
+  padding-right: 20px;
+}

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -40,6 +40,14 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
     user.totp_timestamp = nil
     user.otp_secret_key = nil
     user.save!
+
+    redirect_path = if current_organisation&.super_admin?
+                      super_admin_organisations_path
+                    else
+                      memberships_path
+                    end
+
+    redirect_to redirect_path, notice: "Two factor authentication has been reset"
   end
 
   def validate_can_manage_team

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -51,13 +51,12 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
   end
 
   def validate_can_manage_team
-    if super_admin?
-      return true
-    end
-
     user = User.find(params.fetch(:id))
-    unless current_user.can_manage_team?(current_organisation) && user.membership_for(current_organisation)
-      raise ActionController::RoutingError.new('Not Found')
+
+    if current_user.can_manage_other_user_for_org?(user, current_organisation)
+      @user = user
+    else
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -5,7 +5,9 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
   skip_before_action :confirm_two_factor_setup
   before_action :validate_can_manage_team, only: %i[edit destroy]
 
-  def edit; end
+  def edit
+    @user = User.find(params.fetch(:id))
+  end
 
   def show
     # Used to populate the QR code used in setup.
@@ -30,6 +32,8 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
   end
 
   def destroy
+    @user = User.find(params.fetch(:id))
+
     @user.reset_2fa!
 
     redirect_path = if current_organisation&.super_admin?
@@ -44,11 +48,7 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
   def validate_can_manage_team
     user = User.find(params.fetch(:id))
 
-    if current_user.can_manage_other_user_for_org?(user, current_organisation)
-      @user = user
-    else
-      redirect_to root_path
-    end
+    redirect_to root_path unless current_user.can_manage_other_user_for_org?(user, current_organisation)
   end
 
   def qr_code_uri

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -5,9 +5,7 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
   skip_before_action :confirm_two_factor_setup
   before_action :validate_can_manage_team, only: %i[edit destroy]
 
-  def edit
-    @user = User.find(params[:id])
-  end
+  def edit; end
 
   def show
     # Used to populate the QR code used in setup.
@@ -32,14 +30,7 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
   end
 
   def destroy
-    user = User.find(params.fetch(:id))
-    user.second_factor_attempts_count = nil
-    user.encrypted_otp_secret_key = nil
-    user.encrypted_otp_secret_key_iv = nil
-    user.encrypted_otp_secret_key_salt = nil
-    user.totp_timestamp = nil
-    user.otp_secret_key = nil
-    user.save!
+    @user.reset_2fa!
 
     redirect_path = if current_organisation&.super_admin?
                       super_admin_organisations_path

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,6 +81,17 @@ class User < ApplicationRecord
     !ENV.key?('BYPASS_2FA') && request.env['warden'].user.super_admin?
   end
 
+  def reset_2fa!
+    update!(
+      second_factor_attempts_count: nil,
+      encrypted_otp_secret_key: nil,
+      encrypted_otp_secret_key_iv: nil,
+      encrypted_otp_secret_key_salt: nil,
+      totp_timestamp: nil,
+      otp_secret_key: nil
+    )
+  end
+
   # No-Op
   # We don't send the otp code to the user, this is a presumption in the two_factor_authentication gem.
   # The method has to be defined to avoid a NotImplementedError.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,11 +20,17 @@ class User < ApplicationRecord
   has_one_time_password(encrypted: true)
 
   validates :name, presence: true, on: :update
-  validates :password, presence: true,
-    length: { within: 6..80 },
-    on: :update
+  validates :password,
+            presence: true,
+            length: { within: 6..80 },
+            on: :update,
+            if: :password_present?
 
-  validate :strong_password, on: :update
+  validate :strong_password, on: :update, if: :password_present?
+
+  def password_present?
+    password.present?
+  end
 
   def only_if_unconfirmed
     pending_any_confirmation { yield }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,7 +50,7 @@ class User < ApplicationRecord
   end
 
   def can_manage_team?(organisation)
-    membership_for(organisation).can_manage_team?
+    membership_for(organisation)&.can_manage_team?
   end
 
   def can_manage_locations?(organisation)
@@ -63,6 +63,10 @@ class User < ApplicationRecord
 
   def default_membership
     memberships.first
+  end
+
+  def can_manage_other_user_for_org?(user, org)
+    super_admin? || !!(can_manage_team?(org) && user.membership_for(org))
   end
 
   def new_super_admin?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,7 @@ class User < ApplicationRecord
   validate :strong_password, on: :update, if: :password_present?
 
   def password_present?
-    password.present?
+    not password.nil?
   end
 
   def only_if_unconfirmed

--- a/app/views/memberships/_table.html.erb
+++ b/app/views/memberships/_table.html.erb
@@ -54,7 +54,7 @@
             <%= link_to 'Edit permissions', edit_membership_path(member.membership_for(current_organisation)), class: "govuk-link govuk-link--no-visited-state" %>
             <% if member.totp_enabled? %>
             <%= link_to 'Reset 2FA',
-                { controller: "users/two_factor_authentication_setup", action: "edit", id: member},
+                { controller: "users/two_factor_authentication_setup", action: "edit", id: member },
                 class: "govuk-link govuk-link--no-visited-state" %>
             <% end %>
 

--- a/app/views/memberships/_table.html.erb
+++ b/app/views/memberships/_table.html.erb
@@ -53,15 +53,15 @@
           <% if current_user.can_manage_team?(current_organisation) && member.id != current_user.id %>
             <%= link_to 'Edit permissions', edit_membership_path(member.membership_for(current_organisation)), class: "govuk-link govuk-link--no-visited-state" %>
             <% if member.totp_enabled? %>
-            <%= link_to 'Reset 2FA',
+              <%= link_to 'Reset 2FA',
                 { controller: "users/two_factor_authentication_setup", action: "edit", id: member },
                 class: "govuk-link govuk-link--no-visited-state" %>
             <% end %>
 
             <% if member.invitation_pending? && current_user.can_manage_team?(current_organisation) %>
-            <%= button_to("Resend invite",
-              user_invitation_path(user: { email: member.email }, resend: true),
-              method: :post, class: 'button-as-link govuk-body') %>
+              <%= button_to("Resend invite",
+                user_invitation_path(user: { email: member.email }, resend: true),
+                method: :post, class: 'button-as-link govuk-body') %>
             <% end %>
           <% end %>
       </div>

--- a/app/views/memberships/_table.html.erb
+++ b/app/views/memberships/_table.html.erb
@@ -52,6 +52,11 @@
         <div class='govuk-grid-column-one-third govuk-list govuk-!-padding-right-4 govuk-!-margin-top-0 text-right'>
           <% if current_user.can_manage_team?(current_organisation) && member.id != current_user.id %>
             <%= link_to 'Edit permissions', edit_membership_path(member.membership_for(current_organisation)), class: "govuk-link govuk-link--no-visited-state" %>
+            <% if member.totp_enabled? %>
+            <%= link_to 'Reset 2FA',
+                { controller: "users/two_factor_authentication_setup", action: "edit", id: member},
+                class: "govuk-link govuk-link--no-visited-state" %>
+            <% end %>
 
             <% if member.invitation_pending? && current_user.can_manage_team?(current_organisation) %>
             <%= button_to("Resend invite",

--- a/app/views/super_admin/organisations/_team.html.erb
+++ b/app/views/super_admin/organisations/_team.html.erb
@@ -15,7 +15,7 @@
           <td class="govuk-table__cell text-right" scope="row">
             <% if user.totp_enabled? %>
             <%= link_to 'Reset 2FA',
-                { controller: "users/two_factor_authentication_setup", action: "edit", id: user},
+                { controller: "users/two_factor_authentication_setup", action: "edit", id: user },
                 class: "govuk-button govuk-button--secondary" %>
             <% end %>
           </td>

--- a/app/views/super_admin/organisations/_team.html.erb
+++ b/app/views/super_admin/organisations/_team.html.erb
@@ -12,6 +12,13 @@
                 edit_membership_path(user.membership_for(@organisation), remove_team_member: true),
                 class: 'govuk-button red-button' %>
           </td>
+          <td class="govuk-table__cell text-right" scope="row">
+            <% if user.totp_enabled? %>
+            <%= link_to 'Reset 2FA',
+                { controller: "users/two_factor_authentication_setup", action: "edit", id: user},
+                class: "govuk-button govuk-button--secondary" %>
+            <% end %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/super_admin/organisations/show.html.erb
+++ b/app/views/super_admin/organisations/show.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <%= render "confirm_remove_organisation" if params[:remove_organisation] %>
 
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <%= link_to "Back to list", super_admin_organisations_path, class: "govuk-back-link" %>
 
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-2 govuk-!-margin-top-2">

--- a/app/views/users/two_factor_authentication_setup/edit.html.erb
+++ b/app/views/users/two_factor_authentication_setup/edit.html.erb
@@ -1,0 +1,12 @@
+<%= link_to "Back", :back, class: "govuk-back-link" %>
+
+<div class="govuk-error-summary">
+  <h2 class="govuk-error-summary__title">
+    Are you sure you want to reset two factor authentication for <%= @user.name %>?
+  </h2>
+  <div class="govuk-error-summary__body">
+    <%= button_to 'Yes, reset two factor authentication',
+                { controller: "users/two_factor_authentication_setup", action: "destroy"}, method: :delete,
+                id: @user, class: "govuk-button red-button" %>
+  </div>
+</div>

--- a/app/views/users/two_factor_authentication_setup/edit.html.erb
+++ b/app/views/users/two_factor_authentication_setup/edit.html.erb
@@ -6,7 +6,7 @@
   </h2>
   <div class="govuk-error-summary__body">
     <%= button_to 'Yes, reset two factor authentication',
-                { controller: "users/two_factor_authentication_setup", action: "destroy"}, method: :delete,
+                { controller: "users/two_factor_authentication_setup", action: "destroy" }, method: :delete,
                 id: @user, class: "govuk-button red-button" %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     put 'users/two_factor_authentication_setup', to: 'users/two_factor_authentication_setup#update'
     get 'users/two_factor_authentication_setup', to: 'users/two_factor_authentication_setup#show'
     get 'users/:id/two_factor_authentication/edit', to: 'users/two_factor_authentication_setup#edit'
-    delete 'users/two_factor_authentication_setup/:id', to: 'users/two_factor_authentication_setup#destroy'
+    delete 'users/:id/two_factor_authentication_setup', to: 'users/two_factor_authentication_setup#destroy'
   end
   get 'confirm_new_membership', to: 'users/memberships#create'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
     get 'users/confirmations/pending', to: 'users/confirmations#pending'
     put 'users/two_factor_authentication_setup', to: 'users/two_factor_authentication_setup#update'
     get 'users/two_factor_authentication_setup', to: 'users/two_factor_authentication_setup#show'
+    get 'users/:id/two_factor_authentication/edit', to: 'users/two_factor_authentication_setup#edit'
+    delete 'users/two_factor_authentication_setup/:id', to: 'users/two_factor_authentication_setup#destroy'
   end
   get 'confirm_new_membership', to: 'users/memberships#create'
 

--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe Users::TwoFactorAuthenticationSetupController, type: :controller do
+  let(:organisation) { create(:organisation) }
+
+  let(:superadmin) { create(:user, :super_admin) }
+  let(:admin) { create(:user, organisations: [organisation]) }
+  let(:stranger) { create(:user, :with_organisation) }
+  let(:teammate) { create(:user, organisations: [organisation]) }
+
+  describe 'edit' do
+    context 'when the current_user is not allowed to edit' do
+      before do
+        sign_in stranger
+        @response = get :edit, params: { id: teammate.id }
+      end
+
+      it 'redirects to the home page' do
+        expect(response).to redirect_to root_path
+      end
+
+      it 'does not assign the user variable' do
+        expect(assigns(:user)).to be_nil
+      end
+    end
+
+    context 'when the user is allowed to edit' do
+      before do
+        sign_in admin
+        @response = get :edit, params: { id: teammate.id }
+      end
+
+      it 'renders the right view' do
+        expect(response).to render_template 'edit'
+      end
+
+      it 'assigns the user variable' do
+        expect(assigns(:user)).to eq teammate
+      end
+    end
+
+    context 'when the user is a super admin' do
+      before do
+        sign_in superadmin
+        @response = get :edit, params: { id: teammate.id }
+      end
+
+      it 'renders the right view' do
+        expect(response).to render_template 'edit'
+      end
+
+      it 'assigns the user variable' do
+        expect(assigns(:user)).to eq teammate
+      end
+    end
+  end
+end

--- a/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
+++ b/spec/controllers/users/two_factor_authentication_setup_controller_spec.rb
@@ -54,4 +54,41 @@ RSpec.describe Users::TwoFactorAuthenticationSetupController, type: :controller 
       end
     end
   end
+
+  describe 'delete' do
+    before do
+      allow(User).to receive(:find).and_return teammate
+      allow(teammate).to receive :reset_2fa!
+    end
+
+    context 'when operated by a super-admin' do
+      before do
+        sign_in superadmin
+        @response = get :destroy, params: { id: teammate.id }
+      end
+
+      it 'calls reset_2fa! on the @user' do
+        expect(teammate).to have_received :reset_2fa!
+      end
+
+      it 'redirects to the super admin organisations path' do
+        expect(response).to redirect_to super_admin_organisations_path
+      end
+    end
+
+    context 'when operated by a normal admin' do
+      before do
+        sign_in admin
+        @response = get :destroy, params: { id: teammate.id }
+      end
+
+      it 'calls reset_2fa! on the @user' do
+        expect(teammate).to have_received :reset_2fa!
+      end
+
+      it 'redirects to the current organisation page' do
+        expect(response).to redirect_to memberships_path
+      end
+    end
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -27,6 +27,10 @@ FactoryBot.define do
       end
     end
 
+    trait :with_2fa do
+      otp_secret_key { 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' } # 2FA is set up
+    end
+
     trait :unconfirmed do
       confirmed_at { nil }
     end

--- a/spec/features/team/reset_2fa_spec.rb
+++ b/spec/features/team/reset_2fa_spec.rb
@@ -1,0 +1,133 @@
+describe "Reset two factor authentication", type: :feature do
+  let(:organisation) { create(:organisation) }
+  let(:org_admin_user_1) { create(:user, organisations: [organisation]) }
+  let(:org_admin_user_2) { create(:user, organisations: [organisation]) }
+  let(:org_admin_user_3) { create(:user, organisations: [organisation]) }
+
+  let(:super_admin_organisation) { create(:organisation, super_admin: true) }
+  let(:super_admin_user) { create(:user, organisations: [super_admin_organisation]) }
+
+  before do
+    # Disabling Rubocop check for this as can't figure out a reliable way to stub instance method
+    # for user objects.
+    allow_any_instance_of(User).to receive(:need_two_factor_authentication?).and_return(true) # rubocop:disable RSpec/AnyInstance
+  end
+
+  context "when logged in as a super admin user" do
+    let(:totp_double) { instance_double(ROTP::TOTP) }
+
+    before do
+      allow(ROTP::TOTP).to receive(:new).and_return(totp_double)
+      allow(totp_double).to receive(:verify).and_return(true)
+      allow(totp_double).to receive(:provisioning_uri).and_return("blah")
+
+      # Log in org admin just so 2FA is enabled for their account.
+      sign_in_user(org_admin_user_1, pass_through_two_factor: false)
+      visit root_path
+      fill_in :code, with: '999999'
+      click_on "Complete setup"
+
+      sign_out
+
+      sign_in_user(super_admin_user, pass_through_two_factor: false)
+      visit root_path
+      fill_in :code, with: '999999'
+      click_on "Complete setup"
+    end
+
+    it "only shows the option to reset 2FA for org members who have 2FA enabled" do
+      visit super_admin_organisation_path(organisation)
+
+      expect(page).to have_content("Reset 2FA", count: 1)
+    end
+
+    it "shows confirmation before resetting 2FA for an org member" do
+      visit super_admin_organisation_path(super_admin_organisation)
+      click_on "Reset 2FA"
+
+      expect(page).to have_content("Are you sure you want to reset")
+    end
+
+    it "resets 2FA for an org member once super admin confirms the reset" do
+      visit super_admin_organisation_path(super_admin_organisation)
+      click_on "Reset 2FA"
+      click_on "Yes, reset two factor authentication"
+
+      expect(super_admin_user.reload.totp_enabled?).to be false
+    end
+
+    it "redirects back to org listing once 2FA has been reset" do
+      visit super_admin_organisation_path(organisation)
+      click_on "Reset 2FA"
+      click_on "Yes, reset two factor authentication"
+
+      expect(page).to have_current_path(super_admin_organisations_path)
+    end
+
+    it "shows a notice once 2FA has been reset" do
+      visit super_admin_organisation_path(organisation)
+      click_on "Reset 2FA"
+      click_on "Yes, reset two factor authentication"
+
+      expect(page).to have_content("Two factor authentication has been reset")
+    end
+  end
+
+  context "when logged in as an org admin user" do
+    let(:totp_double) { instance_double(ROTP::TOTP) }
+
+    before do
+      allow(ROTP::TOTP).to receive(:new).and_return(totp_double)
+      allow(totp_double).to receive(:verify).and_return(true)
+      allow(totp_double).to receive(:provisioning_uri).and_return("blah")
+
+      sign_in_user(org_admin_user_1, pass_through_two_factor: false)
+      visit root_path
+      fill_in :code, with: '999999'
+      click_on "Complete setup"
+
+      sign_out
+
+      sign_in_user(org_admin_user_2, pass_through_two_factor: false)
+      visit root_path
+      fill_in :code, with: '999999'
+      click_on "Complete setup"
+    end
+
+    it "only shows the option to reset 2FA for org members who have 2FA enabled" do
+      visit memberships_path
+
+      # Not 2, because "Reset 2FA" link does not show for the current user.
+      expect(page).to have_content("Reset 2FA", count: 1)
+    end
+
+    it "shows confirmation before resetting 2FA for an org member" do
+      visit memberships_path
+      click_on "Reset 2FA"
+
+      expect(page).to have_content("Are you sure you want to reset")
+    end
+
+    it "resets 2FA for an org member once org admin user confirms the reset" do
+      visit memberships_path
+      click_on "Reset 2FA"
+      click_on "Yes, reset two factor authentication"
+
+      expect(org_admin_user_1.reload.totp_enabled?).to be false
+    end
+
+    it "redirects back to members listing once 2FA has been reset" do
+      visit memberships_path
+      click_on "Reset 2FA"
+      click_on "Yes, reset two factor authentication"
+      expect(page).to have_current_path(memberships_path)
+    end
+
+    it "shows a notice once 2FA has been reset" do
+      visit memberships_path
+      click_on "Reset 2FA"
+      click_on "Yes, reset two factor authentication"
+      expect(page).to have_content("Two factor authentication has been reset")
+    end
+  end
+end

--- a/spec/features/team/reset_2fa_spec.rb
+++ b/spec/features/team/reset_2fa_spec.rb
@@ -1,6 +1,7 @@
 describe "Reset two factor authentication", type: :feature do
   let(:organisation) { create(:organisation) }
-  let!(:org_admin_user_1) { create(:user, :with_2fa, organisations: [organisation]) }
+
+  let(:org_admin_user_1) { create(:user, :with_2fa, organisations: [organisation]) }
   let(:org_admin_user_2) { create(:user, :with_2fa, organisations: [organisation]) }
   let(:org_admin_user_3) { create(:user, organisations: [organisation]) } # no 2fa
 
@@ -9,6 +10,7 @@ describe "Reset two factor authentication", type: :feature do
   context "when logged in as a super admin user" do
     before do
       sign_in_user(super_admin_user)
+      org_admin_user_1 # explicit call to avoid lazy-evaluation
     end
 
     it "only shows the option to reset 2FA for org members who have 2FA enabled" do
@@ -46,6 +48,14 @@ describe "Reset two factor authentication", type: :feature do
       click_on "Yes, reset two factor authentication"
 
       expect(page).to have_content("Two factor authentication has been reset")
+    end
+
+    context 'when visiting the superadmin team' do
+      it "shows a link to reset their own 2FA" do
+        visit super_admin_organisation_path(super_admin_user.organisations.first)
+
+        expect(page).to have_content("Reset 2FA", count: 1)
+      end
     end
   end
 

--- a/spec/features/team/reset_2fa_spec.rb
+++ b/spec/features/team/reset_2fa_spec.rb
@@ -1,14 +1,14 @@
 describe "Reset two factor authentication", type: :feature do
   let(:organisation) { create(:organisation) }
-  let(:org_admin_user_1) { create(:user, :with_2fa, organisations: [organisation]) }
+  let!(:org_admin_user_1) { create(:user, :with_2fa, organisations: [organisation]) }
   let(:org_admin_user_2) { create(:user, :with_2fa, organisations: [organisation]) }
+  let(:org_admin_user_3) { create(:user, organisations: [organisation]) } # no 2fa
 
   let(:super_admin_user) { create(:user, :super_admin) }
 
   context "when logged in as a super admin user" do
     before do
       sign_in_user(super_admin_user)
-      org_admin_user_1
     end
 
     it "only shows the option to reset 2FA for org members who have 2FA enabled" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -139,4 +139,52 @@ describe User do
       end
     end
   end
+
+  describe 'can_manage_other_user_for_org?' do
+    let(:organisation) { create(:organisation) }
+
+    let(:superadmin) { create(:user, :new_admin) }
+    let(:admin) { create(:user, organisations: [organisation]) }
+    let(:user) { create(:user, organisations: [organisation]) }
+    let(:colleague) { create(:user, organisations: [organisation]) }
+
+    context 'when the operator is a super admin' do
+      it 'returns true' do
+        expect(superadmin.can_manage_other_user_for_org?(user, organisation))
+          .to be true
+      end
+    end
+
+    context 'when the operator is not entitled to manage the team' do
+      before do
+        colleague.membership_for(organisation).update!(can_manage_team: false)
+      end
+
+      it 'returns false' do
+        expect(colleague.can_manage_other_user_for_org?(user, organisation))
+          .to be false
+      end
+    end
+
+    context 'when the operator can manage the team' do
+      it 'returns true' do
+        expect(admin.can_manage_other_user_for_org?(user, organisation))
+          .to be true
+      end
+    end
+
+    context 'when the user is not part of the same org' do
+      it 'returns false' do
+        expect(admin.can_manage_other_user_for_org?(create(:user, :with_organisation), organisation))
+          .to be false
+      end
+    end
+
+    context 'when the operator is not part of the same org' do
+      it 'returns false' do
+        expect(create(:user, :with_organisation).can_manage_other_user_for_org?(user, organisation))
+          .to be false
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -187,4 +187,16 @@ describe User do
       end
     end
   end
+
+  describe 'reset_2fa!' do
+    let(:user) { create(:user, :with_2fa) }
+
+    before do
+      user.reset_2fa!
+    end
+
+    it 'resets the two factor auth' do
+      expect(user).not_to be_totp_enabled
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,6 +22,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   config.include Warden::Test::Helpers
+  config.include Devise::Test::ControllerHelpers, type: :controller
 
   config.use_transactional_fixtures = true
 

--- a/spec/support/filters/validate_can_manage_team.rb
+++ b/spec/support/filters/validate_can_manage_team.rb
@@ -1,0 +1,45 @@
+RSpec.shared_context 'when using validate_can_manage_team' do
+  let(:organisation) { create(:organisation) }
+
+  let(:superadmin) { create(:user, :super_admin) }
+  let(:admin) { create(:user, organisations: [organisation]) }
+  let(:stranger) { create(:user, :with_organisation) }
+  let(:teammate) { create(:user, organisations: [organisation]) }
+
+  context 'when the current_user is not allowed to edit' do
+    before do
+      sign_in stranger
+      @response = get action, params: { id: teammate.id }
+    end
+
+    it 'redirects to the home page' do
+      expect(response).to redirect_to root_path
+    end
+
+    it 'does not assign the user variable' do
+      expect(assigns(:user)).to be_nil
+    end
+  end
+
+  context 'when the user is allowed to edit' do
+    before do
+      sign_in admin
+      @response = get action, params: { id: teammate.id }
+    end
+
+    it 'assigns the user variable' do
+      expect(assigns(:user)).to eq teammate
+    end
+  end
+
+  context 'when the user is a super admin' do
+    before do
+      sign_in superadmin
+      @response = get action, params: { id: teammate.id }
+    end
+
+    it 'assigns the user variable' do
+      expect(assigns(:user)).to eq teammate
+    end
+  end
+end

--- a/spec/support/filters/validate_can_manage_team.rb
+++ b/spec/support/filters/validate_can_manage_team.rb
@@ -15,10 +15,6 @@ RSpec.shared_context 'when using validate_can_manage_team' do
     it 'redirects to the home page' do
       expect(response).to redirect_to root_path
     end
-
-    it 'does not assign the user variable' do
-      expect(assigns(:user)).to be_nil
-    end
   end
 
   context 'when the user is allowed to edit' do
@@ -27,8 +23,8 @@ RSpec.shared_context 'when using validate_can_manage_team' do
       @response = get action, params: { id: teammate.id }
     end
 
-    it 'assigns the user variable' do
-      expect(assigns(:user)).to eq teammate
+    it 'does not redirect to the home page' do
+      expect(response).not_to redirect_to root_path
     end
   end
 
@@ -38,8 +34,8 @@ RSpec.shared_context 'when using validate_can_manage_team' do
       @response = get action, params: { id: teammate.id }
     end
 
-    it 'assigns the user variable' do
-      expect(assigns(:user)).to eq teammate
+    it 'does not redirect to the home page' do
+      expect(response).not_to redirect_to root_path
     end
   end
 end


### PR DESCRIPTION
## What is it?

This PR adds the functionality to allow org admins and super admins to be able to reset two-factor authentication device for other admin users. 

## Why is it needed?

We already require super admins to login with 2FA, and will soon allow normal admins to do the same. Currently, there isn't a way to reset 2FA device for super admins from the web admin portal, and devs have to do the dirty work of doing this directly on the database! This PR adds the necessary options to the web admin portal, so admins can easily do this themselves (as it should be!). This will become much more important once we roll out 2FA for org admins.

## How does it work?

For super admins, a button that resets 2FA has been added next to each member of an organisation, on the organisation detail pages.

![GovWifi_Admin](https://user-images.githubusercontent.com/3193694/72065725-ca800880-32d6-11ea-9164-a37f5294f977.jpg)

For normal admins, a link that resets 2FA has been added next to each member of their organisation who have 2FA already enabled on their account, on the membership listing page. The link isn't shown next to the current user's name on the listing.

![GovWifi_Admin](https://user-images.githubusercontent.com/3193694/72065965-57c35d00-32d7-11ea-8e3b-44000fce6704.jpg)
