### PR TITLE
FIX: Move yml anchor declaration above usage

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -56,6 +56,35 @@ resources:
       repository: nginx
       tag: alpine
 
+update-status-commands:
+  update-status-base: &update-status-base
+    put: update-status
+    resource: pull-request
+    get_params:
+      skip_download: true
+
+  update-status-params-base: &update-status-params-base
+    path: src
+    context: 'pr'
+
+  update-status-pending: &update-status-pending
+    <<: *update-status-base
+    params:
+      <<: *update-status-params-base
+      status: pending
+
+  update-status-failure: &update-status-failure
+    <<: *update-status-base
+    params:
+      <<: *update-status-params-base
+      status: failure
+
+  update-status-success: &update-status-success
+    <<: *update-status-base
+    params:
+      <<: *update-status-params-base
+      status: success
+
 jobs:
   - name: self-update
     serial: true
@@ -122,33 +151,3 @@ jobs:
     on_success:
       do:
         - <<: *update-status-success
-
-update-status-commands:
-  update-status-base: &update-status-base
-    put: update-status
-    resource: pull-request
-    get_params:
-      skip_download: true
-
-  update-status-params-base: &update-status-params-base
-    path: src
-    context: 'pr'
-
-  update-status-pending: &update-status-pending
-    <<: *update-status-base
-    params:
-      <<: *update-status-params-base
-      status: pending
-
-  update-status-failure: &update-status-failure
-    <<: *update-status-base
-    params:
-      <<: *update-status-params-base
-      status: failure
-
-  update-status-success: &update-status-success
-    <<: *update-status-base
-    params:
-      <<: *update-status-params-base
-      status: success
-


### PR DESCRIPTION
Fixes an error caused by a change to the yml parser used on CI. Similar to alphagov/govwifi-acceptance-tests#25