### PR TITLE
BAU: fix upcoming linting errors

### DIFF
--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -36,7 +36,7 @@ private
 
   def validate_can_manage_team
     unless current_user.can_manage_team?(current_organisation)
-      raise ActionController::RoutingError.new("Not Found")
+      raise ActionController::RoutingError, "Not Found"
     end
   end
 

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -48,7 +48,7 @@ private
 
   def validate_user_is_part_of_organisation
     unless user_belongs_to_same_org
-      raise ActionController::RoutingError.new("Not Found")
+      raise ActionController::RoutingError, "Not Found"
     end
   end
 

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -36,7 +36,7 @@ protected
   end
 
   def with_unconfirmed_confirmable
-    if !@confirmable.new_record?
+    unless @confirmable.new_record?
       @confirmable.only_if_unconfirmed { yield }
     end
   end

--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -21,7 +21,6 @@ class AuthenticationMailer < ::Devise::Mailer
     reset_link = edit_password_url(record, reset_password_token: token)
     template_id = GOV_NOTIFY_CONFIG["reset_password_email"]["template_id"]
 
-
     UseCases::Administrator::SendResetPasswordEmail.new(
       notifications_gateway: EmailGateway.new,
     ).execute(

--- a/app/models/ip.rb
+++ b/app/models/ip.rb
@@ -6,7 +6,7 @@ class Ip < ApplicationRecord
 
   def inactive?
     Session
-      .where(siteIP: self.address)
+      .where(siteIP: address)
       .where("start > ?", Time.zone.today - 10.days)
       .limit(1)
       .empty?
@@ -18,7 +18,7 @@ class Ip < ApplicationRecord
 
   def unused?
     Session
-      .where(siteIP: self.address)
+      .where(siteIP: address)
       .limit(1)
       .empty?
   end
@@ -27,11 +27,11 @@ private
 
   def address_must_be_valid_ip
     checker = UseCases::Administrator::CheckIfValidIp.new
-    results = checker.execute(self.address)
+    results = checker.execute(address)
     errors.add(:address, results[:error_message]) unless results[:success] || address_not_present?
   end
 
   def address_not_present?
-    self.address.blank?
+    address.blank?
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -10,7 +10,7 @@ class Organisation < ApplicationRecord
   validates :service_email, format: { with: Devise.email_regexp, message: "must be a valid email address" }
   validate :validate_in_register?, unless: Proc.new { |org| org.name.blank? }
 
-  scope :sortable_with_child_counts, ->(sort_column, sort_direction) {
+  scope :sortable_with_child_counts, lambda { |sort_column, sort_direction|
     select("organisations.*, COUNT(DISTINCT(locations.id)) AS locations_count, COUNT(DISTINCT(ips.id)) AS ips_count")
     .joins("LEFT OUTER JOIN locations ON locations.organisation_id = organisations.id")
     .joins("LEFT OUTER JOIN ips ON ips.location_id = locations.id")

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -8,7 +8,7 @@ class Organisation < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :service_email, format: { with: Devise.email_regexp, message: "must be a valid email address" }
-  validate :validate_in_register?, unless: Proc.new { |org| org.name.blank? }
+  validate :validate_in_register?, unless: proc { |org| org.name.blank? }
 
   scope :sortable_with_child_counts, lambda { |sort_column, sort_direction|
     select("organisations.*, COUNT(DISTINCT(locations.id)) AS locations_count, COUNT(DISTINCT(ips.id)) AS ips_count")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -75,7 +75,7 @@ class User < ApplicationRecord
   end
 
   def super_admin?
-    membership_for(Organisation.super_admins) != nil || is_super_admin?
+    !membership_for(Organisation.super_admins).nil? || is_super_admin?
   end
 
   def need_two_factor_authentication?(request)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@ class User < ApplicationRecord
   validate :strong_password, on: :update, if: :password_present?
 
   def password_present?
-    not password.nil?
+    !password.nil?
   end
 
   def only_if_unconfirmed

--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -4,7 +4,7 @@
 <script>
  window.dataLayer = [{
      'signedIn': '<%= user_signed_in?.to_json %>',
-     'hasIPs': '<%= (!!current_user && current_organisation&.ips&.any?).to_json %>'
+     'hasIPs': '<%= (current_user && current_organisation&.ips&.any?).to_json %>'
  }];
 </script>
 

--- a/app/views/locations/add_ips.html.erb
+++ b/app/views/locations/add_ips.html.erb
@@ -42,7 +42,7 @@
       </span>
       <%= form.fields_for(:ips, @location.blank_ips) do |ip| %>
         <div class='govuk-!-margin-bottom-3'>
-          <% style = "govuk-input govuk-input--width-10" + (ip.object.errors.has_key?(:address) ? " govuk-input--error" : "") %>
+          <% style = "govuk-input govuk-input--width-10" + (ip.object.errors.key?(:address) ? " govuk-input--error" : "") %>
           <% if ip.object.errors.has_key?(:address) %>
             <span class="govuk-error-message">
               <span class="govuk-visually-hidden">Error:</span> <%= ip.object.errors.full_messages_for(:address).first %>

--- a/app/views/super_admin/organisations/show.html.erb
+++ b/app/views/super_admin/organisations/show.html.erb
@@ -11,7 +11,7 @@
     <p class="govuk-body govuk-!-margin-bottom-8">
       GovWifi organisation since <%= @organisation.created_at.strftime(
                                        "#{@organisation.created_at.day.ordinalize} of %B, %Y",
-      ) %>
+                                     ) %>
     </p>
 
     <%= render "section", heading: "Usage" do %>

--- a/app/views/users/two_factor_authentication/edit.html.erb
+++ b/app/views/users/two_factor_authentication/edit.html.erb
@@ -6,7 +6,9 @@
   </h2>
   <div class="govuk-error-summary__body">
     <%= button_to "Yes, reset two factor authentication",
-                  { controller: "users/two_factor_authentication", action: "destroy" }, method: :delete,
-                  id: @user, class: "govuk-button red-button" %>
+                  { controller: "users/two_factor_authentication", action: "destroy" },
+                  method: :delete,
+                  id: @user,
+                  class: "govuk-button red-button" %>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ Bundler.require(*Rails.groups)
 
 module GovwifiAdmin
   class Application < Rails::Application
-    config.exceptions_app = self.routes
+    config.exceptions_app = routes
 
     config.load_defaults 6.0
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -99,7 +99,8 @@ Rails.application.configure do
               measure_latency: false,
               type: "HTTP",
             },
-          }, {
+          },
+          {
             caller_reference: "AdminMonitoring",
             id: "xyz789",
             health_check_version: 1,
@@ -108,7 +109,7 @@ Rails.application.configure do
               measure_latency: false,
               type: "HTTP",
             },
-          }
+          },
         ],
       },
     },

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,6 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -339,7 +339,7 @@ Devise.setup do |config|
   config.max_login_attempts = 3 # Maximum second factor attempts count.
   config.allowed_otp_drift_seconds = 30 # Allowed TOTP time drift between client and server.
   config.otp_length = 6 # TOTP code length
-  config.remember_otp_session_for_seconds = 86400 # Time before browser has to perform 2fA again. Default is 0.
+  config.remember_otp_session_for_seconds = 86_400 # Time before browser has to perform 2fA again. Default is 0.
   config.otp_secret_encryption_key = ENV["OTP_SECRET_ENCRYPTION_KEY"]
   config.second_factor_resource_id = "id" # Field or method name used to set value for 2fA remember cookie
   config.delete_cookie_on_logout = false # Delete cookie when user signs out, to force 2fA again on login

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,7 @@ def create_user_for_organisations(
 )
   first_name = Faker::Name.first_name
   last_name = Faker::Name.last_name
-  email = email || first_name + "." + last_name + "@example.gov.uk"
+  email ||= first_name + "." + last_name + "@example.gov.uk"
   User.create(
     email: email,
     password: "password",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,7 +17,7 @@ def create_user_for_organisations(
     email: email,
     password: "password",
     name: first_name + " " + last_name,
-    confirmed_at:  confirmed_at,
+    confirmed_at: confirmed_at,
     organisations: organisations,
     is_super_admin: is_super_admin,
   )

--- a/lib/use_cases/administrator/check_if_valid_ip.rb
+++ b/lib/use_cases/administrator/check_if_valid_ip.rb
@@ -51,19 +51,15 @@ module UseCases
       end
 
       def address_is_ipv4?
-        begin
-          IPAddr.new(address).ipv4?
-        rescue IPAddr::InvalidAddressError
-          false
-        end
+        IPAddr.new(address).ipv4?
+      rescue IPAddr::InvalidAddressError
+        false
       end
 
       def address_is_ipv6?
-        begin
-          IPAddr.new(address).ipv6?
-        rescue IPAddr::InvalidAddressError
-          false
-        end
+        IPAddr.new(address).ipv6?
+      rescue IPAddr::InvalidAddressError
+        false
       end
 
       def address_is_not_loopback?

--- a/lib/use_cases/administrator/check_if_valid_ip.rb
+++ b/lib/use_cases/administrator/check_if_valid_ip.rb
@@ -39,7 +39,7 @@ module UseCases
 
         return "'#{address}' is a private IP address. Only public IPv4 addresses can be added." if private_ip_address?
 
-        "'#{address}' is not a valid IP address" if !valid_ipv4_address?
+        "'#{address}' is not a valid IP address" unless valid_ipv4_address?
       end
 
       def address_does_not_allows_all?

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe LocationsController, type: :controller do
   end
 
   describe "POST /update_ips" do
-    let(:params) {
+    let(:params) do
       {
         location: {
           ips_attributes: {
@@ -30,7 +30,7 @@ RSpec.describe LocationsController, type: :controller do
         },
         location_id: location.id,
       }
-    }
+    end
 
     context "when the update goes well" do
       before do
@@ -44,10 +44,10 @@ RSpec.describe LocationsController, type: :controller do
 
     context "when the user is trying to access a location they don't manage" do
       let(:other_location) {  create(:location) }
-      let(:other_params) {
+      let(:other_params) do
         params[:location_id] = other_location.id
         params
-      }
+      end
 
       before do
         @response = post :update_ips, params: other_params

--- a/spec/features/authentication/edit_password_spec.rb
+++ b/spec/features/authentication/edit_password_spec.rb
@@ -1,13 +1,13 @@
 describe "Editing password", type: :feature do
   let(:user) { create(:user, :with_2fa, :with_organisation) }
-  let(:pw) {
+  let(:pw) do
     Faker::Internet.password(
       min_length: 10,
       max_length: 20,
       mix_case: true,
       special_characters: true,
     )
-  }
+  end
 
   before do
     sign_in_user user

--- a/spec/features/ips/add_ip_to_existing_location_spec.rb
+++ b/spec/features/ips/add_ip_to_existing_location_spec.rb
@@ -141,9 +141,9 @@ describe "Adding an IP to an existing location", type: :feature do
     end
 
     context "when filling in all 5 boxes" do
-      let(:ip_addresses) {
+      let(:ip_addresses) do
         ["123.0.0.1", "123.0.0.2", "123.0.0.3", "123.0.0.4", "123.0.0.5"]
-      }
+      end
 
       it "shows a success message" do
         within(".flash-message-notice") do
@@ -159,9 +159,9 @@ describe "Adding an IP to an existing location", type: :feature do
     end
 
     context "when filling entering non-consecutive boxes" do
-      let(:ip_addresses) {
+      let(:ip_addresses) do
         ["123.0.1.1", "", "123.0.1.2", "", "123.0.1.3"]
-      }
+      end
 
       it "adds the IP addresses" do
         within(".flash-message-notice") do
@@ -179,9 +179,9 @@ describe "Adding an IP to an existing location", type: :feature do
     end
 
     context "with IP addresses already in use" do
-      let(:ip_addresses) {
+      let(:ip_addresses) do
         ["123.0.0.2", "123.0.0.10"]
-      }
+      end
 
       it "adds the IP addresses" do
         within(".flash-message-notice") do

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -183,13 +183,13 @@ describe "Sign up as an organisation", type: :feature do
     it_behaves_like "errors in form"
 
     it "shows the user an error message" do
-      within("div#error-summary")do
+      within("div#error-summary") do
         expect(page).to have_content("Organisations name is already registered")
       end
     end
 
     it "displays a contact us link" do
-      within("div#error-summary")do
+      within("div#error-summary") do
         expect(page).to have_link("Contact us", href: new_help_path)
       end
     end

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -25,7 +25,7 @@ describe "Sign up as an organisation", type: :feature do
     it "instructs the user to check their confirmation email" do
       expect(page).to have_content(
         "A confirmation email has been sent to your email address.",
-        )
+      )
     end
   end
 

--- a/spec/features/super_admin/locations/map_spec.rb
+++ b/spec/features/super_admin/locations/map_spec.rb
@@ -2,8 +2,8 @@ describe "GovWifi locations map", type: :feature do
   let!(:location) { create(:location, postcode: "SE10HS") }
 
   before do
-    stub_request(:post, "https://api.postcodes.io/postcodes").
-      to_return(status: 200, body: { 'result': [] }.to_json)
+    stub_request(:post, "https://api.postcodes.io/postcodes")
+      .to_return(status: 200, body: { 'result': [] }.to_json)
     user = create(:user, :super_admin)
     sign_in_user user
     visit map_super_admin_locations_path

--- a/spec/features/support/downloads.rb
+++ b/spec/features/support/downloads.rb
@@ -2,11 +2,11 @@ require "rspec/expectations"
 
 RSpec::Matchers.define :download_file do |expected|
   match do |actual|
-    if not actual.is_a? Capybara::Session
+    unless actual.is_a? Capybara::Session
       raise "you must call this matcher on a Capybara session (page object)"
     end
 
-    if not expected.is_a? ActiveStorage::Attached
+    unless expected.is_a? ActiveStorage::Attached
       raise "you must call this matcher with an ActiveStorage attachment"
     end
 

--- a/spec/features/upload_download_mous_spec.rb
+++ b/spec/features/upload_download_mous_spec.rb
@@ -150,7 +150,6 @@ describe "Uploading and downloading an MOU", type: :feature do
     end
   end
 
-
   context "when signed out" do
     before do
       visit mou_index_path

--- a/spec/gateways/coordinates_spec.rb
+++ b/spec/gateways/coordinates_spec.rb
@@ -5,8 +5,8 @@ describe Gateways::Coordinates do
     let(:postcodes) { %w[OX49 5NU M32 0JG] }
 
     before do
-      stub_request(:post, "https://api.postcodes.io/postcodes").
-      to_return(status: 200, body: {
+      stub_request(:post, "https://api.postcodes.io/postcodes")
+      .to_return(status: 200, body: {
         "status": 200,
         "result": [
             {
@@ -42,8 +42,8 @@ describe Gateways::Coordinates do
       let(:postcodes) { %w[not_a_valid_postcode] }
 
       before do
-        stub_request(:post, "https://api.postcodes.io/postcodes").
-        to_return(status: 200, body: {
+        stub_request(:post, "https://api.postcodes.io/postcodes")
+        .to_return(status: 200, body: {
             "status": 200,
             "result": [
                 {
@@ -64,8 +64,8 @@ describe Gateways::Coordinates do
       let(:postcodes) { %w[not_a_valid_postcode] }
 
       before do
-        stub_request(:post, "https://api.postcodes.io/postcodes").
-        to_return(status: 200, body: {
+        stub_request(:post, "https://api.postcodes.io/postcodes")
+        .to_return(status: 200, body: {
             "status": 200,
             "result": [
                 {
@@ -94,8 +94,8 @@ describe Gateways::Coordinates do
     let(:postcodes) { %w[HA72BL HA73BL HA74BL HA75BL] }
 
     before do
-      stub_request(:post, "https://api.postcodes.io/postcodes").
-      to_return(status: 200, body: {
+      stub_request(:post, "https://api.postcodes.io/postcodes")
+      .to_return(status: 200, body: {
         "status": 200,
         "result": [
             {

--- a/spec/gateways/coordinates_spec.rb
+++ b/spec/gateways/coordinates_spec.rb
@@ -16,13 +16,13 @@ describe Gateways::Coordinates do
               "longitude": -1.069849,
             },
           },
-            {
-              "query": "M32 0JG",
-              "result": {
-                "latitude": 53.455654,
-                "longitude": -2.302836,
-              },
+          {
+            "query": "M32 0JG",
+            "result": {
+              "latitude": 53.455654,
+              "longitude": -2.302836,
             },
+          },
         ],
       }.to_json, headers: {})
     end
@@ -105,27 +105,27 @@ describe Gateways::Coordinates do
               "longitude": -1.069849,
             },
           },
-            {
-              "query": "HA7 3BL",
-              "result": {
-                "latitude": 52.455654,
-                "longitude": -2.302836,
-              },
+          {
+            "query": "HA7 3BL",
+            "result": {
+              "latitude": 52.455654,
+              "longitude": -2.302836,
             },
-            {
-              "query": "HA7 4BL",
-              "result": {
-                "latitude": 53.656146,
-                "longitude": -1.069849,
-              },
+          },
+          {
+            "query": "HA7 4BL",
+            "result": {
+              "latitude": 53.656146,
+              "longitude": -1.069849,
             },
-            {
-              "query": "HA7 5BL",
-              "result": {
-                "latitude": 54.656146,
-                "longitude": -1.069849,
-              },
+          },
+          {
+            "query": "HA7 5BL",
+            "result": {
+              "latitude": 54.656146,
+              "longitude": -1.069849,
             },
+          },
         ],
       }.to_json, headers: {})
     end

--- a/spec/gateways/coordinates_spec.rb
+++ b/spec/gateways/coordinates_spec.rb
@@ -45,12 +45,12 @@ describe Gateways::Coordinates do
         stub_request(:post, "https://api.postcodes.io/postcodes")
         .to_return(status: 200, body: {
           "status": 200,
-            "result": [
-              {
-                "query": "not_valid",
-                  "result": nil,
-              },
-            ],
+          "result": [
+            {
+              "query": "not_valid",
+              "result": nil,
+            },
+          ],
         }.to_json, headers: {})
       end
 
@@ -67,18 +67,18 @@ describe Gateways::Coordinates do
         stub_request(:post, "https://api.postcodes.io/postcodes")
         .to_return(status: 200, body: {
           "status": 200,
-            "result": [
-              {
-                "query": "not_valid",
-                  "result": nil,
-              }, {
-                "query": "M32 0JG",
-                  "result": {
-                    "latitude": 53.455654,
-                    "longitude": -2.302836,
-                  },
-              }
-            ],
+          "result": [
+            {
+              "query": "not_valid",
+              "result": nil,
+            }, {
+              "query": "M32 0JG",
+              "result": {
+                  "latitude": 53.455654,
+                  "longitude": -2.302836,
+                },
+            }
+          ],
         }.to_json, headers: {})
       end
 

--- a/spec/gateways/coordinates_spec.rb
+++ b/spec/gateways/coordinates_spec.rb
@@ -9,13 +9,13 @@ describe Gateways::Coordinates do
       .to_return(status: 200, body: {
         "status": 200,
         "result": [
-            {
-              "query": "OX49 5NU",
-              "result": {
-                "latitude": 51.656146,
-                "longitude": -1.069849,
-                },
-            },
+          {
+            "query": "OX49 5NU",
+            "result": {
+              "latitude": 51.656146,
+              "longitude": -1.069849,
+              },
+          },
             {
               "query": "M32 0JG",
               "result": {
@@ -23,7 +23,7 @@ describe Gateways::Coordinates do
                 "longitude": -2.302836,
                 },
             },
-          ],
+        ],
         }.to_json, headers: {})
     end
 
@@ -46,10 +46,10 @@ describe Gateways::Coordinates do
         .to_return(status: 200, body: {
             "status": 200,
             "result": [
-                {
-                    "query": "not_valid",
-                    "result": nil,
-                },
+              {
+                  "query": "not_valid",
+                  "result": nil,
+              },
             ],
           }.to_json, headers: {})
       end
@@ -68,10 +68,10 @@ describe Gateways::Coordinates do
         .to_return(status: 200, body: {
             "status": 200,
             "result": [
-                {
-                    "query": "not_valid",
-                    "result": nil,
-                }, {
+              {
+                  "query": "not_valid",
+                  "result": nil,
+              }, {
                   "query": "M32 0JG",
                   "result": {
                     "latitude": 53.455654,
@@ -98,13 +98,13 @@ describe Gateways::Coordinates do
       .to_return(status: 200, body: {
         "status": 200,
         "result": [
-            {
-              "query": "HA7 2BL",
-              "result": {
-                "latitude": 51.656146,
-                "longitude": -1.069849,
-                },
-            },
+          {
+            "query": "HA7 2BL",
+            "result": {
+              "latitude": 51.656146,
+              "longitude": -1.069849,
+              },
+          },
             {
               "query": "HA7 3BL",
               "result": {
@@ -126,7 +126,7 @@ describe Gateways::Coordinates do
                 "longitude": -1.069849,
                 },
             },
-          ],
+        ],
         }.to_json, headers: {})
     end
 

--- a/spec/gateways/coordinates_spec.rb
+++ b/spec/gateways/coordinates_spec.rb
@@ -14,17 +14,17 @@ describe Gateways::Coordinates do
             "result": {
               "latitude": 51.656146,
               "longitude": -1.069849,
-              },
+            },
           },
             {
               "query": "M32 0JG",
               "result": {
                 "latitude": 53.455654,
                 "longitude": -2.302836,
-                },
+              },
             },
         ],
-        }.to_json, headers: {})
+      }.to_json, headers: {})
     end
 
     it "Converts the postcode to long and latitude" do
@@ -44,14 +44,14 @@ describe Gateways::Coordinates do
       before do
         stub_request(:post, "https://api.postcodes.io/postcodes")
         .to_return(status: 200, body: {
-            "status": 200,
+          "status": 200,
             "result": [
               {
-                  "query": "not_valid",
+                "query": "not_valid",
                   "result": nil,
               },
             ],
-          }.to_json, headers: {})
+        }.to_json, headers: {})
       end
 
       it "will return an empty list" do
@@ -66,20 +66,20 @@ describe Gateways::Coordinates do
       before do
         stub_request(:post, "https://api.postcodes.io/postcodes")
         .to_return(status: 200, body: {
-            "status": 200,
+          "status": 200,
             "result": [
               {
-                  "query": "not_valid",
+                "query": "not_valid",
                   "result": nil,
               }, {
-                  "query": "M32 0JG",
+                "query": "M32 0JG",
                   "result": {
                     "latitude": 53.455654,
                     "longitude": -2.302836,
-                    },
-                }
+                  },
+              }
             ],
-          }.to_json, headers: {})
+        }.to_json, headers: {})
       end
 
       it "returns only the valid postcode longitude and latitude" do
@@ -103,31 +103,31 @@ describe Gateways::Coordinates do
             "result": {
               "latitude": 51.656146,
               "longitude": -1.069849,
-              },
+            },
           },
             {
               "query": "HA7 3BL",
               "result": {
                 "latitude": 52.455654,
                 "longitude": -2.302836,
-                },
+              },
             },
             {
               "query": "HA7 4BL",
               "result": {
                 "latitude": 53.656146,
                 "longitude": -1.069849,
-                },
+              },
             },
             {
               "query": "HA7 5BL",
               "result": {
                 "latitude": 54.656146,
                 "longitude": -1.069849,
-                },
+              },
             },
         ],
-        }.to_json, headers: {})
+      }.to_json, headers: {})
     end
 
     it "batches them to prevent rate limiting" do

--- a/spec/gateways/coordinates_spec.rb
+++ b/spec/gateways/coordinates_spec.rb
@@ -71,13 +71,14 @@ describe Gateways::Coordinates do
             {
               "query": "not_valid",
               "result": nil,
-            }, {
+            },
+            {
               "query": "M32 0JG",
               "result": {
-                  "latitude": 53.455654,
-                  "longitude": -2.302836,
-                },
-            }
+                "latitude": 53.455654,
+                "longitude": -2.302836,
+              },
+            },
           ],
         }.to_json, headers: {})
       end

--- a/spec/gateways/ips_spec.rb
+++ b/spec/gateways/ips_spec.rb
@@ -8,10 +8,11 @@ describe Gateways::Ips do
       {
         ip: "186.3.1.2",
         location_id: location_1.id,
-      }, {
+      },
+      {
         ip: "186.3.1.1",
         location_id: location_2.id,
-      }
+      },
     ]
   end
 

--- a/spec/gateways/s3_spec.rb
+++ b/spec/gateways/s3_spec.rb
@@ -14,7 +14,7 @@ describe Gateways::S3 do
     before do
       Rails.application.config.s3_aws_config = {
         stub_responses: {
-          get_object: ->(context) {
+          get_object: lambda { |context|
             if context.params.fetch(:bucket) == bucket && context.params.fetch(:key) == key
               { body: "some data" }
             end

--- a/spec/gateways/s3_spec.rb
+++ b/spec/gateways/s3_spec.rb
@@ -5,7 +5,6 @@ describe Gateways::S3 do
   let(:key) { "StubKey" }
   let(:data) { { blah: "foobar" }.to_json }
 
-
   it "writes the data to the S3 bucket" do
     expect(gateway.write(data: data)).to eq({})
   end

--- a/spec/gateways/sessions_spec.rb
+++ b/spec/gateways/sessions_spec.rb
@@ -21,7 +21,7 @@ describe Gateways::Sessions do
     end
 
     context "when recent log entries contain only one of my IP addresses" do
-      let(:expected_result) {
+      let(:expected_result) do
         [
           {
             ap: nil,
@@ -39,7 +39,7 @@ describe Gateways::Sessions do
             username: "BOBABC",
           }
         ]
-      }
+      end
 
       before do
         create(:session, start: today_date, success: true, username: username, siteIP: "127.0.0.1")

--- a/spec/gateways/sessions_spec.rb
+++ b/spec/gateways/sessions_spec.rb
@@ -30,14 +30,15 @@ describe Gateways::Sessions do
             start: today_date,
             success: true,
             username: "BOBABC",
-          }, {
+          },
+          {
             ap: nil,
             mac: nil,
             site_ip: "127.0.0.1",
             start: yesterday,
             success: true,
             username: "BOBABC",
-          }
+          },
         ]
       end
 

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -52,7 +52,7 @@ describe Location do
   end
 
   context "when adding IPs with a mix of hash and strong parameters" do
-    let(:location) {
+    let(:location) do
       described_class.create(
         address: "6-8 HEMMING ST",
         postcode: "",
@@ -62,7 +62,7 @@ describe Location do
           "1" => ActionController::Parameters.new(address: "wrong"),
         ).permit!,
       )
-    }
+    end
 
     it "does not pass validation" do
       expect(location).not_to be_valid

--- a/spec/requests/email_domain/delete_spec.rb
+++ b/spec/requests/email_domain/delete_spec.rb
@@ -3,7 +3,6 @@ describe "DELETE /authorised_email_domains/:id", type: :request do
   let(:regex_gateway) { instance_spy(Gateways::S3, write: nil) }
   let(:email_domains_gateway) { instance_spy(Gateways::S3) }
 
-
   before { allow(Gateways::S3).to receive(:new).and_return(regex_gateway, email_domains_gateway) }
 
   context "when the user is a super admin" do

--- a/spec/requests/ips/create_spec.rb
+++ b/spec/requests/ips/create_spec.rb
@@ -8,12 +8,12 @@ describe "POST /ips", type: :request do
     Rails.application.config.force_ssl = false
     Rails.application.config.s3_aws_config = { access_key_id: "1234", secret_access_key: "abc" }
 
-    stub_request(:get, "http://169.254.169.254/latest/meta-data/iam/security-credentials/").
-    to_return(status: 200, body: "", headers: {})
+    stub_request(:get, "http://169.254.169.254/latest/meta-data/iam/security-credentials/")
+    .to_return(status: 200, body: "", headers: {})
 
-    stub_request(:put, "https://s3.eu-west-2.amazonaws.com/StubBucket/StubKey").
-    with(body: "[{\"ip\":\"#{ip_address}\",\"location_id\":#{location.id}}]").
-    to_return(status: 200, body: "", headers: {})
+    stub_request(:put, "https://s3.eu-west-2.amazonaws.com/StubBucket/StubKey")
+    .with(body: "[{\"ip\":\"#{ip_address}\",\"location_id\":#{location.id}}]")
+    .to_return(status: 200, body: "", headers: {})
   end
 
   it "publishes IP to s3 for performance platform" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,11 +30,11 @@ RSpec.configure do |config|
     FactoryBot.reload
     ActionMailer::Base.deliveries.clear
 
-    stub_request(:get, "https://government-organisation.register.gov.uk/records.json?page-size=5000").
-     to_return(status: 200, body: File.read(Rails.root.join("spec/fixtures/gov_orgs_payload.json")))
+    stub_request(:get, "https://government-organisation.register.gov.uk/records.json?page-size=5000")
+     .to_return(status: 200, body: File.read(Rails.root.join("spec/fixtures/gov_orgs_payload.json")))
 
-    stub_request(:get, "https://local-authority-eng.register.gov.uk/records.json?page-size=5000").
-      to_return(status: 200, body: File.read(Rails.root.join("spec/fixtures/local_auths_payload.json")))
+    stub_request(:get, "https://local-authority-eng.register.gov.uk/records.json?page-size=5000")
+      .to_return(status: 200, body: File.read(Rails.root.join("spec/fixtures/local_auths_payload.json")))
   end
 
   config.around do |example|

--- a/spec/use_cases/administrator/health_checks/calculate_health_spec.rb
+++ b/spec/use_cases/administrator/health_checks/calculate_health_spec.rb
@@ -11,13 +11,14 @@ class FakeHealthyRoute53Gateway
                                 status_report: {
                                   status: "Success: HTTP Status Code 200, OK",
                                 },
-                              }, {
+                              },
+                              {
                                 region: "ap-eu-west-1",
                                 ip_address: "27.111.39.33",
                                 status_report: {
                                   status: "Success: HTTP Status Code 200, OK",
                                 },
-                              }
+                              },
                             ])
 
     client.get_health_check_status(health_check_id: health_check_id)
@@ -40,7 +41,8 @@ class FakeHealthyRoute53Gateway
                 measure_latency: false,
                 type: "HTTP",
               },
-            }, {
+            },
+            {
               caller_reference: "AdminMonitoring",
               id: "xyz789",
               health_check_version: 1,
@@ -49,7 +51,7 @@ class FakeHealthyRoute53Gateway
                 measure_latency: false,
                 type: "HTTP",
               },
-            }
+            },
           ],
         },
       },

--- a/spec/use_cases/administrator/sort_users_spec.rb
+++ b/spec/use_cases/administrator/sort_users_spec.rb
@@ -9,9 +9,9 @@ describe UseCases::Administrator::SortUsers do
   context "when calling execute" do
     let(:valid_order_query) do
       Arel::Nodes::NamedFunction.new("COALESCE", [
-          User.arel_table["name"],
+        User.arel_table["name"],
           User.arel_table["email"],
-        ]).asc
+      ]).asc
     end
 
     before do

--- a/spec/use_cases/administrator/sort_users_spec.rb
+++ b/spec/use_cases/administrator/sort_users_spec.rb
@@ -10,7 +10,7 @@ describe UseCases::Administrator::SortUsers do
     let(:valid_order_query) do
       Arel::Nodes::NamedFunction.new("COALESCE", [
         User.arel_table["name"],
-          User.arel_table["email"],
+        User.arel_table["email"],
       ]).asc
     end
 

--- a/spec/use_cases/organisation/fetch_organisation_register_spec.rb
+++ b/spec/use_cases/organisation/fetch_organisation_register_spec.rb
@@ -50,9 +50,16 @@ describe UseCases::Organisation::FetchOrganisationRegister do
     end
     let(:expected_response) do
       [
-        "Gov Org 1", "Gov Org 2", "Gov Org 3", "Gov Org 4",
-        "Local Auth 1", "Local Auth 2", "Local Auth 3", "Local Auth 4",
-        "Custom Org 1", "Custom Org 2"
+        "Gov Org 1",
+        "Gov Org 2",
+        "Gov Org 3",
+        "Gov Org 4",
+        "Local Auth 1",
+        "Local Auth 2",
+        "Local Auth 3",
+        "Local Auth 4",
+        "Custom Org 1",
+        "Custom Org 2",
       ]
     end
 

--- a/spec/use_cases/performance_platform/publish_locations_ips_spec.rb
+++ b/spec/use_cases/performance_platform/publish_locations_ips_spec.rb
@@ -13,10 +13,11 @@ describe UseCases::PerformancePlatform::PublishLocationsIps do
       {
         ip: "127.0.0.1",
         location_id: 1,
-      }, {
+      },
+      {
         ip: "186.3.1.1",
         location_id: 2,
-      }
+      },
     ]
   end
 


### PR DESCRIPTION
This repo is using a very old version of rubocop-govuk.  We've not updated it in a long time, so there are a lot of linting violations blocking us from switching to the latest version.

This PR fixes some of those violations in advance. There are some others that are proving harder to fix. I hope to sort those out later, but for the moment, let's get these easier changes into master.

I've batched the changes into separate commits per rule (except for changes to .erb files, which are all done in one commit as there aren't many), because otherwise this would be a nightmare to review.