### PR TITLE
fix: don't let unauthenticated users download blobs

### DIFF
--- a/app/controllers/active_storage/blobs_controller.rb
+++ b/app/controllers/active_storage/blobs_controller.rb
@@ -1,0 +1,39 @@
+# NOTE TO READER: this replacement of ActiveStorage's blob controller
+# is in place to enforce authentication when accessing a blob. At the
+# time of writing, the `/rails/active_storage/blobs/XXX` path is not
+# protected which means the Rails app will happily generate a valid
+# link to the underlying service+asset and redirect anyone who asks
+# there.
+#
+# However ActiveStorage will naturally evolve and probably implement a
+# way to do this without redefining the controller itself but in the
+# meantime it means we've started diverging. This should be kept in
+# sight and ultimately removed.
+#
+# PS: a more direct `before_action: authenticate_user!` was causing an
+# error, probably because the filter is meant to be used in the
+# context of a Rails app rather than its internal engines.
+
+# frozen_string_literal: true
+
+# Take a signed permanent reference for a blob and turn it into an expiring service URL for download.
+# Note: These URLs are publicly accessible. If you need to enforce access protection beyond the
+# security-through-obscurity factor of the signed blob references, you'll need to implement your own
+# authenticated redirection controller.
+class ActiveStorage::BlobsController < ActiveStorage::BaseController
+  include ActiveStorage::SetBlob
+  include Rails.application.routes.url_helpers
+
+  before_action :check_user
+
+  def check_user
+    if current_user.nil?
+      redirect_to new_user_session_path
+    end
+  end
+
+  def show
+    expires_in ActiveStorage::Blob.service.url_expires_in
+    redirect_to @blob.service_url(disposition: params[:disposition])
+  end
+end

--- a/app/controllers/active_storage/blobs_controller.rb
+++ b/app/controllers/active_storage/blobs_controller.rb
@@ -1,18 +1,25 @@
 # NOTE TO READER: this replacement of ActiveStorage's blob controller
-# is in place to enforce authentication when accessing a blob. At the
-# time of writing, the `/rails/active_storage/blobs/XXX` path is not
-# protected which means the Rails app will happily generate a valid
-# link to the underlying service+asset and redirect anyone who asks
-# there.
+# is in place to enforce authentication with devise when accessing a
+# blob. At the time of writing, the `/rails/active_storage/blobs/XXX`
+# path is not protected which means the Rails app will happily
+# generate a valid link to the underlying service+asset and redirect
+# anyone who asks there.
 #
-# However ActiveStorage will naturally evolve and probably implement a
-# way to do this without redefining the controller itself but in the
-# meantime it means we've started diverging. This should be kept in
-# sight and ultimately removed.
+# Our code adds a filter to check for a logged-in user but also make
+# sure they belong to the organisation they are requesting the MoU
+# from.
+#
+# Let's keep in mind that ActiveStorage will naturally evolve and
+# probably implement a way to do this without redefining the
+# controller itself but in the meantime it means we've started
+# diverging. This should be kept in sight and ultimately removed.
 #
 # PS: a more direct `before_action: authenticate_user!` was causing an
 # error, probably because the filter is meant to be used in the
 # context of a Rails app rather than its internal engines.
+
+# the following code is copied from the original rails trunk at:
+# /active_storage/app/controllers/blobs_controller.rb
 
 # frozen_string_literal: true
 
@@ -29,6 +36,17 @@ class ActiveStorage::BlobsController < ActiveStorage::BaseController
   def check_user
     if current_user.nil?
       redirect_to new_user_session_path
+    else
+      # current_organisation is not available here
+      org = Organisation.find(
+        ActiveStorage::Attachment
+          .find_by(blob: @blob)
+          .record_id
+      )
+
+      unless can? :read_mou, org
+        redirect_to overview_index_path, alert: "You are not allowed to see this MoU."
+      end
     end
   end
 

--- a/app/controllers/active_storage/blobs_controller.rb
+++ b/app/controllers/active_storage/blobs_controller.rb
@@ -37,15 +37,14 @@ class ActiveStorage::BlobsController < ActiveStorage::BaseController
     if current_user.nil?
       redirect_to new_user_session_path
     else
-      # current_organisation is not available here
-      org = Organisation.find(
-        ActiveStorage::Attachment
-          .find_by(blob: @blob)
-          .record_id
-      )
+      attachment = ActiveStorage::Attachment.find_by(blob: @blob)
 
-      unless can? :read_mou, org
-        redirect_to overview_index_path, alert: "You are not allowed to see this MoU."
+      if attachment.name == "signed_mou"
+        org = Organisation.find attachment.record_id
+
+        unless can? :read_mou, org
+          redirect_to overview_index_path, alert: "You are not allowed to see this MoU."
+        end
       end
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,7 +6,11 @@ class Ability
   def initialize(user)
     if user.present?
       can :administrate, :all # FIXME: we can probaly scope this to user orgs
+      can :read_mou, Organisation do |org|
+        user.membership_for(org)
+      end
 
+      # :manage is a reserved can-can word to represent ALL actions
       if user.super_admin?
         can :manage, :all
       end

--- a/spec/features/upload_download_mous_spec.rb
+++ b/spec/features/upload_download_mous_spec.rb
@@ -71,7 +71,8 @@ describe "Uploading and downloading an MOU", type: :feature do
           it "lets them download the MoU" do
             visit @link
 
-            expect(page).to have_current_path(@link)
+            # as we're running locally, the actual asset lives under rails/active_storage/disk
+            expect(page.current_path).to start_with("/rails/active_storage/disk")
           end
         end
       end

--- a/spec/features/upload_download_mous_spec.rb
+++ b/spec/features/upload_download_mous_spec.rb
@@ -1,9 +1,32 @@
 describe "Uploading and downloading an MOU", type: :feature do
   let(:user) { create(:user, :with_organisation) }
+  let(:superadmin) { create(:user, :super_admin) }
 
   context "when signed in" do
     before do
       sign_in_user user
+    end
+
+    describe "MOU template" do
+      before do
+        visit root_path
+        sign_out
+
+        sign_in_user superadmin
+        visit super_admin_mou_index_path
+        attach_file("unsigned_document", Rails.root + "spec/fixtures/mou.pdf")
+        click_on "Upload"
+        sign_out
+
+        sign_in_user user
+        visit mou_index_path
+      end
+
+      it "allows users to download the MOU template" do
+        click_on "Download a copy of the MOU"
+
+        expect(page.current_path).to start_with "/rails/active_storage/disk/"
+      end
     end
 
     context "when no file is chosen to upload" do

--- a/spec/features/upload_download_mous_spec.rb
+++ b/spec/features/upload_download_mous_spec.rb
@@ -35,6 +35,21 @@ describe "Uploading and downloading an MOU", type: :feature do
       it 'redirects to "after MOU uploaded" path for analytics' do
         expect(page).to have_current_path("/mou/created")
       end
+
+      context "when someone is not authenticated and tries to get the link" do
+        before do
+          visit mou_index_path
+          @link = page.find("a", text: "download and view the document.")[:href]
+
+          sign_out
+        end
+
+        it "asks the user to authenticate" do
+          visit @link
+
+          expect(page).to have_current_path(new_user_session_path)
+        end
+      end
     end
 
     context "when replacing the signed mou" do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -12,7 +12,7 @@ describe Ability do
   end
 
   context "when a user is logged in" do
-    let(:user) { create(:user) }
+    let(:user) { create(:user, :with_organisation) }
     let(:ability) { described_class.new(user) }
 
     context "with a normal account" do
@@ -22,6 +22,22 @@ describe Ability do
 
       it "cannot manage" do
         expect(ability.can?(:manage, :all)).to be false
+      end
+
+      describe "reading the MOU" do
+        context "when the user is part of the organisation" do
+          it "can read the MOU" do
+            expect(ability.can?(:read_mou, user.organisations.first)).to be true
+          end
+        end
+
+        context "when the user is not part of the organisation" do
+          let(:other_org) { create(:organisation) }
+
+          it "cannot read the MOU" do
+            expect(ability.can?(:read_mou, other_org)).to be false
+          end
+        end
       end
     end
 


### PR DESCRIPTION
# Description
We don't want unauthenticated users to download files so override the ActiveStorage controller to prevent this. See commit and and commit message.
