### PR TITLE
Add Docker Hub credentials and login command

### DIFF
--- a/ci/tasks/build-deployable.yml
+++ b/ci/tasks/build-deployable.yml
@@ -12,8 +12,6 @@ params:
   CONTEXT: src
   BUILD_ARG_BUNDLE_INSTALL_FLAGS: '--without test development'
   TAG:
-  DOCKER_HUB_USERNAME_ENV: '((docker_hub_username))'
-  DOCKER_HUB_AUTHTOKEN_ENV: '((docker_hub_authtoken))'
 
 inputs:
   - name: src

--- a/ci/tasks/build-deployable.yml
+++ b/ci/tasks/build-deployable.yml
@@ -12,6 +12,8 @@ params:
   CONTEXT: src
   BUILD_ARG_BUNDLE_INSTALL_FLAGS: '--without test development'
   TAG:
+  DOCKER_HUB_USERNAME_ENV: '((docker_hub_username))'
+  DOCKER_HUB_AUTHTOKEN_ENV: '((docker_hub_authtoken))'
 
 inputs:
   - name: src

--- a/ci/tasks/pre-build.yml
+++ b/ci/tasks/pre-build.yml
@@ -20,6 +20,8 @@ params:
   # Set this to custom image names for preloading the app image. see `docker-compose.concourse.yml`
   PREBUILT_TAG: 'app-prebuilt'
   PREBUILT_CACHED_DIR: 'docker-cache/app-prebuilt-cached'
+  DOCKER_HUB_USERNAME_ENV: '((docker_hub_username))'
+  DOCKER_HUB_AUTHTOKEN_ENV: '((docker_hub_authtoken))'
 
 run:
   path: docker-wrapper

--- a/ci/tasks/scripts/pre-build.sh
+++ b/ci/tasks/scripts/pre-build.sh
@@ -3,7 +3,7 @@
 set -e -u -o pipefail
 
 ./src/ci/tasks/scripts/with-docker.sh
-echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
+echo "${DOCKER_HUB_AUTHTOKEN_ENV}" | docker login -u $(echo "${DOCKER_HUB_USERNAME_ENV}") --password-stdin
 
 workspace_dir="${PWD}"
 prebuilt_dir="${workspace_dir}/docker-cache/${PREBUILT_TAG}"

--- a/ci/tasks/scripts/pre-build.sh
+++ b/ci/tasks/scripts/pre-build.sh
@@ -3,6 +3,7 @@
 set -e -u -o pipefail
 
 ./src/ci/tasks/scripts/with-docker.sh
+echo "$DOCKER_HUB_AUTHTOKEN_ENV" | img login -u ((docker_hub_username)) --password-stdin
 
 workspace_dir="${PWD}"
 prebuilt_dir="${workspace_dir}/docker-cache/${PREBUILT_TAG}"

--- a/ci/tasks/scripts/pre-build.sh
+++ b/ci/tasks/scripts/pre-build.sh
@@ -3,7 +3,7 @@
 set -e -u -o pipefail
 
 ./src/ci/tasks/scripts/with-docker.sh
-echo "${DOCKER_HUB_AUTHTOKEN_ENV}" | docker login -u $(echo "${DOCKER_HUB_USERNAME_ENV}") --password-stdin
+echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
 
 workspace_dir="${PWD}"
 prebuilt_dir="${workspace_dir}/docker-cache/${PREBUILT_TAG}"

--- a/ci/tasks/scripts/pre-build.sh
+++ b/ci/tasks/scripts/pre-build.sh
@@ -3,7 +3,7 @@
 set -e -u -o pipefail
 
 ./src/ci/tasks/scripts/with-docker.sh
-echo "$DOCKER_HUB_AUTHTOKEN_ENV" | img login -u ((docker_hub_username)) --password-stdin
+echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
 
 workspace_dir="${PWD}"
 prebuilt_dir="${workspace_dir}/docker-cache/${PREBUILT_TAG}"


### PR DESCRIPTION
Add credentials to allow Concourse pipeline tasks to pull images from Docker Hub. Also update build script to include login step.

We need to do this because Docker Hub will introduce rate limiting on 1 November.

paired: @camdesgov & @sarahseewhy 
