### PR TITLE
Feature/cookies

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,7 @@
 //= require all.js
+//= require govwifi-shared-frontend.js
 
 window.addEventListener("DOMContentLoaded", () => {
   window.GOVUKFrontend.initAll();
+  window.GovWifi.cookies.checkCookiePolicy();
 });

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -1,7 +1,13 @@
 //= require all.js
 //= require govwifi-shared-frontend.js
 
+const GA_ID = "<%= SITE_CONFIG["google_analytics_script_id"] %>";
+
 window.addEventListener("DOMContentLoaded", () => {
   window.GOVUKFrontend.initAll();
   window.GovWifi.cookies.checkCookiePolicy();
+
+  if (!!GA_ID && !GovWifi.cookies.isCategoryAllowed("tracking")) {
+    window['ga-disable-' + GA_ID] = true;
+  }
 });

--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -3,17 +3,13 @@
 
 <script>
  window.dataLayer = [{
-       'signedIn': '<%= user_signed_in?.to_json %>',
+     'signedIn': '<%= user_signed_in?.to_json %>',
      'hasIPs': '<%= (!!current_user && current_organisation&.ips&.any?).to_json %>'
  }];
 </script>
 
 <!-- Google Tag Manager -->
 <script>
- if (!GovWifi.cookies.isCategoryAllowed("tracking")) {
-     window['ga-disable-<%= SITE_CONFIG["google_analytics_script_id"] %>'] = true;
- }
-
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());

--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -1,31 +1,35 @@
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=<%= SITE_CONFIG["google_analytics_script_id"] %>"></script>
 
-  <script>
-    window.dataLayer = [{
-      'signedIn': '<%= user_signed_in?.to_json %>',
-      'hasIPs': '<%= (!!current_user && current_organisation&.ips&.any?).to_json %>'
-    }];
-  </script>
+<script>
+ window.dataLayer = [{
+       'signedIn': '<%= user_signed_in?.to_json %>',
+     'hasIPs': '<%= (!!current_user && current_organisation&.ips&.any?).to_json %>'
+ }];
+</script>
 
 <!-- Google Tag Manager -->
 <script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', <%= SITE_CONFIG["google_analytics_script_id"] %>);
+ if (!GovWifi.cookies.isCategoryAllowed("tracking")) {
+     window['ga-disable-<%= SITE_CONFIG["google_analytics_script_id"] %>'] = true;
+ }
 
-  (function(w, d, s, l, i) {
-    w[l] = w[l] || [];
-    w[l].push({
-      "gtm.start": new Date().getTime(),
-      event: "gtm.js"
-    });
-    var f = d.getElementsByTagName(s)[0],
-      j = d.createElement(s),
-      dl = l != "dataLayer" ? "&l=" + l : "";
-    j.async = true;
-    j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-    f.parentNode.insertBefore(j, f);
-  })(window, document, "script", "dataLayer", "GTM-WX4MM64");
+ window.dataLayer = window.dataLayer || [];
+ function gtag(){dataLayer.push(arguments);}
+ gtag('js', new Date());
+ gtag('config', <%= SITE_CONFIG["google_analytics_script_id"] %>);
+
+ (function(w, d, s, l, i) {
+     w[l] = w[l] || [];
+     w[l].push({
+         "gtm.start": new Date().getTime(),
+         event: "gtm.js"
+     });
+     var f = d.getElementsByTagName(s)[0],
+         j = d.createElement(s),
+         dl = l != "dataLayer" ? "&l=" + l : "";
+     j.async = true;
+     j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+     f.parentNode.insertBefore(j, f);
+ })(window, document, "script", "dataLayer", "GTM-WX4MM64");
 </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <!-- test post please ignore -->
 
-    <%= render 'layouts/google_analytics' %>
+    <%= render "layouts/google_analytics" %>
 
     <title><%= content_for?(:page_title) ? yield(:page_title) : SITE_CONFIG["default_page_title"] %></title>
 
@@ -36,7 +36,7 @@
   </head>
 
   <body class="govuk-template__body app-body-class">
-    <%= render 'layouts/google_tag_manager_no_script' %>
+    <%= render "layouts/google_tag_manager_no_script" %>
 
     <script>
         document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <!-- test post please ignore -->
 
-    <%#= render 'layouts/google_analytics' %>
+    <%= render 'layouts/google_analytics' %>
 
     <title><%= content_for?(:page_title) ? yield(:page_title) : SITE_CONFIG["default_page_title"] %></title>
 
@@ -36,7 +36,7 @@
   </head>
 
   <body class="govuk-template__body app-body-class">
-    <%#= render 'layouts/google_tag_manager_no_script' %>
+    <%= render 'layouts/google_tag_manager_no_script' %>
 
     <script>
         document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -17,5 +17,6 @@ Rails.application.config.assets.paths += [
   Rails.root.join("node_modules/govuk-frontend/govuk/assets/images"),
   Rails.root.join("node_modules/govuk-frontend/govuk/assets/fonts"),
   Rails.root.join("node_modules/govuk-frontend/govuk"),
+  Rails.root.join("node_modules/govwifi-shared-frontend/dist"),
   Rails.root.join("node_modules/html5shiv/dist"),
 ]

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "dependencies": {
     "govuk-frontend": "^3.5.0",
+    "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/0.6.2/govwifi-shared-frontend-0.6.2.tgz",
     "html5shiv": "^3.7.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "govuk-frontend": "^3.5.0",
-    "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/0.6.2/govwifi-shared-frontend-0.6.2.tgz",
+    "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/0.6.3/govwifi-shared-frontend-0.6.3.tgz",
     "html5shiv": "^3.7.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,17 @@ govuk-frontend@^3.5.0:
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.5.0.tgz#040e6fd0227f65d3e5820f8a05a9932ffdfb2a9e"
   integrity sha512-4tNKgcChO1bMNsrTz2UsK4fDMmU9R87UDxy/KhKIMbnhsuJLVuArDveYLkZuUsZ6B3eaCbl5gmI8i/Q/Mi680A==
 
+"govwifi-shared-frontend@https://github.com/alphagov/govwifi-shared-frontend/releases/download/0.6.3/govwifi-shared-frontend-0.6.3.tgz":
+  version "0.6.3"
+  resolved "https://github.com/alphagov/govwifi-shared-frontend/releases/download/0.6.3/govwifi-shared-frontend-0.6.3.tgz#6513c83caffbea007c6a7fef8fb89c7e48959166"
+  dependencies:
+    js-cookie "^2.2.1"
+
 html5shiv@^3.7.3:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/html5shiv/-/html5shiv-3.7.3.tgz#d78a84a367bcb9a710100d57802c387b084631d2"
+
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==


### PR DESCRIPTION
# Description
See https://github.com/alphagov/govwifi-product-page/pull/240. 

The difference in approach here is that admin is an actual server (as opposed to a statically generated website) so we want to include the shared frontend assets server-side but do the checking and potential disabling of analytics client-side.