### PR TITLE
Add `has_2fa?` method to `user`, and use in memberships table

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,4 +115,8 @@ class User < ApplicationRecord
          url: Rails.application.routes.url_helpers.users_two_factor_authentication_direct_otp_url(code: code),
 )
   end
+
+  def has_2fa?
+    second_factor_method.present?
+  end
 end

--- a/app/views/memberships/_table.html.erb
+++ b/app/views/memberships/_table.html.erb
@@ -52,7 +52,7 @@
         <div class='govuk-grid-column-one-third govuk-list govuk-!-padding-right-4 govuk-!-margin-top-0 text-right'>
           <% if current_user.can_manage_team?(current_organisation) && member.id != current_user.id %>
             <%= link_to "Edit permissions", edit_membership_path(member.membership_for(current_organisation)), class: "govuk-link govuk-link--no-visited-state" %>
-            <% if member.totp_enabled? %>
+            <% if member.has_2fa? %>
               <%= link_to "Reset 2FA",
                           { controller: "users/two_factor_authentication", action: "edit", id: member },
                           class: "govuk-link govuk-link--no-visited-state" %>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -28,7 +28,12 @@ FactoryBot.define do
     end
 
     trait :with_2fa do
+      second_factor_method { "app" }
       otp_secret_key { "ABCDEFGHIJKLMNOPQRSTUVWXYZ" } # 2FA is set up
+    end
+
+    trait :with_email_2fa do
+      second_factor_method { "email" }
     end
 
     trait :unconfirmed do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -259,4 +259,28 @@ describe User do
       end
     end
   end
+
+  describe ".has_2fa?" do
+    let(:no_2fa) { create(:user) }
+    let(:app_2fa) { create(:user, :with_2fa) }
+    let(:email_2fa) { create(:user, :with_email_2fa) }
+
+    context "when no 2fa" do
+      it "returns false" do
+        expect(no_2fa.has_2fa?).to be false
+      end
+    end
+
+    context "when app 2fa" do
+      it "returns true" do
+        expect(app_2fa.has_2fa?).to be true
+      end
+    end
+
+    context "when email 2fa" do
+      it "returns true" do
+        expect(email_2fa.has_2fa?).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
We've previously used `totp_enabled?` to decide if we should display
2fa reset link, however this only checks app 2fa. This method checks both
app and email.

Note, the `reset_2fa!` method on `user` already resets the
`second_factor_method` column, which covers email, so no changes are
required there.