### PR TITLE
fix: don't show cookie banner multiple times on different pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "govuk-frontend": "^3.9.1",
-    "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/0.6.3/govwifi-shared-frontend-0.6.3.tgz",
+    "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.6/govwifi-shared-frontend-0.6.6.tgz",
     "html5shiv": "^3.7.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,9 +7,9 @@ govuk-frontend@^3.9.1:
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.9.1.tgz#731aa62f5d956aa9999726027a1e25c8b7e52fc4"
   integrity sha512-ouOoDUj0QwDA4uCHIBkGCFMpORuTRcSuDscOrz7V1PBcOecntLglxJAZAuNm+j2sPo7anoScHU0ZSeE2QIoeAg==
 
-"govwifi-shared-frontend@https://github.com/alphagov/govwifi-shared-frontend/releases/download/0.6.3/govwifi-shared-frontend-0.6.3.tgz":
-  version "0.6.3"
-  resolved "https://github.com/alphagov/govwifi-shared-frontend/releases/download/0.6.3/govwifi-shared-frontend-0.6.3.tgz#6513c83caffbea007c6a7fef8fb89c7e48959166"
+"govwifi-shared-frontend@https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.6/govwifi-shared-frontend-0.6.6.tgz":
+  version "0.6.6"
+  resolved "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.6/govwifi-shared-frontend-0.6.6.tgz#098955af8f879a396101060394b0ab6107ec3767"
   dependencies:
     js-cookie "^2.2.1"
 


### PR DESCRIPTION
the newer version of the shared-frontend sets the cookies on the top
domain so this bug should go away with the upgrade.