### PR TITLE
Don't prevent load of ActiveStorage when precompiling assets.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,6 @@ COPY . .
 
 ARG RUN_PRECOMPILATION=true
 RUN if [ ${RUN_PRECOMPILATION} = 'true' ]; then \
-  ASSET_PRECOMPILATION_ONLY=true RAILS_ENV=production bundle exec rails assets:precompile; \
+  RAILS_ENV=production bundle exec rails assets:precompile; \
   fi
 CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
-require "active_storage/engine" unless ENV["ASSET_PRECOMPILATION_ONLY"]
+require "active_storage/engine"
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,9 +1,7 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  unless ENV["ASSET_PRECOMPILATION_ONLY"]
-    config.active_storage.service = :amazon
-  end
+  config.active_storage.service = :amazon
 
   # Code is not reloaded between requests.
   config.cache_classes = true


### PR DESCRIPTION
I suspect this was disabled as a optimisation as it wasn't relevant to
asset compilation, but now we've added the ActiveStorage route it's required.