### PR TITLE
Rescue Zendesk exceptions when submitting tickets

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -59,6 +59,9 @@ class HelpController < ApplicationController
     else
       render @support_form.choice
     end
+  rescue ZendeskAPI::Error::RecordInvalid
+    @support_form.errors.add(:email, " is not a valid email address")
+    render @support_form.choice
   end
 
 private

--- a/spec/features/contact_us_when_not_signed_in_spec.rb
+++ b/spec/features/contact_us_when_not_signed_in_spec.rb
@@ -160,6 +160,18 @@ describe "Contact us when not signed in", type: :feature do
         expect(page).to have_content "Email is not a valid email address"
       end
     end
+
+    context "correct but rejected by Zendesk" do
+      let(:email) { "blah_blah%\#@\#$" }
+      before do
+        ZendeskClientMock.exception_to_raise = ZendeskAPI::Error::RecordInvalid.new({})
+        click_on "Submit"
+      end
+
+      it "does not submit the form" do
+        expect(page).to have_content "Email is not a valid email address"
+      end
+    end
   end
 end
 

--- a/spec/features/support/mock_zendesk_client.rb
+++ b/spec/features/support/mock_zendesk_client.rb
@@ -3,6 +3,7 @@ shared_context "with a mocked support tickets client" do
     class << self
       attr_accessor :config
       attr_accessor :support_tickets
+      attr_accessor :exception_to_raise
     end
 
     def initialize
@@ -14,6 +15,7 @@ shared_context "with a mocked support tickets client" do
     def self.reset!
       self.support_tickets = []
       self.config = Struct.new(:url, :username, :token).new
+      self.exception_to_raise = nil
     end
 
     def tickets
@@ -22,6 +24,8 @@ shared_context "with a mocked support tickets client" do
     end
 
     def create!(subject: nil, requester: nil, comment: nil, tags: nil)
+      raise self.class.exception_to_raise unless self.class.exception_to_raise.nil?
+
       self.class.support_tickets << {
         subject: subject,
         requester: requester,


### PR DESCRIPTION
 This can occur when an email address passes the local form validation
 but is rejected by Zendesk

Trello: https://trello.com/c/dpv3GGFg/526-handle-malformed-emails-in-our-support-form