### PR TITLE
Fix the submission of forms created with `form_with`

### DIFF
--- a/app/views/logs_searches/contact.html.erb
+++ b/app/views/logs_searches/contact.html.erb
@@ -8,7 +8,7 @@
   <h1 class='govuk-heading-l govuk-grid-column-full'>Search for user details</h1>
 
   <div class='govuk-grid-column-two-thirds'>
-    <%= form_with url: super_admin_wifi_user_search_path do |f| %>
+    <%= form_with url: super_admin_wifi_user_search_path, local: true do |f| %>
       <p>
         <%= f.label :search_term, "Username, email address or phone number", class: "govuk-label", for: :search_term %>
         <%= f.text_field :search_term, class: "govuk-input govuk-input--width-50" %>

--- a/app/views/logs_searches/new.html.erb
+++ b/app/views/logs_searches/new.html.erb
@@ -8,7 +8,7 @@
       Logs are kept for recent authentication requests made to the GovWifi service.
     </p>
 
-    <%= form_with url: logs_searches_path, method: :post do |form| %>
+    <%= form_with url: logs_searches_path, method: :post, local: true do |form| %>
       <div class="govuk-form-group">
         <p class="govuk-body">
           How do you want to filter these logs?

--- a/app/views/super_admin/whitelists/steps/_fifth.html.erb
+++ b/app/views/super_admin/whitelists/steps/_fifth.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-l">Add the organisation's email domain to the whitelist</h1>
 
 <%= render "layouts/form_errors", resource: @email_domain %>
-<%= form_with model: @whitelist, url: new_super_admin_whitelist_path, method: :get do |form| %>
+<%= form_with model: @whitelist, url: new_super_admin_whitelist_path, method: :get, local: true do |form| %>
   <div class="govuk-form-group">
     <%= form.label :email_domain, value: "Email domain", for: :email_domain, class: "govuk-label" %>
     <%= form.text_field :email_domain, id: :email_domain, autocomplete: "off", class: "govuk-input govuk-input--width-30" %>

--- a/app/views/super_admin/whitelists/steps/_fourth.html.erb
+++ b/app/views/super_admin/whitelists/steps/_fourth.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-l">Add the organisation name to the register</h1>
 
 <%= render "layouts/form_errors", resource: @organisation_name %>
-<%= form_with model: @whitelist, url: new_super_admin_whitelist_path, method: :get do |form| %>
+<%= form_with model: @whitelist, url: new_super_admin_whitelist_path, method: :get, local: true do |form| %>
   <div class="govuk-form-group">
     <%= form.label :organisation_name, value: "Organisation name", for: :organisation_name, class: "govuk-label" %>
     <%= form.text_field :organisation_name, id: :organisation_name, autocomplete: "off", class: "govuk-input govuk-input--width-30" %>

--- a/app/views/super_admin/whitelists/steps/_sixth.html.erb
+++ b/app/views/super_admin/whitelists/steps/_sixth.html.erb
@@ -35,7 +35,7 @@
   </tbody>
 </table>
 
-<%= form_with model: @whitelist, url: super_admin_whitelist_path do |form| %>
+<%= form_with model: @whitelist, url: super_admin_whitelist_path, local: true do |form| %>
   <div class="govuk-form-group">
     <%= form.hidden_field :organisation_name, value: params.dig(:whitelist, :organisation_name) %>
     <%= form.hidden_field :email_domain, value: params.dig(:whitelist, :email_domain) %>


### PR DESCRIPTION
# Description

Forms created with `form_with` helper got broken (e.g. the logs search feature), ever since jQuery UI library was added (for password strength indicator).

This is because Rails forms created with `form_with` are remote (i.e. AJAX-based) by default. Due to this, when jQuery UI was introduced to the codebase, it also brought with it AJAX event handlers for such forms, which hijack form submissions in order to facilitate JS processing.

In this PR, we explicitly marks forms, which were supposed to be submitted locally (i.e. without AJAX), as local, so that their submission isn't hijacked.