### PR TITLE
Fixed linting issues.

### DIFF
--- a/app/models/authorised_email_domain.rb
+++ b/app/models/authorised_email_domain.rb
@@ -1,4 +1,4 @@
 class AuthorisedEmailDomain < ApplicationRecord
   validates :name, presence: true, uniqueness: { case_sensitive: false }
-  validates_format_of :name, with: /\A[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/, on: :create
+  validates :name, format: { with: /\A[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/, on: :create }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  has_many :memberships, inverse_of: :user # rubocop:disable Rails/HasManyOrHasOneDependent
+  has_many :memberships, inverse_of: :user, dependent: :destroy
   has_many :organisations, through: :memberships, inverse_of: :users
 
   accepts_nested_attributes_for :organisations, :memberships

--- a/db/migrate/20200803151344_add_uniqueness_index_to_organisation.rb
+++ b/db/migrate/20200803151344_add_uniqueness_index_to_organisation.rb
@@ -1,0 +1,5 @@
+class AddUniquenessIndexToOrganisation < ActiveRecord::Migration[6.0]
+  def change
+    add_index :organisations, :name, unique: true
+  end
+end

--- a/db/migrate/20200803151856_add_uniqueness_index_to_authorised_email_domain.rb
+++ b/db/migrate/20200803151856_add_uniqueness_index_to_authorised_email_domain.rb
@@ -1,0 +1,5 @@
+class AddUniquenessIndexToAuthorisedEmailDomain < ActiveRecord::Migration[6.0]
+  def change
+    add_index :authorised_email_domains, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_24_102836) do
+ActiveRecord::Schema.define(version: 2020_08_03_151856) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2020_06_24_102836) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_authorised_email_domains_on_name", unique: true
   end
 
   create_table "custom_organisation_names", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -89,6 +90,7 @@ ActiveRecord::Schema.define(version: 2020_06_24_102836) do
     t.datetime "updated_at", null: false
     t.string "service_email"
     t.boolean "super_admin", default: false
+    t.index ["name"], name: "index_organisations_on_name", unique: true
   end
 
   create_table "permissions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/lib/gateways/route53.rb
+++ b/lib/gateways/route53.rb
@@ -4,9 +4,7 @@ module Gateways
       @client = Aws::Route53::Client.new(config)
     end
 
-    def list_health_checks
-      client.list_health_checks
-    end
+    delegate :list_health_checks, to: :client
 
     def get_health_check_status(health_check_id:)
       client.get_health_check_status(health_check_id: health_check_id)

--- a/lib/tasks/repair_migrated_data.rake
+++ b/lib/tasks/repair_migrated_data.rake
@@ -1,4 +1,5 @@
 namespace :repair_migrated_data do
+  desc "Adds missing default locations"
   task add_missing_default_location_to_organisations: :environment do
     missing_default_locations = Organisation.all.select do |org|
       org.locations.empty?
@@ -9,6 +10,7 @@ namespace :repair_migrated_data do
     end
   end
 
+  desc "Confirms and creates passwords for users"
   task confirm_and_create_passwords_for_users: :environment do
     User.all.each do |user|
       random_password = Devise.friendly_token.first(16)

--- a/spec/gateways/authorised_email_domains_spec.rb
+++ b/spec/gateways/authorised_email_domains_spec.rb
@@ -14,6 +14,6 @@ describe Gateways::AuthorisedEmailDomains do
   end
 
   it "fetches the locations ips" do
-    expect(domain_gateway.fetch_domains).to eq(result)
+    expect(domain_gateway.fetch_domains).to match_array(result)
   end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -213,7 +213,13 @@ describe Organisation do
     let(:ip4) { create(:ip, location: location2) }
     let(:ip5) { create(:ip, location: location3) }
 
-    before { ip1; ip2; ip3; ip4; ip5 }
+    before do
+      ip1
+      ip2
+      ip3
+      ip4
+      ip5
+    end
 
     it "exports organisation names" do
       expect(csv.first["Name"]).to eq(org1.name)
@@ -240,7 +246,10 @@ describe Organisation do
     let(:user1) { create(:user, email: org1.service_email) }
     let(:user2) { create(:user, email: org2.service_email) }
 
-    before { user1; user2 }
+    before do
+      user1
+      user2
+    end
 
     it "exports service email addresses for each organisation" do
       expect(csv.first["Service email address"]).to eq(org1.service_email)

--- a/spec/requests/admin/organisations/get_spec.rb
+++ b/spec/requests/admin/organisations/get_spec.rb
@@ -5,7 +5,9 @@ describe "GET /admin/organisations", type: :request do
   let(:another_user) { create(:user, email: organisation_1.service_email) }
 
   before do
-    another_user; organisation_1; organisation_2
+    another_user
+    organisation_1
+    organisation_2
     sign_in_user(user)
     https!
   end

--- a/spec/requests/home/get_spec.rb
+++ b/spec/requests/home/get_spec.rb
@@ -5,7 +5,9 @@ describe "GET /home", type: :request do
   let(:both) { create(:user, :new_admin, :super_admin) }
 
   before do
-    classic_admin; admin; both;
+    classic_admin
+    admin
+    both
     https!
   end
 


### PR DESCRIPTION
Fixing these issues allows us to upgrade to the latest GOV.UK Rubocop version

- Added two migrations to add indices to models with uniqueness constraints
- Added a ```dependent: :destroy``` option to the user model to make sure that memberships get destroyed when a user is deleted.
- The indices to the name column of the authorised_email_domain table means that the order of ips returned in the test in authorised_email_domains_spec file is reversed. The order does not seem to matter so that is now reflected in the test