### PR TITLE
Fix/insecure direct object references

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -30,7 +30,15 @@ class LocationsController < ApplicationController
 
   def add_ips
     @location = Location.find(params[:location_id])
-    @location.add_blank_ips(5)
+
+    if !current_organisation.locations.include? @location
+      redirect_to(
+        ips_path,
+        notice: "You are not authorised to edit this location",
+      )
+    else
+      @location.add_blank_ips(5)
+    end
   end
 
   def update_ips

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,5 +1,6 @@
 class LocationsController < ApplicationController
   before_action :authorise_manage_locations
+  before_action :authorise_manage_current_location, only: %i[add_ips update_ips update]
 
   def new
     @location = Location.new
@@ -30,20 +31,13 @@ class LocationsController < ApplicationController
 
   def add_ips
     @location = Location.find(params[:location_id])
-
-    if !current_organisation.locations.include? @location
-      redirect_to(
-        ips_path,
-        notice: "You are not authorised to edit this location",
-      )
-    else
-      @location.add_blank_ips(5)
-    end
+    @location.add_blank_ips(5)
   end
 
   def update_ips
     @location = Location.find(params[:location_id])
     length_of_ips_before = @location.ips.length
+
     if !present_ips.empty? && @location.update(ips_attributes: present_ips)
       Facades::Ips::Publish.new.execute
       length_of_ips_added = @location.ips.length - length_of_ips_before
@@ -76,8 +70,15 @@ private
     location_params = params
       .require(:location)
       .permit(ips_attributes: [:address])
+
     location_params[:ips_attributes].reject do |_, a|
       a["address"].blank? || @location.ips.map(&:address).include?(a["address"])
+    end
+  end
+
+  def authorise_manage_current_location
+    unless can? :edit, Location.find(params[:location_id] || params[:id])
+      redirect_to root_path, error: "You are not allowed to perform this operation"
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,6 +10,10 @@ class Ability
         user.membership_for(org)
       end
 
+      can :edit, Location do |loc|
+        user.membership_for(loc.organisation)
+      end
+
       # :manage is a reserved can-can word to represent ALL actions
       if user.super_admin?
         can :manage, :all

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -1,26 +1,82 @@
 require "rails_helper"
 
 RSpec.describe LocationsController, type: :controller do
-  let(:user) { create(:user, :with_organisation) }
+  let(:user) { create(:user, :with_organisation, :with_2fa) }
   let(:location) { create(:location, organisation: user.organisations.first) }
   let(:other_location) { create(:location, organisation: create(:organisation)) }
 
+  before do
+    sign_in user
+  end
+
   describe "GET /add_ips" do
-    before do
-      sign_in user
-    end
-
-    it "renders the add ip view" do
-      response = get :add_ips, params: { location_id: location.id }
-
-      expect(response).to render_template "add_ips"
-    end
-
     context "when the user does not belong to the organisation" do
-      it "redirects to user locations page" do
+      it "redirects to the root path" do
         response = get :add_ips, params: { location_id: other_location.id }
 
-        expect(response).to redirect_to(ips_path)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe "POST /update_ips" do
+    let(:params) {
+      {
+        location: {
+          ips_attributes: {
+            "0": { address: Faker::Internet.ip_v4_address },
+            "1": { address: Faker::Internet.ip_v4_address },
+          },
+        },
+        location_id: location.id,
+      }
+    }
+
+    context "when the update goes well" do
+      before do
+        @response = post :update_ips, params: params
+      end
+
+      it "redirects to the created ips path" do
+        expect(@response).to redirect_to(created_ips_path)
+      end
+    end
+
+    context "when the user is trying to access a location they don't manage" do
+      let(:other_location) {  create(:location) }
+      let(:other_params) {
+        params[:location_id] = other_location.id
+        params
+      }
+
+      before do
+        @response = post :update_ips, params: other_params
+      end
+
+      it "redirects them to the root path" do
+        expect(@response).to redirect_to root_path
+      end
+
+      it "does not update the location" do
+        expect(other_location.reload.ips).to be_empty
+      end
+    end
+  end
+
+  describe "POST /update" do
+    context "when the user does not belong to the requested location" do
+      it "redirects to the root path" do
+        @response = put :update, params: { id: other_location.id }
+
+        expect(@response).to redirect_to(root_path)
+      end
+    end
+
+    context "when the user belongs to the requested location" do
+      it "redirects to the ips path" do
+        @response = put :update, params: { id: location.id }
+
+        expect(@response).to redirect_to(ips_path)
       end
     end
   end

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe LocationsController, type: :controller do
+  let(:user) { create(:user, :with_organisation) }
+  let(:location) { create(:location, organisation: user.organisations.first) }
+  let(:other_location) { create(:location, organisation: create(:organisation)) }
+
+  describe "GET /add_ips" do
+    before do
+      sign_in user
+    end
+
+    it "renders the add ip view" do
+      response = get :add_ips, params: { location_id: location.id }
+
+      expect(response).to render_template "add_ips"
+    end
+
+    context "when the user does not belong to the organisation" do
+      it "redirects to user locations page" do
+        response = get :add_ips, params: { location_id: other_location.id }
+
+        expect(response).to redirect_to(ips_path)
+      end
+    end
+  end
+end

--- a/spec/features/locations/add_new_location_spec.rb
+++ b/spec/features/locations/add_new_location_spec.rb
@@ -74,12 +74,8 @@ describe "Add location", type: :feature do
       visit location_add_ips_path(other_loc.id)
     end
 
-    it "redirects to current organisation locations panel" do
-      expect(page).to have_current_path(ips_path)
-    end
-
-    it "displays a message to the user" do
-      expect(page).to have_content "not authorised to edit this location"
+    it "does not render the add_ips_path" do
+      expect(page).to_not have_current_path(location_add_ips_path)
     end
   end
 

--- a/spec/features/locations/add_new_location_spec.rb
+++ b/spec/features/locations/add_new_location_spec.rb
@@ -67,6 +67,22 @@ describe "Add location", type: :feature do
     end
   end
 
+  context "when trying to update a different location" do
+    let(:other_loc) { create(:location, organisation: create(:organisation)) }
+
+    before do
+      visit location_add_ips_path(other_loc.id)
+    end
+
+    it "redirects to current organisation locations panel" do
+      expect(page).to have_current_path(ips_path)
+    end
+
+    it "displays a message to the user" do
+      expect(page).to have_content "not authorised to edit this location"
+    end
+  end
+
   context "when logged out" do
     before do
       sign_out

--- a/spec/features/locations/add_new_location_spec.rb
+++ b/spec/features/locations/add_new_location_spec.rb
@@ -75,7 +75,7 @@ describe "Add location", type: :feature do
     end
 
     it "does not render the add_ips_path" do
-      expect(page).to_not have_current_path(location_add_ips_path)
+      expect(page).to_not have_current_path(location_add_ips_path(other_loc.id))
     end
   end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -39,6 +39,23 @@ describe Ability do
           end
         end
       end
+
+      describe "editing locations" do
+        let(:location) { create(:location, organisation: user.organisations.first) }
+        let(:other_location) { create(:location) }
+
+        context "when the user belongs to the parent organisation" do
+          it "can edit the location" do
+            expect(ability.can?(:edit, location)).to be true
+          end
+        end
+
+        context "when the user does not belong to the parent organisation" do
+          it "cannot edit the location" do
+            expect(ability.can?(:edit, other_location)).to be false
+          end
+        end
+      end
     end
 
     context "with a superadmin account" do


### PR DESCRIPTION
# Description
Ensure users can only modify objects (namely: IPs) when they are allowed to. Previously we would just parse the params and retrieve these objects which was a security concern.