### PR TITLE
Use devise for tfa DO NOT MERGE

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,9 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :authenticate_user!, except: :error
-  before_action :confirm_two_factor_setup
+  before_action :confirm_two_factor_setup, unless: :tfa_feature_flag?
+  before_action :choose_two_factor_method, if: :tfa_feature_flag?
+
   before_action :configure_devise_permitted_parameters, if: :devise_controller?
   before_action :redirect_user_with_no_organisation, unless: :current_action_is_valid?
 
@@ -59,30 +61,28 @@ protected
     @valid_help_actions ||= %w[signed_in create].freeze
   end
 
-  def confirm_two_factor_setup
-    user = request.env["warden"].user
+  def tfa_feature_flag?
+    Rails.configuration.enable_enhanced_2fa_experience
+  end
 
-    if Rails.configuration.enable_enhanced_2fa_experience
-      return unless user
+  def choose_two_factor_method
+    return if user.nil?
 
-      unless user.second_factor_method.nil?
-        # Handled by Devise's controller.
-        return if user.second_factor_method == "app"
-
-        # Handled by us.
-        redirect_to users_two_factor_authentication_email_path
-        return
-      end
-
-      # TODO: Replace with route helper once fully migrated to enhanced 2FA.
+    if user.second_factor_method.nil?
       redirect_to "/users/two_factor_authentication/setup"
-      return
     end
+  end
 
+  def confirm_two_factor_setup
     return unless user &&
-      user.need_two_factor_authentication?(request) &&
-      !user.totp_enabled?
+        user.need_two_factor_authentication?(request) &&
+        !user.totp_enabled?
 
     redirect_to users_two_factor_authentication_setup_path
   end
+
+  def user
+    request.env["warden"].user
+  end
+
 end

--- a/app/controllers/users/two_factor_authentication/setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication/setup_controller.rb
@@ -51,7 +51,8 @@ class Users::TwoFactorAuthentication::SetupController < ApplicationController
 private
 
   def save_two_factor_method(method)
-    # TODO: This will be implemented in future.
+    current_user.second_factor_method = method
+    current_user.save
   end
 
   def send_email

--- a/app/controllers/users/two_factor_authentication/setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication/setup_controller.rb
@@ -3,6 +3,7 @@ class Users::TwoFactorAuthentication::SetupController < ApplicationController
   skip_before_action :handle_two_factor_authentication
   # Skips 2FA setup confirmation callback in ApplicationController.
   skip_before_action :confirm_two_factor_setup
+  skip_before_action :choose_two_factor_method
 
   helper_method :qr_code_uri
 

--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -1,5 +1,13 @@
-class Users::TwoFactorAuthenticationController < ApplicationController
+class Users::TwoFactorAuthenticationController < Devise::TwoFactorAuthenticationController
   before_action :validate_can_manage_team, only: %i[edit destroy]
+
+  def show
+    user = warden.user(resource_name)
+    unless user&.totp_enabled?
+      redirect_to "/users/two_factor_authentication/email"
+      return
+    end
+  end
 
   def edit
     @user = User.find(params.fetch(:id))

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -3,6 +3,7 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
   skip_before_action :handle_two_factor_authentication
   # Skips 2FA setup confirmation callback in ApplicationController.
   skip_before_action :confirm_two_factor_setup
+  skip_before_action :choose_two_factor_method
 
   def show
     # Used to populate the QR code used in setup.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,7 +83,8 @@ class User < ApplicationRecord
   def need_two_factor_authentication?(request)
     return false if ENV.key?("BYPASS_2FA")
 
-    true
+    needs_auth = request.env["warden"].session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION]
+    (needs_auth != false) || super_admin?
   end
 
   def reset_2fa!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,6 +81,9 @@ class User < ApplicationRecord
   end
 
   def need_two_factor_authentication?(request)
+    # 2FA becomes mandatory with the new 2FA experience.
+    return true if Rails.configuration.enable_enhanced_2fa_experience
+
     return false if ENV.key?("BYPASS_2FA")
 
     needs_auth = request.env["warden"].session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION]
@@ -109,7 +112,7 @@ class User < ApplicationRecord
   # via Users::TwoFactorAuthenticationSetupController so this mechanism is bypassed.
   def create_direct_otp(options = {}); end
 
-  # Indicate to two_factor_authentication gem that we are using TOTP
+  # Indicate to two_factor_authentication gem whether we are using TOTP or direct OTP (email).
   def direct_otp
     false
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,8 +83,7 @@ class User < ApplicationRecord
   def need_two_factor_authentication?(request)
     return false if ENV.key?("BYPASS_2FA")
 
-    needs_auth = request.env["warden"].session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION]
-    (needs_auth != false) || super_admin?
+    true
   end
 
   def reset_2fa!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,8 @@ class User < ApplicationRecord
 
   validate :strong_password, on: :update, if: :password_present?
 
+  enum second_factor_method: { email: "email", app: "app" }
+
   def password_present?
     !password.nil?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     registrations: "users/registrations",
     invitations: "users/invitations",
     passwords: "users/passwords",
+    two_factor_authentication: "users/two_factor_authentication"
   }
 
   devise_scope :user do

--- a/db/migrate/20200624102836_add_second_factor_method_to_users.rb
+++ b/db/migrate/20200624102836_add_second_factor_method_to_users.rb
@@ -1,0 +1,5 @@
+class AddSecondFactorMethodToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :second_factor_method, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_01_132306) do
+ActiveRecord::Schema.define(version: 2020_06_24_102836) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -135,6 +135,7 @@ ActiveRecord::Schema.define(version: 2019_11_01_132306) do
     t.string "encrypted_otp_secret_key_salt"
     t.timestamp "totp_timestamp"
     t.boolean "is_super_admin", default: false, null: false
+    t.string "second_factor_method"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true

--- a/spec/features/authentication/logging_in_after_signing_up_spec.rb
+++ b/spec/features/authentication/logging_in_after_signing_up_spec.rb
@@ -9,7 +9,8 @@ describe "Logging in after signing up", type: :feature do
 
   before do
     sign_up_for_account(email: "tom@gov.uk")
-    update_user_details(password: correct_password, two_factor_method: nil)
+    update_user_details(password: correct_password)
+    skip_two_factor_authentication
 
     click_on "Sign out"
 

--- a/spec/features/authentication/logging_in_after_signing_up_with_enhanced_2fa_spec.rb
+++ b/spec/features/authentication/logging_in_after_signing_up_with_enhanced_2fa_spec.rb
@@ -12,6 +12,7 @@ describe "Logging in after signing up", type: :feature do
 
     sign_up_for_account(email: "tom@gov.uk")
     update_user_details(password: correct_password)
+    complete_two_factor_authentication
 
     click_on "Sign out"
 

--- a/spec/features/authentication/logging_in_after_signing_up_with_enhanced_2fa_spec.rb
+++ b/spec/features/authentication/logging_in_after_signing_up_with_enhanced_2fa_spec.rb
@@ -8,8 +8,10 @@ describe "Logging in after signing up", type: :feature do
   include_context "when using the notifications service"
 
   before do
+    allow(Rails.application.config).to receive(:enable_enhanced_2fa_experience).and_return true
+
     sign_up_for_account(email: "tom@gov.uk")
-    update_user_details(password: correct_password, two_factor_method: nil)
+    update_user_details(password: correct_password)
 
     click_on "Sign out"
 

--- a/spec/features/authentication/set_up_enhanced_two_factor_authentication_spec.rb
+++ b/spec/features/authentication/set_up_enhanced_two_factor_authentication_spec.rb
@@ -61,6 +61,15 @@ describe "Set up two factor authentication", type: :feature do
     it "explains what can be done in case email is not received" do
       expect(page).to have_css("#resend-email")
     end
+
+    it "asks for the email 2FA method when user logs in again" do
+      click_on "Sign out"
+
+      sign_in_user(user, pass_through_two_factor: false)
+      visit root_path
+
+      expect(page).to have_content("We have emailed you a link to sign in to GovWifi.")
+    end
   end
 
   context "when admin user requests to re-send TOTP email" do
@@ -115,6 +124,16 @@ describe "Set up two factor authentication", type: :feature do
 
     it "redirects the user to the admin app" do
       expect(page).to have_current_path(super_admin_organisations_path)
+    end
+
+    it "asks for the app 2FA method when user logs in again" do
+      click_on "Sign out"
+
+      sign_in_user(user, pass_through_two_factor: false)
+      visit root_path
+
+      expect(page).to have_content("Please enter your 6 digit two factor authentication code.")
+      expect(page).to have_button("Authenticate")
     end
   end
 

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -32,11 +32,15 @@ describe "Sign up as an organisation", type: :feature do
   context "with correct data" do
     before do
       sign_up_for_account(email: email)
-      update_user_details(name: name, two_factor_method: nil)
+      update_user_details(name: name)
     end
 
     context "with a gov.uk email" do
       let(:email) { "someone@gov.uk" }
+
+      before do
+        skip_two_factor_authentication
+      end
 
       it "signs me in" do
         expect(page).to have_content "Sign out"
@@ -51,6 +55,10 @@ describe "Sign up as an organisation", type: :feature do
 
     context "with a email from a subdomain of gov.uk" do
       let(:email) { "someone@other.gov.uk" }
+
+      before do
+        skip_two_factor_authentication
+      end
 
       it "signs me in" do
         expect(page).to have_content "Sign out"
@@ -93,7 +101,8 @@ describe "Sign up as an organisation", type: :feature do
   context "when password is too short" do
     before do
       sign_up_for_account
-      update_user_details(password: "1", two_factor_method: nil)
+      update_user_details(password: "1")
+      skip_two_factor_authentication
     end
 
     it_behaves_like "errors in form"
@@ -108,7 +117,8 @@ describe "Sign up as an organisation", type: :feature do
 
     before do
       sign_up_for_account
-      update_user_details(password: "", two_factor_method: nil)
+      update_user_details(password: "")
+      skip_two_factor_authentication
     end
 
     it_behaves_like "errors in form"
@@ -121,7 +131,8 @@ describe "Sign up as an organisation", type: :feature do
   context "when service email is not filled in" do
     before do
       sign_up_for_account
-      update_user_details(service_email: "", two_factor_method: nil)
+      update_user_details(service_email: "")
+      skip_two_factor_authentication
     end
 
     it_behaves_like "errors in form"
@@ -134,7 +145,8 @@ describe "Sign up as an organisation", type: :feature do
   context "when service email entered is not an email address" do
     before do
       sign_up_for_account
-      update_user_details(service_email: "InvalidEmail", two_factor_method: nil)
+      update_user_details(service_email: "InvalidEmail")
+      skip_two_factor_authentication
     end
 
     it_behaves_like "errors in form"
@@ -147,7 +159,8 @@ describe "Sign up as an organisation", type: :feature do
   context "when password is too short" do
     before do
       sign_up_for_account
-      update_user_details(password: "1", two_factor_method: nil)
+      update_user_details(password: "1")
+      skip_two_factor_authentication
     end
 
     it_behaves_like "errors in form"
@@ -160,7 +173,8 @@ describe "Sign up as an organisation", type: :feature do
   context "when account is already confirmed" do
     before do
       sign_up_for_account
-      update_user_details(two_factor_method: nil)
+      update_user_details
+      skip_two_factor_authentication
       visit confirmation_email_link
     end
 
@@ -177,7 +191,8 @@ describe "Sign up as an organisation", type: :feature do
     before do
       sign_up_for_account
       create(:organisation, name: existing_org_name)
-      update_user_details(organisation_name: existing_org_name, two_factor_method: nil)
+      update_user_details(organisation_name: existing_org_name)
+      skip_two_factor_authentication
     end
 
     it_behaves_like "errors in form"
@@ -212,7 +227,8 @@ describe "Sign up as an organisation", type: :feature do
     before { sign_up_for_account }
 
     it "displays one error message that the name cannot be left blank" do
-      update_user_details(organisation_name: org_name_left_blank, two_factor_method: nil)
+      update_user_details(organisation_name: org_name_left_blank)
+      skip_two_factor_authentication
       within("div#error-summary") do
         expect(page).to have_selector("li#error-message", count: 1, text: "Organisations name can't be blank")
       end
@@ -231,7 +247,8 @@ describe "Sign up as an organisation", type: :feature do
       allow(presenter).to receive(:execute).and_return(data)
 
       sign_up_for_account
-      update_user_details(organisation_name: "Org 1", two_factor_method: nil)
+      update_user_details(organisation_name: "Org 1")
+      skip_two_factor_authentication
     end
 
     it "publishes the updated list of organisation names to S3" do

--- a/spec/features/registration/sign_up_as_an_organisation_with_enhanced_2fa_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_with_enhanced_2fa_spec.rb
@@ -162,6 +162,7 @@ describe "Sign up as an organisation", type: :feature do
     before do
       sign_up_for_account
       update_user_details
+      complete_two_factor_authentication
       visit confirmation_email_link
     end
 

--- a/spec/features/registration/sign_up_as_an_organisation_with_enhanced_2fa_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_with_enhanced_2fa_spec.rb
@@ -5,6 +5,7 @@ describe "Sign up as an organisation", type: :feature do
   let(:name) { "Sally" }
 
   before do
+    allow(Rails.application.config).to receive(:enable_enhanced_2fa_experience).and_return true
     Rails.application.config.s3_aws_config = {
       stub_responses: {
         get_object: { body: SIGNUP_WHITELIST_PREFIX_MATCHER + '(gov\.uk)$' },
@@ -32,7 +33,7 @@ describe "Sign up as an organisation", type: :feature do
   context "with correct data" do
     before do
       sign_up_for_account(email: email)
-      update_user_details(name: name, two_factor_method: nil)
+      update_user_details(name: name)
     end
 
     context "with a gov.uk email" do
@@ -93,7 +94,7 @@ describe "Sign up as an organisation", type: :feature do
   context "when password is too short" do
     before do
       sign_up_for_account
-      update_user_details(password: "1", two_factor_method: nil)
+      update_user_details(password: "1")
     end
 
     it_behaves_like "errors in form"
@@ -108,7 +109,7 @@ describe "Sign up as an organisation", type: :feature do
 
     before do
       sign_up_for_account
-      update_user_details(password: "", two_factor_method: nil)
+      update_user_details(password: "")
     end
 
     it_behaves_like "errors in form"
@@ -121,7 +122,7 @@ describe "Sign up as an organisation", type: :feature do
   context "when service email is not filled in" do
     before do
       sign_up_for_account
-      update_user_details(service_email: "", two_factor_method: nil)
+      update_user_details(service_email: "")
     end
 
     it_behaves_like "errors in form"
@@ -134,7 +135,7 @@ describe "Sign up as an organisation", type: :feature do
   context "when service email entered is not an email address" do
     before do
       sign_up_for_account
-      update_user_details(service_email: "InvalidEmail", two_factor_method: nil)
+      update_user_details(service_email: "InvalidEmail")
     end
 
     it_behaves_like "errors in form"
@@ -147,7 +148,7 @@ describe "Sign up as an organisation", type: :feature do
   context "when password is too short" do
     before do
       sign_up_for_account
-      update_user_details(password: "1", two_factor_method: nil)
+      update_user_details(password: "1")
     end
 
     it_behaves_like "errors in form"
@@ -160,7 +161,7 @@ describe "Sign up as an organisation", type: :feature do
   context "when account is already confirmed" do
     before do
       sign_up_for_account
-      update_user_details(two_factor_method: nil)
+      update_user_details
       visit confirmation_email_link
     end
 
@@ -177,7 +178,7 @@ describe "Sign up as an organisation", type: :feature do
     before do
       sign_up_for_account
       create(:organisation, name: existing_org_name)
-      update_user_details(organisation_name: existing_org_name, two_factor_method: nil)
+      update_user_details(organisation_name: existing_org_name)
     end
 
     it_behaves_like "errors in form"
@@ -212,7 +213,7 @@ describe "Sign up as an organisation", type: :feature do
     before { sign_up_for_account }
 
     it "displays one error message that the name cannot be left blank" do
-      update_user_details(organisation_name: org_name_left_blank, two_factor_method: nil)
+      update_user_details(organisation_name: org_name_left_blank)
       within("div#error-summary") do
         expect(page).to have_selector("li#error-message", count: 1, text: "Organisations name can't be blank")
       end
@@ -231,7 +232,7 @@ describe "Sign up as an organisation", type: :feature do
       allow(presenter).to receive(:execute).and_return(data)
 
       sign_up_for_account
-      update_user_details(organisation_name: "Org 1", two_factor_method: nil)
+      update_user_details(organisation_name: "Org 1")
     end
 
     it "publishes the updated list of organisation names to S3" do

--- a/spec/features/support/sign_up_helpers.rb
+++ b/spec/features/support/sign_up_helpers.rb
@@ -11,7 +11,8 @@ def update_user_details(
   password: "actually1 strongPassw0rd !!",
   name: "bob",
   service_email: "admin@gov.uk",
-  organisation_name: "Org 1"
+  organisation_name: "Org 1",
+  two_factor_method: "app"
 )
   return unless confirmation_email_received?
 
@@ -24,13 +25,24 @@ def update_user_details(
   fill_in "Password", with: password
   click_on "Create my account"
 
-  skip_two_factor_authentication
+  complete_two_factor_authentication(two_factor_method)
 end
 
+#TODO - Check whether this is still needed
 def skip_two_factor_authentication
   Warden.on_next_request do |proxy|
     proxy.session(:user)[two_factor_session_key] = false
   end
+end
+
+def complete_two_factor_authentication(two_factor_method)
+  totp_double = instance_double(ROTP::TOTP)
+
+  allow(ROTP::TOTP).to receive(:new).and_return(totp_double)
+  allow(totp_double).to receive(:verify).and_return(true)
+
+  fill_in :code, with: "999999"
+  click_on "Complete setup"
 end
 
 def confirmation_email_link

--- a/spec/features/support/sign_up_helpers.rb
+++ b/spec/features/support/sign_up_helpers.rb
@@ -28,7 +28,7 @@ def update_user_details(
   complete_two_factor_authentication(two_factor_method)
 end
 
-#TODO - Check whether this is still needed
+# TODO: Check whether this is still needed
 def skip_two_factor_authentication
   Warden.on_next_request do |proxy|
     proxy.session(:user)[two_factor_session_key] = false
@@ -40,6 +40,9 @@ def complete_two_factor_authentication(two_factor_method)
 
   allow(ROTP::TOTP).to receive(:new).and_return(totp_double)
   allow(totp_double).to receive(:verify).and_return(true)
+
+  choose "app"
+  click_on "Continue"
 
   fill_in :code, with: "999999"
   click_on "Complete setup"

--- a/spec/features/support/sign_up_helpers.rb
+++ b/spec/features/support/sign_up_helpers.rb
@@ -25,7 +25,11 @@ def update_user_details(
   fill_in "Password", with: password
   click_on "Create my account"
 
-  complete_two_factor_authentication(two_factor_method)
+  if two_factor_method.nil?
+    skip_two_factor_authentication
+  else
+    complete_two_factor_authentication(two_factor_method)
+  end
 end
 
 # TODO: Check whether this is still needed
@@ -40,6 +44,7 @@ def complete_two_factor_authentication(two_factor_method)
 
   allow(ROTP::TOTP).to receive(:new).and_return(totp_double)
   allow(totp_double).to receive(:verify).and_return(true)
+  allow(totp_double).to receive(:provisioning_uri).and_return("some-url")
 
   choose "app"
   click_on "Continue"

--- a/spec/features/support/sign_up_helpers.rb
+++ b/spec/features/support/sign_up_helpers.rb
@@ -11,8 +11,7 @@ def update_user_details(
   password: "actually1 strongPassw0rd !!",
   name: "bob",
   service_email: "admin@gov.uk",
-  organisation_name: "Org 1",
-  two_factor_method: "app"
+  organisation_name: "Org 1"
 )
   return unless confirmation_email_received?
 
@@ -24,22 +23,15 @@ def update_user_details(
   fill_in "Your name", with: name
   fill_in "Password", with: password
   click_on "Create my account"
-
-  if two_factor_method.nil?
-    skip_two_factor_authentication
-  else
-    complete_two_factor_authentication(two_factor_method)
-  end
 end
 
-# TODO: Check whether this is still needed
 def skip_two_factor_authentication
   Warden.on_next_request do |proxy|
     proxy.session(:user)[two_factor_session_key] = false
   end
 end
 
-def complete_two_factor_authentication(two_factor_method)
+def complete_two_factor_authentication
   totp_double = instance_double(ROTP::TOTP)
 
   allow(ROTP::TOTP).to receive(:new).and_return(totp_double)

--- a/spec/requests/users/two_factor_authentication/setup/update_spec.rb
+++ b/spec/requests/users/two_factor_authentication/setup/update_spec.rb
@@ -1,0 +1,33 @@
+describe "PUT /users/two_factor_authentication/setup/:method", type: :request do
+  let(:organisation) { create(:organisation) }
+
+  before do
+    https!
+    @user = create(:user, :with_2fa, organisations: [organisation])
+    sign_in_user(@user)
+    totp_double = double(ROTP::TOTP)
+    allow(ROTP::TOTP).to receive(:new).and_return(totp_double)
+    allow(totp_double).to receive(:verify).and_return(true)
+  end
+
+  context "'email' is passed as the 2FA method'" do
+    it "saves 'email' as the 2FA method" do
+      put "/users/two_factor_authentication/setup", params: { method: "email" }
+      expect(@user.reload.second_factor_method).to eq("email")
+    end
+  end
+
+  context "nonsense is passed as the 2FA method'" do
+    it "saves 'app' as the 2FA method" do
+      put "/users/two_factor_authentication/setup", params: { method: "blah", code: "a_code" }
+      expect(@user.reload.second_factor_method).to_not eq("blah")
+    end
+  end
+
+  context "'app' is passed as the 2FA method" do
+    it "saves 'app' as the 2FA method" do
+      put "/users/two_factor_authentication/setup", params: { method: "app", code: "a_code" }
+      expect(@user.reload.second_factor_method).to eq("app")
+    end
+  end
+end


### PR DESCRIPTION
-- DO NOT MERGE -- 

= only the last commit is relevant = 

Use devise controller for email and totp 2fa methods.

Simplify the code by inheriting the original Devise 'two_factor_authentication_controller'.

Split out the 2fa before method ```#confirm_two_factor_setup``` into the better named ```#confirm_two_factor_setup``` and ```#choose_two_factor_method```