### PR TITLE
Bau/add secrets baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-11-12T16:28:50Z",
+  "generated_at": "2020-11-12T16:47:39Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -76,14 +76,6 @@
         "is_verified": false,
         "line_number": 32,
         "type": "Secret Keyword"
-      }
-    ],
-    "config/initializers/devise.rb": [
-      {
-        "hashed_secret": "f4810d3444033d3a53d41d1c9a2c48b25d016f9d",
-        "is_verified": false,
-        "line_number": 121,
-        "type": "Hex High Entropy String"
       }
     ],
     "config/locales/devise.en.yml": [

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,261 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-11-12T16:28:50Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "Dockerfile": [
+      {
+        "hashed_secret": "cb1e30734a7c5f222161598c0ec51fae535908f6",
+        "is_verified": false,
+        "line_number": 10,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "c94055f8ca03dd00999828feb2eaead9acb1302e",
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "dc76e9f0c0006e8f919e0c515c66dbba3982f785",
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Secret Keyword"
+      }
+    ],
+    "config/initializers/devise.rb": [
+      {
+        "hashed_secret": "f4810d3444033d3a53d41d1c9a2c48b25d016f9d",
+        "is_verified": false,
+        "line_number": 121,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "config/locales/devise.en.yml": [
+      {
+        "hashed_secret": "eba6dadb9ee44711de2b83fb6c129d6f18e297a3",
+        "is_verified": false,
+        "line_number": 71,
+        "type": "Secret Keyword"
+      }
+    ],
+    "config/secrets.yml": [
+      {
+        "hashed_secret": "ef678205593788329ff416ce5c65fa04f33a05bd",
+        "is_verified": false,
+        "line_number": 16,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "487db0d75ddb88456463026834833f31ad96350c",
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "3426f5a05c7bbed4105b36d016f14e248a409719",
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "docker-compose.yml": [
+      {
+        "hashed_secret": "dc76e9f0c0006e8f919e0c515c66dbba3982f785",
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Secret Keyword"
+      }
+    ],
+    "lib/tasks/repair_migrated_data.rake": [
+      {
+        "hashed_secret": "f42ffbeef5654fe58c5a777b27f703e7b30346ec",
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Secret Keyword"
+      }
+    ],
+    "lib/use_cases/radius/generate_radius_ip_whitelist.rb": [
+      {
+        "hashed_secret": "5e55653708ebba33134b5b8a8b84d2738d65fb1b",
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/features/authentication/lock_user_account_spec.rb": [
+      {
+        "hashed_secret": "002180ed71a88b9e89a4f04922e29c3cea9b84d0",
+        "is_verified": false,
+        "line_number": 8,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/features/authentication/logging_in_after_signing_up_spec.rb": [
+      {
+        "hashed_secret": "002180ed71a88b9e89a4f04922e29c3cea9b84d0",
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/features/authentication/logging_in_after_signing_up_with_enhanced_2fa_spec.rb": [
+      {
+        "hashed_secret": "fbf39bbc6f3940f35cfa1ffeed9e937acdda74e5",
+        "is_verified": false,
+        "line_number": 15,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/features/authentication/set_up_enhanced_two_factor_authentication_spec.rb": [
+      {
+        "hashed_secret": "fbf39bbc6f3940f35cfa1ffeed9e937acdda74e5",
+        "is_verified": false,
+        "line_number": 296,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/features/registration/sign_up_as_an_organisation_spec.rb": [
+      {
+        "hashed_secret": "53f87d0cadd4f96eb250190b62c20381802bd43c",
+        "is_verified": false,
+        "line_number": 120,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/features/registration/sign_up_as_an_organisation_with_enhanced_2fa_spec.rb": [
+      {
+        "hashed_secret": "53f87d0cadd4f96eb250190b62c20381802bd43c",
+        "is_verified": false,
+        "line_number": 112,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/features/support/sign_up_helpers.rb": [
+      {
+        "hashed_secret": "083f2b92c8365a694047a59039d752f263f5eaa8",
+        "is_verified": false,
+        "line_number": 11,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/gateways/email_gateway_spec.rb": [
+      {
+        "hashed_secret": "cfb1f1eb7b00c363670bb487a597eed6a5a116c8",
+        "is_verified": false,
+        "line_number": 9,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/models/user_spec.rb": [
+      {
+        "hashed_secret": "defa2e28baf5a26a82a89a48b5ebf13184a5fdf4",
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "0c84b4f74bf4a84f9e86aff2010aa84036eaaebf",
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "7edad6bb43a3d2db8a21c71b8c03e38304e37e5e",
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/support/notifications_service.rb": [
+      {
+        "hashed_secret": "cfb1f1eb7b00c363670bb487a597eed6a5a116c8",
+        "is_verified": false,
+        "line_number": 8,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/use_cases/publish_whitelist_spec.rb": [
+      {
+        "hashed_secret": "369df430db780e0929e497da6c3ab49dc0d74a53",
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Secret Keyword"
+      }
+    ],
+    "spec/use_cases/radius/generate_radius_ip_whitelist_spec.rb": [
+      {
+        "hashed_secret": "369df430db780e0929e497da6c3ab49dc0d74a53",
+        "is_verified": false,
+        "line_number": 59,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "0872721b3a66619cad29d76d662c84211fa9c8ae",
+        "is_verified": false,
+        "line_number": 63,
+        "type": "Secret Keyword"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -118,7 +118,7 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 11
 
   # Set up a pepper to generate the hashed password.
-  # config.pepper = 'd45dd0ecc231072563494d44e90aee688407424366fa93a664a16c306dd2b1a2bf960444478736dea45c52a6863d6287b7bd2e30a8de13c4578660eaa816667b'
+  # config.pepper = '<insert a pepper value here; 128 hex digits>'
 
   # Send a notification to the original email when the user's email is changed.
   # config.send_email_changed_notification = false


### PR DESCRIPTION
https://github.com/alphagov/gds-pre-commit

The majority of detected secrets are clearly false passwords used in tests or in developer config.  There are a handful that might conceivably be real ones:

* `Dockerfile` contains a NOTIFY_API_KEY which looks to me like it could be genuine.  Is this a problem?
* It also has a few DB_PASS keys with a value of `root`; I presume those aren't for anything that affects a live environment.
* `config/initializers/devise.rb` had a commented out config item called `config.pepper` with a lengthy hex value.  This had been unchanged (i.e. always commented out) since the file was created.  I'm assuming it was just there as a template.  To avoid confusion and reduce the noise in .secrets.baseline, I've replaced the hex value with a note.  I'm assuming the original value was not actually relevant to our system - but if it was, we will need to do something about the git history.