### PR TITLE
Fix: Enforce password confirmation validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,8 @@ class User < ApplicationRecord
             presence: true,
             length: { within: 6..80 },
             on: :update,
-            if: :password_present?
+            if: :password_present?,
+            confirmation: true
 
   validate :strong_password, on: :update, if: :password_present?
 

--- a/spec/features/authentication/edit_password_spec.rb
+++ b/spec/features/authentication/edit_password_spec.rb
@@ -41,4 +41,25 @@ describe "Editing password", type: :feature do
 
     expect(page).to have_content "Sign out"
   end
+
+  it "stays on the same page and does not change the password, if the confirmation does not match" do
+    visit edit_user_registration_path
+
+    fill_in "Current password", with: user.password
+    fill_in "Password", with: pw
+    fill_in "Password confirmation", with: "different password"
+
+    click_on "Submit"
+
+    expect(page).to have_content "Password confirmation doesn't match Password"
+
+    sign_out
+
+    fill_in "Email", with: user.email
+    fill_in "Password", with: pw
+
+    click_on "Continue"
+
+    expect(page).not_to have_content "Sign out"
+  end
 end

--- a/spec/features/authentication/edit_password_spec.rb
+++ b/spec/features/authentication/edit_password_spec.rb
@@ -52,14 +52,5 @@ describe "Editing password", type: :feature do
     click_on "Submit"
 
     expect(page).to have_content "Password confirmation doesn't match Password"
-
-    sign_out
-
-    fill_in "Email", with: user.email
-    fill_in "Password", with: pw
-
-    click_on "Continue"
-
-    expect(page).not_to have_content "Sign out"
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,7 @@ describe User do
 
   describe "validation" do
     let(:user) { create(:user) }
+    let(:pw) { "this is 333 a strong !!! password" }
 
     it "has a valid factory user" do
       expect(user).to be_valid
@@ -11,6 +12,18 @@ describe User do
     ["password123", "my password", "pa55w0rd"].each do |weak_pass|
       it "does not accept a weak password (#{weak_pass})" do
         user.update(password: weak_pass)
+
+        expect(user).not_to be_valid
+      end
+
+      it "accepts a strong password" do
+        user.update(password: pw)
+
+        expect(user).to be_valid
+      end
+
+      it "checks for a password confirmation field" do
+        user.update(password: pw, password_confirmation: pw.reverse)
 
         expect(user).not_to be_valid
       end


### PR DESCRIPTION
Password confirmation was not being enforced on the password change screen.