### PR TITLE
Add Docker Hub auth token

### DIFF
--- a/ci/tasks/build-deployable.yml
+++ b/ci/tasks/build-deployable.yml
@@ -28,4 +28,5 @@ run:
     - '-exc'
     - |
       echo "$TAG" > image/tag
+      echo "$DOCKER_HUB_AUTHTOKEN_ENV" | img login -u ((docker_hub_username)) --password-stdin
       build


### PR DESCRIPTION
Add Docker Hub auth token to allow Concourse pipeline task to pull images from Docker Hub.

The pipeline is configured in [govwifi-concourse-deploy-pipeline](https://github.com/alphagov/govwifi-concourse-deploy-pipeline).

We need to do this because Docker Hub will introduce rate limiting on 1 November.

paired: @camdesgov & @sarahseewhy 