### PR TITLE
fix: add missing page titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,11 @@ module ApplicationHelper
 
     classes.join(" ")
   end
+
+  def infer_page_title
+    [
+      content_for(:page_title),
+      SITE_CONFIG["default_page_title"],
+    ].reject(&:nil?).join(" - ")
+  end
 end

--- a/app/views/application/error.html.erb
+++ b/app/views/application/error.html.erb
@@ -1,10 +1,10 @@
 <% if params[:code] == "404" %>
-  <% content_for :page_title, "Page not found - GovWifi" %>
+  <% content_for :page_title, "Page not found" %>
   <h1 class="govuk-heading-xl">Page not found</h1>
   <p class="govuk-body">If you entered a web address please check it was correct.</p>
   <p class="govuk-body">You can browse from the <%= link_to "homepage", root_path, class: "govuk-link" %> to find the information you need.</p>
 <% else %>
-  <% content_for :page_title, "An error occurred - GovWifi" %>
+  <% content_for :page_title, "An error occurred" %>
   <h1 class="govuk-heading-xl">Sorry an error occurred</h1>
   <p class="govuk-body">Something went wrong while processing the request.</p>
 <% end %>

--- a/app/views/application/error.html.erb
+++ b/app/views/application/error.html.erb
@@ -1,8 +1,10 @@
 <% if params[:code] == "404" %>
+  <% content_for :page_title, "Page not found - GovWifi" %>
   <h1 class="govuk-heading-xl">Page not found</h1>
   <p class="govuk-body">If you entered a web address please check it was correct.</p>
   <p class="govuk-body">You can browse from the <%= link_to "homepage", root_path, class: "govuk-link" %> to find the information you need.</p>
 <% else %>
+  <% content_for :page_title, "An error occurred - GovWifi" %>
   <h1 class="govuk-heading-xl">Sorry an error occurred</h1>
   <p class="govuk-body">Something went wrong while processing the request.</p>
 <% end %>

--- a/app/views/help/admin_account.erb
+++ b/app/views/help/admin_account.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Manage GovWifi in your organisation support - GovWifi" %>
+<% content_for :page_title, "Manage GovWifi in your organisation support" %>
 <% content_for :meta_description, "Contact us for technical help and support with managing an existing GovWifi installation in your organisation" %>
 
 <%= render "layouts/form_errors", resource: @support_form %>

--- a/app/views/help/new.html.erb
+++ b/app/views/help/new.html.erb
@@ -1,4 +1,4 @@
-<div><% content_for :page_title, "Network administrator support - GovWifi" %></div>
+<div><% content_for :page_title, "Network administrator support" %></div>
 <div><% content_for :meta_description, "Help and support for network administrators installing or managing GovWifi in public sector organisations." %></div>
 
 <div class="govuk-grid-row">

--- a/app/views/help/signed_in.html.erb
+++ b/app/views/help/signed_in.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Support - GovWifi" %>
+<% content_for :page_title, "Support" %>
 
 <%= render "layouts/form_errors", resource: @support_form %>
 

--- a/app/views/help/signed_in.html.erb
+++ b/app/views/help/signed_in.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Support - GovWifi" %>
+
 <%= render "layouts/form_errors", resource: @support_form %>
 
 <div class="govuk-grid-row">

--- a/app/views/help/technical_support.html.erb
+++ b/app/views/help/technical_support.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Set up GovWifi in your organisation support - GovWifi" %>
+<% content_for :page_title, "Set up GovWifi in your organisation support" %>
 <% content_for :meta_description, "Contact us for technical help and support setting up GovWifi in your organisation" %>
 
 <%= render "layouts/form_errors", resource: @support_form %>

--- a/app/views/help/user_support.html.erb
+++ b/app/views/help/user_support.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "User account support - GovWifi" %>
+<% content_for :page_title, "User account support" %>
 <% content_for :meta_description, "Contact us for help and support with users connecting to GovWifi in your organisation" %>
 
 <%= render "layouts/form_errors", resource: @support_form %>

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Manage locations - GovWifi" %>
+<% content_for :page_title, "Manage locations" %>
 
 <div id='wrapper'>
   <div class="govuk-grid-row">

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Manage locations - GovWifi" %>
+
 <div id='wrapper'>
   <div class="govuk-grid-row">
     <%= render "confirm_remove_ip" if @ip_to_delete && current_user.can_manage_locations?(current_organisation) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
 
     <%= render "layouts/google_analytics" %>
 
-    <title><%= content_for?(:page_title) ? yield(:page_title) : SITE_CONFIG["default_page_title"] %></title>
+    <title><%= infer_page_title %></title>
 
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/app/views/locations/add_ips.html.erb
+++ b/app/views/locations/add_ips.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Add IP addresses - GovWifi" %>
+
 <%= render "layouts/form_errors", resource: @ip %>
 
 <% if action_name == 'update_ips' %>

--- a/app/views/locations/add_ips.html.erb
+++ b/app/views/locations/add_ips.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Add IP addresses - GovWifi" %>
+<% content_for :page_title, "Add IP addresses" %>
 
 <%= render "layouts/form_errors", resource: @ip %>
 

--- a/app/views/locations/new.erb
+++ b/app/views/locations/new.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Add location - GovWifi" %>
+
 <% if @location.errors.any? %>
   <div class="govuk-error-summary">
     <h2 class="govuk-error-summary__title">There is a problem</h2>

--- a/app/views/locations/new.erb
+++ b/app/views/locations/new.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Add location - GovWifi" %>
+<% content_for :page_title, "Add location" %>
 
 <% if @location.errors.any? %>
   <div class="govuk-error-summary">

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Results - logs search - GovWifi" %>
+<% content_for :page_title, "Results - logs search" %>
 
 <%= render "logs/back_link", params: params %>
 

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Results - logs search - GovWifi" %>
+
 <%= render "logs/back_link", params: params %>
 
 <% if @logs.present? %>

--- a/app/views/logs_searches/contact.html.erb
+++ b/app/views/logs_searches/contact.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Search logs by user details - GovWifi" %>
+<% content_for :page_title, "Search logs by user details" %>
 
 <%= render "layouts/form_errors", resource: @search %>
 

--- a/app/views/logs_searches/contact.html.erb
+++ b/app/views/logs_searches/contact.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Search logs by user details - GovWifi" %>
+
 <%= render "layouts/form_errors", resource: @search %>
 
 <div class='govuk-grid-row'>

--- a/app/views/logs_searches/ip.html.erb
+++ b/app/views/logs_searches/ip.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Search logs by IP address - GovWifi" %>
+
 <%= render "layouts/form_errors", resource: @search %>
 
 <div class='govuk-grid-row'>

--- a/app/views/logs_searches/ip.html.erb
+++ b/app/views/logs_searches/ip.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Search logs by IP address - GovWifi" %>
+<% content_for :page_title, "Search logs by IP address" %>
 
 <%= render "layouts/form_errors", resource: @search %>
 

--- a/app/views/logs_searches/location.html.erb
+++ b/app/views/logs_searches/location.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Search logs by location - GovWifi" %>
+
 <%= render "layouts/form_errors", resource: @search %>
 
 <div class='govuk-grid-row'>

--- a/app/views/logs_searches/location.html.erb
+++ b/app/views/logs_searches/location.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Search logs by location - GovWifi" %>
+<% content_for :page_title, "Search logs by location" %>
 
 <%= render "layouts/form_errors", resource: @search %>
 

--- a/app/views/logs_searches/new.html.erb
+++ b/app/views/logs_searches/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Start logs search - GovWifi" %>
+<% content_for :page_title, "Start logs search" %>
 
 <%= render "layouts/form_errors", resource: @search %>
 

--- a/app/views/logs_searches/new.html.erb
+++ b/app/views/logs_searches/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Start logs search - GovWifi" %>
+
 <%= render "layouts/form_errors", resource: @search %>
 
 <div class='govuk-grid-row'>

--- a/app/views/logs_searches/username.html.erb
+++ b/app/views/logs_searches/username.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Search logs by username - GovWifi" %>
+
 <%= render "layouts/form_errors", resource: @search %>
 
 <div class='govuk-grid-row'>

--- a/app/views/logs_searches/username.html.erb
+++ b/app/views/logs_searches/username.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Search logs by username - GovWifi" %>
+<% content_for :page_title, "Search logs by username" %>
 
 <%= render "layouts/form_errors", resource: @search %>
 

--- a/app/views/memberships/edit.html.erb
+++ b/app/views/memberships/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Manage team member - GovWifi" %>
+
 <%= link_to "Back", :back, class: "govuk-back-link" %>
 <%= render "confirm_remove_team_member" if params[:remove_team_member] %>
 

--- a/app/views/memberships/edit.html.erb
+++ b/app/views/memberships/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Manage team member - GovWifi" %>
+<% content_for :page_title, "Manage team member" %>
 
 <%= link_to "Back", :back, class: "govuk-back-link" %>
 <%= render "confirm_remove_team_member" if params[:remove_team_member] %>

--- a/app/views/memberships/index.html.erb
+++ b/app/views/memberships/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Team members - GovWifi" %>
+<% content_for :page_title, "Team members" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/memberships/index.html.erb
+++ b/app/views/memberships/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Team members - GovWifi" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Team members</h1>

--- a/app/views/mou/index.html.erb
+++ b/app/views/mou/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Memorandum of understanding - GovWifi" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <%= link_to "Back to settings", setup_instructions_path, class: "govuk-back-link" %>

--- a/app/views/mou/index.html.erb
+++ b/app/views/mou/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Memorandum of understanding - GovWifi" %>
+<% content_for :page_title, "Memorandum of understanding" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">

--- a/app/views/organisations/edit.html.erb
+++ b/app/views/organisations/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Edit service email - GovWifi" %>
+<% content_for :page_title, "Edit service email" %>
 
 <% if @organisation.errors.any? %>
   <div class="govuk-error-summary">

--- a/app/views/organisations/edit.html.erb
+++ b/app/views/organisations/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Edit service email - GovWifi" %>
+
 <% if @organisation.errors.any? %>
   <div class="govuk-error-summary">
     <h2 class="govuk-error-summary__title">There is a problem</h2>

--- a/app/views/organisations/new.html.erb
+++ b/app/views/organisations/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Register an organisation - GovWifi" %>
+
 <%= render "layouts/form_errors", resource: @organisation %>
 
 <h2 class="govuk-heading-l">Register an organisation for GovWifi</h2>

--- a/app/views/organisations/new.html.erb
+++ b/app/views/organisations/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Register an organisation - GovWifi" %>
+<% content_for :page_title, "Register an organisation" %>
 
 <%= render "layouts/form_errors", resource: @organisation %>
 

--- a/app/views/overview/index.html.erb
+++ b/app/views/overview/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Overview - GovWifi" %>
+<% content_for :page_title, "Overview" %>
 
 <% unless @current_org_signed_mou %>
   <div class="govuk-grid-row">

--- a/app/views/overview/index.html.erb
+++ b/app/views/overview/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Overview - GovWifi" %>
+
 <% unless @current_org_signed_mou %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/setup_instructions/index.html.erb
+++ b/app/views/setup_instructions/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Organisation settings - GovWifi" %>
+
 <h2 class="govuk-heading-l">Settings</h2>
 
 <%= render "account" %>

--- a/app/views/setup_instructions/index.html.erb
+++ b/app/views/setup_instructions/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Organisation settings - GovWifi" %>
+<% content_for :page_title, "Organisation settings" %>
 
 <h2 class="govuk-heading-l">Settings</h2>
 

--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Servers status - GovWifi" %>
+
 <%= link_to "Back", root_path, class: "govuk-back-link" %>
 
 <h1 class="govuk-heading-l float-left">

--- a/app/views/status/index.html.erb
+++ b/app/views/status/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Servers status - GovWifi" %>
+<% content_for :page_title, "Servers status" %>
 
 <%= link_to "Back", root_path, class: "govuk-back-link" %>
 

--- a/app/views/super_admin/locations/index.html.erb
+++ b/app/views/super_admin/locations/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Locations - GovWifi" %>
+<% content_for :page_title, "Locations" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/super_admin/locations/index.html.erb
+++ b/app/views/super_admin/locations/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Locations - GovWifi" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">GovWifi locations</h1>

--- a/app/views/super_admin/locations/map/index.html.erb
+++ b/app/views/super_admin/locations/map/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Location map - GovWifi" %>
+<% content_for :page_title, "Location map" %>
 
 <%= link_to "Back to locations", super_admin_locations_path, class: "govuk-back-link" %>
 <h1 class="govuk-heading-l">GovWifi Map of Locations</h1>

--- a/app/views/super_admin/locations/map/index.html.erb
+++ b/app/views/super_admin/locations/map/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Location map - GovWifi" %>
+
 <%= link_to "Back to locations", super_admin_locations_path, class: "govuk-back-link" %>
 <h1 class="govuk-heading-l">GovWifi Map of Locations</h1>
 

--- a/app/views/super_admin/mou/index.html.erb
+++ b/app/views/super_admin/mou/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Memorandum of understanding - GovWifi" %>
+<% content_for :page_title, "Memorandum of understanding" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/super_admin/mou/index.html.erb
+++ b/app/views/super_admin/mou/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Memorandum of understanding - GovWifi" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l">Memorandum of Understanding</h2>

--- a/app/views/super_admin/organisations/index.html.erb
+++ b/app/views/super_admin/organisations/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "All organisations - GovWifi" %>
+<% content_for :page_title, "All organisations" %>
 
 <h1 class="govuk-heading-l">All organisations</h1>
 <h3 class="govuk-body">

--- a/app/views/super_admin/organisations/index.html.erb
+++ b/app/views/super_admin/organisations/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "All organisations - GovWifi" %>
+
 <h1 class="govuk-heading-l">All organisations</h1>
 <h3 class="govuk-body">
   GovWifi is in

--- a/app/views/super_admin/organisations/show.html.erb
+++ b/app/views/super_admin/organisations/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{@organisation.name} - GovWifi" %>
+<% content_for :page_title, @organisation.name.to_s %>
 
 <div class="govuk-grid-row">
   <%= render "confirm_remove_organisation" if params[:remove_organisation] %>

--- a/app/views/super_admin/organisations/show.html.erb
+++ b/app/views/super_admin/organisations/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "#{@organisation.name} - GovWifi" %>
+
 <div class="govuk-grid-row">
   <%= render "confirm_remove_organisation" if params[:remove_organisation] %>
 

--- a/app/views/super_admin/whitelists/email_domains/index.html.erb
+++ b/app/views/super_admin/whitelists/email_domains/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Manage allowed domains - GovWifi" %>
+<% content_for :page_title, "Manage allowed domains" %>
 
 <%= render "confirm_remove_email_domain" if params[:domain_to_remove] %>
 

--- a/app/views/super_admin/whitelists/email_domains/index.html.erb
+++ b/app/views/super_admin/whitelists/email_domains/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Manage allowed domains - GovWifi" %>
+
 <%= render "confirm_remove_email_domain" if params[:domain_to_remove] %>
 
 <div class="govuk-grid-row">

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Invite a team member" %>
+
 <%= render "layouts/form_errors" %>
 
 <% if super_admin? %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Network administrator account - GovWifi" %>
+<% content_for :page_title, "Sign into GovWifi admin - GovWifi" %>
 <% content_for :meta_description, "Sign in to manage an existing GovWifi installation in your organisation." %>
 
 <div class="govuk-grid-row">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Sign into GovWifi admin - GovWifi" %>
+<% content_for :page_title, "Sign in" %>
 <% content_for :meta_description, "Sign in to manage an existing GovWifi installation in your organisation." %>
 
 <div class="govuk-grid-row">

--- a/config/site.yml
+++ b/config/site.yml
@@ -8,7 +8,7 @@ default: &default
   product_page_link: 'https://wifi.service.gov.uk'
   organisation_register_url: 'https://government-organisation.register.gov.uk/records.json?page-size=5000'
   local_auth_register_url: 'https://local-authority-eng.register.gov.uk/records.json?page-size=5000'
-  default_page_title: 'GovWifi Admin'
+  default_page_title: 'GovWifi admin'
   default_meta_description: 'GovWifi - Administration Platform'
 
 development:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe ApplicationHelper, type: :helper do
+  let(:title) { "some random title" }
+
+  describe "#infer_page_title" do
+    let(:dummy) do
+      Class.new do
+        extend ApplicationHelper
+        extend ActionView::Helpers::CaptureHelper
+      end
+    end
+
+    context "when there is a page title" do
+      before do
+        allow(dummy).to receive(:content_for) { title }
+      end
+
+      it "is prefixed to the default page title and joined with a dash" do
+        expect(dummy.infer_page_title).to eq "#{title} - GovWifi admin"
+      end
+    end
+
+    context "when there is no page title" do
+      before do
+        allow(dummy).to receive(:content_for) { nil }
+      end
+
+      it "resorts to the default page title" do
+        expect(dummy.infer_page_title).to eq "GovWifi admin"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Beth and I have gone through most of the pages exposed in the GovWifi
admin and have amended the page titles to reflect their content.

Some pages were intentionally left out because of their complexity,
namely the superadmin "allow orgs/users" flow, and the help form which
can be figured out in the coming days.