### PR TITLE
BAU - allow manual trigger of PR jobs

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -105,7 +105,7 @@ jobs:
 
   - name: lint & test
     interruptible: true
-    disable_manual_trigger: true
+    disable_manual_trigger: false
     build_logs_to_retain: 10
     plan:
       - aggregate:


### PR DESCRIPTION
Occasionally a concourse PR build job will fail for reasons unrelated with the PR itself (network timeout, for example). This means we usually need to do a workaround of force pushing an "empty" commit to re-trigger the job.
This PR allows for concourse jobs to be triggered via the concourse GUI or via fly by pinning the version