### PR TITLE
BAU: Run auto rebase for dependabots at night

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,7 +2,7 @@ version: 1
 update_configs:
   - package_manager: "ruby:bundler"
     directory: "/"
-    update_schedule: "live"
+    update_schedule: "daily"
 
   - package_manager: "docker"
     directory: "/"
@@ -10,4 +10,4 @@ update_configs:
 
   - package_manager: "javascript"
     directory: "/"
-    update_schedule: "live"
+    update_schedule: "daily"


### PR DESCRIPTION
The admin repo has a fair bit of movement and everytime we merge a PR, all pending dependabot PRs will automatically rebase and trigger a PR build on concourse. This can significantly impact build run time when you are regularly pushing on a branch.
So, for the time being, we are only running rebases at 3AM, which should also decrease the number of rebases and jobs triggered.