### PR TITLE
Revert "build(deps-dev): bump rack-mini-profiler from 1.1.4 to 1.1.6"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,7 +200,7 @@ GEM
     puma (4.3.1)
       nio4r (~> 2.0)
     rack (2.2.2)
-    rack-mini-profiler (1.1.6)
+    rack-mini-profiler (1.1.4)
       rack (>= 1.2.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)


### PR DESCRIPTION
Reverts alphagov/govwifi-admin#957

Tests are failing on concourse; reverting this to unblock the pipeline while I investigate.