### PR TITLE
Don't attempt to `destroy!` a `nil` record

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -63,7 +63,7 @@ private
   end
 
   def delete_user_record
-    invited_user.destroy!
+    invited_user.destroy! unless invited_user.nil?
   end
 
   def set_target_organisation


### PR DESCRIPTION
An error occurred where `invited_user` was `nil`. 

I was able to reproduce this by appending `resend=true` to the post data, however I don't think this was the likely cause in 'the field'. In any case, we only want to delete the user account at this point _if it already exists_.