### PR TITLE
feat: add a RSpec matcher to make sure Capybara downloads a file

### DIFF
--- a/spec/features/support/downloads.rb
+++ b/spec/features/support/downloads.rb
@@ -1,0 +1,15 @@
+require "rspec/expectations"
+
+RSpec::Matchers.define :download_file do |expected|
+  match do |actual|
+    if not actual.is_a? Capybara::Session
+      raise "you must call this matcher on a Capybara session (page object)"
+    end
+
+    if not expected.is_a? ActiveStorage::Attached
+      raise "you must call this matcher with an ActiveStorage attachment"
+    end
+
+    expected.blob.download == actual.body
+  end
+end

--- a/spec/features/upload_download_mous_spec.rb
+++ b/spec/features/upload_download_mous_spec.rb
@@ -25,7 +25,7 @@ describe "Uploading and downloading an MOU", type: :feature do
       it "allows users to download the MOU template" do
         click_on "Download a copy of the MOU"
 
-        expect(page.current_path).to start_with "/rails/active_storage/disk/"
+        expect(page).to download_file AdminConfig.mou.unsigned_document
       end
     end
 
@@ -95,7 +95,7 @@ describe "Uploading and downloading an MOU", type: :feature do
             visit @link
 
             # as we're running locally, the actual asset lives under rails/active_storage/disk
-            expect(page.current_path).to start_with("/rails/active_storage/disk")
+            expect(page).to download_file user.organisations.first.signed_mou
           end
         end
       end


### PR DESCRIPTION
# Description
Rather than using all sorts of hacks to check our file downloads (due
to the fact that Rails abstracts the underlying storage service and
therefore generates temporal, unique URLs), create an actual matcher
that accepts a Capybara::Session object (i.e the `page` variable) and
an ActiveStorage::Attached attachment to then compare their raw value
through `page.body` and the attachement's `blob.download` method.