### PR TITLE
Fix issue where 2FA can't be reset when enhanced 2fa isn't enabled

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,6 +117,6 @@ class User < ApplicationRecord
   end
 
   def has_2fa?
-    second_factor_method.present?
+    Rails.configuration.enable_enhanced_2fa_experience ? second_factor_method.present? : totp_enabled?
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -277,9 +277,19 @@ describe User do
       end
     end
 
-    context "when email 2fa" do
-      it "returns true" do
-        expect(email_2fa.has_2fa?).to be true
+    context "when enable_enhanced_2fa_experience is true" do
+      before do
+        allow(Rails.application.config).to receive(:enable_enhanced_2fa_experience).and_return true
+      end
+
+      after do
+        allow(Rails.application.config).to receive(:enable_enhanced_2fa_experience).and_call_original
+      end
+
+      context "when email 2fa" do
+        it "returns true" do
+          expect(email_2fa.has_2fa?).to be true
+        end
       end
     end
   end


### PR DESCRIPTION
has_2fa? needs to take into account the feature flag, and fall back to
totp_enabled? when off.

Previous fix to allow resetting of Email 2FA had not accounted for the feature flag, so was checking `second_factor_method` which is not currently set in production - this resulted in the *Reset 2FA* option being missing.