### PR TITLE
gem: attempt an update to SASSC

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "notifications-ruby-client", "~> 5.1.2"
 gem "puma", "~> 4.3"
 gem "rails", "~> 6.0.3"
 gem "rqrcode"
-gem "sass-rails", "~> 5.1"
+gem "sassc-rails"
 gem "sentry-raven"
 gem "two_factor_authentication"
 gem "tzinfo-data"
@@ -37,7 +37,6 @@ group :test do
   gem "rails-controller-testing"
   gem "rspec-rails", "~> 4"
   gem "rubocop-govuk"
-  gem "scss_lint-govuk"
   gem "shoulda-matchers", "~> 4.3"
   gem "simplecov", require: false
   gem "simplecov-console", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,21 +307,14 @@ GEM
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.1.0)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
-    scss_lint-govuk (0.2.0)
-      scss_lint
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     sentry-raven (3.0.0)
       faraday (>= 1.0)
     shellany (0.0.1)
@@ -417,8 +410,7 @@ DEPENDENCIES
   rqrcode
   rspec-rails (~> 4)
   rubocop-govuk
-  sass-rails (~> 5.1)
-  scss_lint-govuk
+  sassc-rails
   sentry-raven
   shoulda-matchers (~> 4.3)
   simplecov

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,9 @@ serve: stop build
 	$(DOCKER_COMPOSE) run --rm app ./bin/rails db:create db:schema:load db:seed
 	$(DOCKER_COMPOSE) up -d app
 
-lint: lint-ruby lint-sass lint-erb
+lint: lint-ruby lint-erb
 lint-ruby: build
 	$(DOCKER_COMPOSE) run --rm app bundle exec rubocop
-lint-sass: build
-	$(DOCKER_COMPOSE) run --rm app bundle exec scss-lint app/assets/stylesheets
 lint-erb: build
 	$(DOCKER_COMPOSE) run --rm app bundle exec erblint --lint-all
 


### PR DESCRIPTION
This usually fails at the Concourse level but maybe having upgraded to
Rails 6 has eased the path.

Note that this removes the SASS linting tool as both
gems (`scss_lint-govuk` and `scss_lint`) are deprecated and are the
only gems dragging `sass` and `sass-rails`.

We should eventually replace it (stylelint seems to be the recommended
solution) but another PR will help keep this one small (also stylelint
might think differently to scss_lint causing a trivial-but-huge
diff).