### PR TITLE
Improve password strength feedback

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -1,6 +1,6 @@
 //= require all.js
 //= require jquery
-//= require jquery_ujs
+//= require rails-ujs
 //= require govwifi-shared-frontend.js
 //= require password_validation.js
 

--- a/app/assets/javascripts/password_validation.js
+++ b/app/assets/javascripts/password_validation.js
@@ -1,24 +1,54 @@
-$("#user_password").on("ajax:success", (event, xhr) => {
-  const { score } = xhr;
-  const suggestions = xhr.suggestions.length
-    ? xhr.suggestions
-    : "Choose a password that is harder to guess";
+const getSuggestionHtml = suggestions => {
+  const headingHtml = `
+    <span class="govuk-error-message govuk-!-margin-bottom-1">
+        Choose a password that is harder to guess${suggestions.length ? ':' : ''}
+    </span>
+  `;
+  const suggestionListHtml = `
+    <ul class="govuk-error-message govuk-list govuk-list--bullet">
+        ${suggestions.map(s => `<li>${s}</li>`).join('')}
+    </ul>
+  `;
+  return suggestions.length ? `${headingHtml}${suggestionListHtml}` : headingHtml;
+};
 
+const getScoreHtml = score => {
+  const scoreText = score < 2 ? 'weak' : (score < 4 ? 'medium' : 'good');
+  return `Password strength: <span class="password-strength-score">${scoreText}</span>`;
+};
+
+const updateScore = score => $('.password-strength').html(getScoreHtml(score));
+
+const updateError = suggestions => {
+  $('#password').addClass('govuk-form-group--error');
+  $('#password')
+    .find('input')
+    .addClass('govuk-input--error');
+  $('.password-error-message')
+    .css('display', 'inline-block')
+    .html(`<span class="govuk-visually-hidden">Error:</span> ${getSuggestionHtml(suggestions)}`);
+};
+
+const removeError = () => {
+  $('#password').removeClass('govuk-form-group--error');
+  $('#password')
+    .find('input')
+    .removeClass('govuk-input--error');
+  $('.govuk-error-message').css('display', 'none');
+};
+
+$('#user_password').on('ajax:success', event => {
+  const detail = event.detail;
+  const [data, status] = detail;
+  if (!data || typeof data !== 'object' || status !== 'OK') return;
+  const { score, suggestions } = data;
+  if (typeof score !== 'number') return;
+  updateScore(score);
   if (score < 4) {
-    $("#password").addClass("govuk-form-group--error");
-    $("#password")
-      .find("input")
-      .addClass("govuk-input--error");
-    $(".govuk-error-message")
-      .css("display", "inline-block")
-      .html(`<span class="govuk-visually-hidden">Error:</span> ${suggestions}`);
-  } else {
-    $("#password").removeClass("govuk-form-group--error");
-    $("#password")
-      .find("input")
-      .removeClass("govuk-input--error");
-    $(".govuk-error-message").css("display", "none");
+    updateError(suggestions);
+    return;
   }
+  removeError();
 });
 
 $("#user_password_visibility_toggle").click(handleVisibilityButton);

--- a/app/assets/javascripts/password_validation.js
+++ b/app/assets/javascripts/password_validation.js
@@ -13,8 +13,11 @@ const getSuggestionHtml = suggestions => {
 };
 
 const getScoreHtml = score => {
-  const scoreText = score < 2 ? 'weak' : (score < 4 ? 'medium' : 'good');
-  return `Password strength: <span class="password-strength-score">${scoreText}</span>`;
+  const scoreClassification = score < 2 ? 'weak' : (score < 4 ? 'medium' : 'good');
+  return `
+    Password strength:
+    <span class="password-strength-score score-${scoreClassification}">${scoreClassification}</span>
+  `;
 };
 
 const updateScore = score => $('.password-strength').html(getScoreHtml(score));
@@ -38,8 +41,7 @@ const removeError = () => {
 };
 
 $('#user_password').on('ajax:success', event => {
-  const detail = event.detail;
-  const [data, status] = detail;
+  const { detail: [data, status] } = event;
   if (!data || typeof data !== 'object' || status !== 'OK') return;
   const { score, suggestions } = data;
   if (typeof score !== 'number') return;

--- a/app/assets/javascripts/password_validation.js
+++ b/app/assets/javascripts/password_validation.js
@@ -51,23 +51,25 @@ $('#user_password').on('ajax:success', event => {
   removeError();
 });
 
-$("#user_password_visibility_toggle").click(handleVisibilityButton);
-$("#user_password_confirmation_visibility_toggle").click(handleVisibilityButton);
+$('#user_password_visibility_toggle').click(onVisibilityButtonToggle);
+$('#user_password_confirmation_visibility_toggle').click(onVisibilityButtonToggle);
 
-function handleVisibilityButton(clickEvent) {
+function onVisibilityButtonToggle(clickEvent) {
   const buttonId = clickEvent.target.id;
-  const visibilityTargetId = ("user_password_visibility_toggle" == buttonId) ? "user_password" : "user_password_confirmation";
+  const visibilityTargetId = 'user_password_visibility_toggle' === buttonId
+    ? 'user_password'
+    : 'user_password_confirmation';
   toggleVisibility(buttonId, visibilityTargetId);
 }
 
 function toggleVisibility(buttonId, targetElementId) {
-  const button = $("#" + buttonId);
-  const targetElement = $("#" + targetElementId);
-  if (button.text() == "Show") {
-    targetElement.attr("type", "text");
-    button.html("Hide");
+  const button = $('#' + buttonId);
+  const targetElement = $('#' + targetElementId);
+  if (button.text() === 'Show') {
+    targetElement.attr('type', 'text');
+    button.html('Hide');
   } else {
-    targetElement.attr("type", "password");
-    button.html("Show");
+    targetElement.attr('type', 'password');
+    button.html('Show');
   }
 }

--- a/app/assets/stylesheets/components/team_members.scss
+++ b/app/assets/stylesheets/components/team_members.scss
@@ -15,3 +15,21 @@
 .govuk-table__cell:last-child {
   padding-right: 20px;
 }
+
+#password {
+  .password-strength-score {
+    font-weight: bold;
+
+    &.score-weak {
+      color: $govuk-error-colour;
+    }
+
+    &.score-medium {
+      color: $govuk-brand-colour;
+    }
+
+    &.score-good {
+      color: $colour-green;
+    }
+  }
+}

--- a/app/assets/stylesheets/utilities/colours.scss
+++ b/app/assets/stylesheets/utilities/colours.scss
@@ -4,3 +4,4 @@ $colour-light-blue: govuk-colour('light-blue');
 $colour-dark-grey: govuk-colour('dark-grey');
 $colour-turquoise: govuk-colour('turquoise');
 $colour-white: govuk-colour('white');
+$colour-green: govuk-colour('green');

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -19,7 +19,7 @@
   <div id="password" class="govuk-form-group">
     <%= f.label :password, class: "govuk-label" %>
     <span class="password-strength govuk-hint"></span>
-    <span class="govuk-error-message"></span>
+    <div class="password-error-message"></div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
         <%= f.password_field :password, class: "govuk-input", data: { remote: true, url: check_password_strength_path, method: "post" } %>


### PR DESCRIPTION
# Description

This PR does the following:

* Fix the bug where jQuery UI had a conflict, which caused AJAX submissions outside of password strength feature to fail
* Improve password strength feedback message format
* Add password score, in order to make it easier for the user to know how much stronger a password needs to be, before being acceptable
* Code tightening and cleanup

Look at commit messages for better context.

# Screenshots

The following examples describe the before and after behaviour.

## Weak password with suggestion list

### Before

![GovWifi_Admin](https://user-images.githubusercontent.com/3193694/85060311-f31d0000-b19c-11ea-9c4e-4fdcf075a297.jpg)

### After
![Weak password with suggestion list](https://user-images.githubusercontent.com/3193694/85059687-f8c61600-b19b-11ea-82ba-3a7f01527630.jpg)

## Medium password with default suggestion

### Before

![GovWifi_Admin](https://user-images.githubusercontent.com/3193694/85060383-134cbf00-b19d-11ea-8121-086bb29364e5.jpg)

### After

![Medium password without suggestion list](https://user-images.githubusercontent.com/3193694/85059843-39259400-b19c-11ea-9f94-51845582ae50.jpg)

## Strong password

### Before

![GovWifi_Admin](https://user-images.githubusercontent.com/3193694/85060424-265f8f00-b19d-11ea-9137-000f90a59c79.jpg)

### After

![GovWifi_Admin](https://user-images.githubusercontent.com/3193694/85060101-93265980-b19c-11ea-8721-ddaa5c1be33f.jpg)