### PR TITLE
Get rid of `status` check in password validation API response handler (in JS)

### DIFF
--- a/app/assets/javascripts/password_validation.js
+++ b/app/assets/javascripts/password_validation.js
@@ -41,8 +41,8 @@ const removeError = () => {
 };
 
 $('#user_password').on('ajax:success', event => {
-  const { detail: [data, status] } = event;
-  if (!data || typeof data !== 'object' || status !== 'OK') return;
+  const { detail: [data] } = event;
+  if (!data || typeof data !== 'object') return;
   const { score, suggestions } = data;
   if (typeof score !== 'number') return;
   updateScore(score);


### PR DESCRIPTION
This is because, for some weird reason, `status` field had a value of empty string, on production. Due to this flakiness, it's best not to rely on it, and as our existing checks for `score` being a number should suffice. It's also a success event handler anyway, so we should be good in theory.