### PR TITLE
fix: properly quote the GA ID

### DIFF
--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -13,7 +13,7 @@
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());
- gtag('config', <%= SITE_CONFIG["google_analytics_script_id"] %>);
+ gtag('config', '<%= SITE_CONFIG["google_analytics_script_id"] %>');
 
  (function(w, d, s, l, i) {
      w[l] = w[l] || [];


### PR DESCRIPTION
The development environment doesn't have a GA ID, which means the
substitution just ends up as

```js
gtag('config',)
```

which is perfectly valid in JS. However in staging and production, the
GA string isn't quoted so it's interpreted and inevitably crashes.