### PR TITLE
Make it optional for org admins to be able to setup 2FA

### DIFF
--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -15,9 +15,9 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
   end
 
   def update
-    if params[:commit] == 'Remind me next time'
+    if params[:commit] == "Remind me next time"
       # Ensures the user doesn't go through 2FA check again.
-      request.env['warden'].session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
+      request.env["warden"].session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
       flash[:notice] = "Two factor authentication setup skipped until next time"
       redirect_to stored_location_for(:user) || root_path
       return

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -15,6 +15,14 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
   end
 
   def update
+    if params[:commit] == 'Remind me next time'
+      # Ensures the user doesn't go through 2FA check again.
+      request.env['warden'].session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
+      flash[:notice] = "Two factor authentication setup skipped until next time"
+      redirect_to stored_location_for(:user) || root_path
+      return
+    end
+
     @otp_secret_key = params[:otp_secret_key]
     if current_user.authenticate_totp(params[:code], otp_secret_key: @otp_secret_key)
       current_user.otp_secret_key = @otp_secret_key

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -16,10 +16,8 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
 
   def update
     if params[:commit] == "Remind me next time"
-      # Ensures the user doesn't go through 2FA check again.
-      request.env["warden"].session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
       flash[:notice] = "Two factor authentication setup skipped until next time"
-      redirect_to stored_location_for(:user) || root_path
+      disable_2fa_checks_for_session
       return
     end
 
@@ -27,12 +25,8 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
     if current_user.authenticate_totp(params[:code], otp_secret_key: @otp_secret_key)
       current_user.otp_secret_key = @otp_secret_key
       current_user.save(validate: false)
-
-      # Ensures the user doesn't go through 2FA check again.
-      request.env["warden"].session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
-
       flash[:notice] = "Two factor authentication setup successful"
-      redirect_to stored_location_for(:user) || root_path
+      disable_2fa_checks_for_session
     else
       flash[:alert] = "Six digit code is not valid"
       render "show"
@@ -69,4 +63,12 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
     qr_code.as_png(size: 180, fill: ChunkyPNG::Color::TRANSPARENT).to_data_url
   end
   helper_method :qr_code_uri
+
+private
+
+  def disable_2fa_checks_for_session
+    # Ensures the user doesn't go through 2FA check again.
+    request.env["warden"].session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
+    redirect_to stored_location_for(:user) || root_path
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,6 +79,7 @@ class User < ApplicationRecord
 
   def need_two_factor_authentication?(request)
     return false if ENV.key?("BYPASS_2FA")
+
     needs_auth = request.env["warden"].session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION]
     needs_auth.nil? || needs_auth || request.env["warden"].user.super_admin?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,7 +78,9 @@ class User < ApplicationRecord
   end
 
   def need_two_factor_authentication?(request)
-    !ENV.key?("BYPASS_2FA") && request.env["warden"].user.super_admin?
+    return false if ENV.key?("BYPASS_2FA")
+    needs_auth = request.env["warden"].session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION]
+    needs_auth.nil? || needs_auth || request.env["warden"].user.super_admin?
   end
 
   def reset_2fa!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,7 +81,7 @@ class User < ApplicationRecord
     return false if ENV.key?("BYPASS_2FA")
 
     needs_auth = request.env["warden"].session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION]
-    needs_auth.nil? || needs_auth || request.env["warden"].user.super_admin?
+    (needs_auth != false) || super_admin?
   end
 
   def reset_2fa!

--- a/app/views/users/two_factor_authentication_setup/show.html.erb
+++ b/app/views/users/two_factor_authentication_setup/show.html.erb
@@ -21,8 +21,8 @@
                              autocomplete: "off",
                              autofocus: true %>
         </div>
-        <%= submit_tag t('.complete_setup'), class: "govuk-button govuk-!-margin-right-1" %>
-        <%= submit_tag t('.skip_setup'), class: "govuk-button govuk-button--secondary" %>
+        <%= submit_tag t(".complete_setup"), class: "govuk-button govuk-!-margin-right-1" %>
+        <%= submit_tag t(".skip_setup"), class: "govuk-button govuk-button--secondary" %>
       <% end %>
     </div>
   </div>

--- a/app/views/users/two_factor_authentication_setup/show.html.erb
+++ b/app/views/users/two_factor_authentication_setup/show.html.erb
@@ -21,7 +21,8 @@
                              autocomplete: "off",
                              autofocus: true %>
         </div>
-        <input type="submit" class="govuk-button" value="Complete setup" />
+        <%= submit_tag t('.complete_setup'), class: "govuk-button" %>
+        <%= submit_tag t('.skip_setup'), class: "govuk-button govuk-button--secondary" %>
       <% end %>
     </div>
   </div>

--- a/app/views/users/two_factor_authentication_setup/show.html.erb
+++ b/app/views/users/two_factor_authentication_setup/show.html.erb
@@ -21,7 +21,7 @@
                              autocomplete: "off",
                              autofocus: true %>
         </div>
-        <%= submit_tag t('.complete_setup'), class: "govuk-button" %>
+        <%= submit_tag t('.complete_setup'), class: "govuk-button govuk-!-margin-right-1" %>
         <%= submit_tag t('.skip_setup'), class: "govuk-button govuk-button--secondary" %>
       <% end %>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,3 +17,9 @@ en:
               existing GovWifi installation, you must be invited to that \n
               organisation's team. <a class='govuk-link' href='/help/new'>Contact us</a> \n
               if you need help."
+
+  users:
+    two_factor_authentication_setup:
+      show:
+        complete_setup: "Complete setup"
+        skip_setup: "Remind me next time"

--- a/spec/features/authentication/set_up_two_factor_authentication_spec.rb
+++ b/spec/features/authentication/set_up_two_factor_authentication_spec.rb
@@ -84,8 +84,8 @@ describe "Set up two factor authentication", type: :feature do
   context "with a normal admin user" do
     let(:user) { create(:user, organisations: [organisation]) }
 
-    it "2FA setup is not enforced" do
-      expect(page).to have_current_path(new_organisation_setup_instructions_path)
+    it "enforces 2FA setup" do
+      expect(page).to have_current_path(users_two_factor_authentication_setup_path)
     end
   end
 end

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -12,6 +12,8 @@ describe "Sign up as an organisation", type: :feature do
     }
   end
 
+  after { Warden.test_reset! }
+
   include_context "when sending a confirmation email"
   include_context "when using the notifications service"
 

--- a/spec/features/support/sign_up_helpers.rb
+++ b/spec/features/support/sign_up_helpers.rb
@@ -23,6 +23,14 @@ def update_user_details(
   fill_in "Your name", with: name
   fill_in "Password", with: password
   click_on "Create my account"
+
+  skip_two_factor_authentication
+end
+
+def skip_two_factor_authentication
+  Warden.on_next_request do |proxy|
+    proxy.session(:user)[two_factor_session_key] = false
+  end
 end
 
 def confirmation_email_link

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -115,6 +115,10 @@ describe User do
     let(:request) { instance_double(ActionDispatch::Request, env: { "warden" => warden }) }
     let(:organisation) { create(:organisation) }
 
+    before do
+      allow(warden).to receive(:session).with(:user) { Hash[two_factor_session_key => nil] }
+    end
+
     context "with super admins membership" do
       let(:organisation) { create(:organisation, super_admin: true) }
 
@@ -124,7 +128,15 @@ describe User do
     end
 
     context "with a normal admin user" do
+      it "is true" do
+        expect(user.need_two_factor_authentication?(request)).to be true
+      end
+    end
+
+    context "when skipped for later" do
       it "is false" do
+        allow(warden).to receive(:session).with(:user) { Hash[two_factor_session_key => false] }
+
         expect(user.need_two_factor_authentication?(request)).to be false
       end
     end

--- a/spec/requests/home/get_spec.rb
+++ b/spec/requests/home/get_spec.rb
@@ -1,5 +1,5 @@
 describe "GET /home", type: :request do
-  let(:user) { create(:user, :with_organisation) }
+  let(:user) { create(:user, :with_2fa, :with_organisation) }
   let(:classic_admin) { create(:user, :super_admin) }
   let(:admin) { create(:user, :new_admin) }
   let(:both) { create(:user, :new_admin, :super_admin) }

--- a/spec/requests/ips/delete_spec.rb
+++ b/spec/requests/ips/delete_spec.rb
@@ -1,11 +1,12 @@
 describe "DELETE /ips/:id", type: :request do
-  let(:user) { create(:user, :with_organisation) }
+  let(:user) { create(:user, :with_2fa, :with_organisation) }
   let(:location) { create(:location, organisation: user.organisations.first) }
   let!(:ip) { create(:ip, location: location) }
 
   before do
     https!
     login_as(user, scope: :user)
+    skip_two_factor_authentication
     stub_request(:get, "http://169.254.169.254/latest/meta-data/iam/security-credentials/")
     stub_request(:put, /s3.eu-west-2/)
   end

--- a/spec/requests/locations/delete_spec.rb
+++ b/spec/requests/locations/delete_spec.rb
@@ -1,10 +1,11 @@
 describe "DELETE /locations/:id", type: :request do
-  let(:user) { create(:user, :with_organisation) }
+  let(:user) { create(:user, :with_2fa, :with_organisation) }
   let!(:location) { create(:location, organisation: user.organisations.first) }
 
   before do
     https!
     login_as(user, scope: :user)
+    skip_two_factor_authentication
   end
 
   context "when the user owns the location" do

--- a/spec/requests/users/invitations/create_spec.rb
+++ b/spec/requests/users/invitations/create_spec.rb
@@ -2,7 +2,7 @@ require "support/invite_use_case"
 require "support/notifications_service"
 
 describe "POST /users/invitation", type: :request do
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :with_2fa, organisations: [organisation]) }
   let(:organisation) { create(:organisation) }
 
   before do


### PR DESCRIPTION
## What is it?

This will basically present the two factor authentication (2FA) setup screen, as currently shown to super admin users only, to all org admins. At the moment, this is an optional thing, and users can skip setting it up, until next time.

## Why is it needed?

We already require two factory authentication for super admins. This PR extends it to org admins, for better security.

## How will it work?

Once org admins log into the admin portal, they will be presented with a screen to setup 2FA, by scanning a QR code - this is how it works for super admins currently and hasn't changed.

However, there is a new option added for skipping the 2FA setup, until next time, if the user isn't ready for this yet.

---

## Screenshots:

### Screenshot 1: Option to skip setting up 2FA until next time

![GovWifi Admin - Option to skip setting up 2FA until next time](https://user-images.githubusercontent.com/3193694/72537248-b22e6180-3873-11ea-8c0b-06350d097ca4.jpg)

---

### Screenshot 2: Flash message to confirm that 2FA setup has been skipped

![GovWifi Admin - Flash message to confirm that 2FA setup has been skipped](https://user-images.githubusercontent.com/3193694/72537239-ac388080-3873-11ea-88b5-aa6439f3df93.jpg)