### PR TITLE
Fix broken styling on various links

### DIFF
--- a/app/assets/stylesheets/components/team_members.scss
+++ b/app/assets/stylesheets/components/team_members.scss
@@ -1,9 +1,11 @@
-.list-item-padding {
-  margin-bottom: -5px;
-}
+.membership-list {
+  .list-item-padding {
+    margin-bottom: -5px;
+  }
 
-.govuk-link {
-  display: block;
+  .govuk-link {
+    display: block;
+  }
 }
 
 .govuk-table__row {

--- a/app/views/memberships/_table.html.erb
+++ b/app/views/memberships/_table.html.erb
@@ -1,6 +1,6 @@
 <div class='govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0 govuk-!-margin-bottom-3'></div>
 
-<ul class='govuk-list govuk-width-container govuk-!-margin-left-0'>
+<ul class='govuk-list membership-list govuk-width-container govuk-!-margin-left-0'>
   <% team_members.each do |member| %>
     <li class='govuk-!-margin-bottom-1'>
       <div class='govuk-grid-row'>


### PR DESCRIPTION
Styling of (for example) the 'memorandum of understanding' reminder link was broken during implementation of the 2FA reset task (PR 931).

https://trello.com/c/eGfyV8mO/69-fix-broken-styling-of-links-on-admin-portal-estimate-small-1-2-days