### PR TITLE
fix: let superadmins invite team members to their own team

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -67,7 +67,12 @@ private
   end
 
   def set_target_organisation
-    @target_organisation = Organisation.find(params[:organisation_id])
+    @target_organisation =
+      if params[:organisation_id].present?
+        Organisation.find(params[:organisation_id])
+      else
+        current_organisation
+      end
   end
 
   def user_is_invalid?

--- a/spec/features/super_admin/invite_user_to_organisation_spec.rb
+++ b/spec/features/super_admin/invite_user_to_organisation_spec.rb
@@ -87,4 +87,24 @@ describe "Inviting a team member as a super admin", type: :feature do
       end
     end
   end
+
+  describe "going through the normal invite flow" do
+    let(:other_organisation) { create(:organisation) }
+
+    before do
+      super_admin.memberships.create!(organisation: other_organisation).confirm!
+
+      click_on "Switch organisation"
+      click_on other_organisation.name
+
+      visit memberships_path
+    end
+
+    it "sets the correct target organisation" do
+      click_on "Invite team member"
+
+      expect(page).to have_current_path(new_user_invitation_path)
+      expect(page).to have_content "Invite a team member to #{other_organisation.name}"
+    end
+  end
 end


### PR DESCRIPTION
# Description
A super-admin may be part of other organisations and try to invite
team members on their own team, going through the normal org flow (as
opposed to the omniscient superadmin one). In that scenario, we can't
assume an organisation ID was passed and need to fallback on the
current organisation.

# Testing
- pull branch;
- invite member as normal user;
- invite member of a foreign org as super-admin;
- invite member of an org the super-admin belongs-to.