### PR TITLE
Switch to active_record_store for sessions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem "activerecord-session_store"
 gem "aws-sdk-route53", "~> 1.44.0"
 gem "aws-sdk-s3", "~> 1.86.0"
 gem "cancancan"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,12 @@ GEM
     activerecord (6.1.3)
       activemodel (= 6.1.3)
       activesupport (= 6.1.3)
+    activerecord-session_store (1.1.3)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     activestorage (6.1.3)
       actionpack (= 6.1.3)
       activejob (= 6.1.3)
@@ -201,6 +207,7 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     mysql2 (0.5.3)
@@ -404,6 +411,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   aws-sdk-route53 (~> 1.44.0)
   aws-sdk-s3 (~> 1.86.0)
   bullet (~> 6.0)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :active_record_store, key: "_govwifi_admin_session"

--- a/db/migrate/20210226140906_add_sessions_table.rb
+++ b/db/migrate/20210226140906_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[6.1]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/migrate/20210226140906_add_sessions_table.rb
+++ b/db/migrate/20210226140906_add_sessions_table.rb
@@ -1,12 +1,12 @@
 class AddSessionsTable < ActiveRecord::Migration[6.1]
   def change
-    create_table :sessions do |t|
-      t.string :session_id, :null => false
+    create_table :sessions, bulk: true do |t|
+      t.string :session_id, null: false
       t.text :data
       t.timestamps
-    end
 
-    add_index :sessions, :session_id, :unique => true
-    add_index :sessions, :updated_at
+      t.index :session_id, unique: true
+      t.index :updated_at
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_23_115015) do
+ActiveRecord::Schema.define(version: 2021_02_26_140906) do
 
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -107,6 +107,15 @@ ActiveRecord::Schema.define(version: 2021_02_23_115015) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_permissions_on_user_id"
+  end
+
+  create_table "sessions", charset: "utf8", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
   create_table "users", charset: "utf8", force: :cascade do |t|


### PR DESCRIPTION
There is a 4kb limit on cookie sessions, which occasionally gets passed causing CookieOverflow exception.
Switching to database storage solves this.

```
ActionDispatch::Cookies::CookieOverflow: ActionDispatch::Cookies::CookieOverflow
  actionpack (6.0.3.4) lib/action_dispatch/middleware/cookies.rb:637:in `commit'
  actionpack (6.0.3.4) lib/action_dispatch/middleware/cookies.rb:472:in `[]='
  actionpack (6.0.3.4) lib/action_dispatch/middleware/session/cookie_store.rb:110:in `set_cookie'
  rack (2.2.3) lib/rack/session/abstract/id.rb:403:in `commit_session'
  rack (2.2.3) lib/rack/session/abstract/id.rb:268:in `context'
...
(32 additional frame(s) were not displayed)
```