### PR TITLE
Fixes a bug in which 2fa emails are not sent.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -103,7 +103,7 @@ class User < ApplicationRecord
   end
 
   def send_new_otp_after_login?
-    second_factor_method == "email" && direct_otp.present?
+    second_factor_method == "email"
   end
 
   def send_two_factor_authentication_code(code)

--- a/spec/features/authentication/set_up_enhanced_two_factor_authentication_spec.rb
+++ b/spec/features/authentication/set_up_enhanced_two_factor_authentication_spec.rb
@@ -130,22 +130,32 @@ describe "Set up two factor authentication", type: :feature do
         end
       end
 
-      context "The user signs out and back in again" do
+      context "The user signs in" do
         before :each do
-          click_on "Sign out"
-          visit root_path
-
-          fill_in "Email", with: "tom@gov.uk"
-          fill_in "Password", with: correct_password
-          click_on "Continue"
+          visit users_two_factor_authentication_direct_otp_path(code: @user.reload.direct_otp)
         end
 
-        it "sends an email again" do
-          expect(notification_instance).to have_received(:send_email).twice
+        it "sucessfully sets up 2fa" do
+          expect(page).to have_content("Two factor authentication setup successful")
         end
 
-        it "asks for the email 2FA method when user logs in again" do
-          expect(page).to have_content("We have emailed you a link to sign in to GovWifi.")
+        context "The user signs out and back in again" do
+          before :each do
+            click_on "Sign out"
+            visit root_path
+
+            fill_in "Email", with: "tom@gov.uk"
+            fill_in "Password", with: correct_password
+            click_on "Continue"
+          end
+
+          it "sends an email again" do
+            expect(notification_instance).to have_received(:send_email).twice
+          end
+
+          it "asks for the email 2FA method when user logs in again" do
+            expect(page).to have_content("We have emailed you a link to sign in to GovWifi.")
+          end
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -230,19 +230,13 @@ describe User do
   end
 
   describe "#send_new_otp_after_login?" do
-    it "does not send an email if the direct otp has not been set" do
+    it "it sends an email if the user has chosen to 2fa through email" do
       user = create(:user, :with_organisation, second_factor_method: "email")
-      expect(user.send_new_otp_after_login?).to be false
-    end
-
-    it "it sends an email if the direct otp has been set" do
-      user = create(:user, :with_organisation, second_factor_method: "email")
-      user.create_direct_otp
       expect(user.send_new_otp_after_login?).to be true
     end
 
     it "does not send an email if the user has chosen to 2fa through the app" do
-      user = create(:user, :with_organisation, second_factor_method: "app", otp_secret_key: "12345678")
+      user = create(:user, :with_organisation, second_factor_method: "app")
       expect(user.send_new_otp_after_login?).to be false
     end
   end


### PR DESCRIPTION
An email was not sent if:

- a user signs up for email 2fa
- the user successfully 2fa authenticates
- the user signs out
- the user signs back in again

In this case ```user.direct_otp``` would be ```nil``` and the email not set.

This fix ensures that the email is always sent regardless wether
```user.direct_otp``` is set.

The feature tests have been update to simulate successfully authenticating, which is a step that had previously been omitted an which highlights the error.