### PR TITLE
Resolve deploy build issue by applying correct fix.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,6 @@ COPY . .
 
 ARG RUN_PRECOMPILATION=true
 RUN if [ ${RUN_PRECOMPILATION} = 'true' ]; then \
-  RAILS_ENV=production bundle exec rails assets:precompile; \
+  ASSET_PRECOMPILATION_ONLY=true RAILS_ENV=production bundle exec rails assets:precompile; \
   fi
 CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]

--- a/app/controllers/active_storage/blobs/redirect_controller.rb
+++ b/app/controllers/active_storage/blobs/redirect_controller.rb
@@ -27,7 +27,7 @@
 # Note: These URLs are publicly accessible. If you need to enforce access protection beyond the
 # security-through-obscurity factor of the signed blob references, you'll need to implement your own
 # authenticated redirection controller.
-class ActiveStorage::SecureBlobsController < ActiveStorage::BaseController
+class ActiveStorage::Blobs::RedirectController < ActiveStorage::BaseController
   include ActiveStorage::SetBlob
   include Rails.application.routes.url_helpers
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
-require "active_storage/engine"
+require "active_storage/engine" unless ENV["ASSET_PRECOMPILATION_ONLY"]
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,9 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.active_storage.service = :amazon
+  unless ENV["ASSET_PRECOMPILATION_ONLY"]
+    config.active_storage.service = :amazon
+  end
 
   # Code is not reloaded between requests.
   config.cache_classes = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,10 +104,6 @@ Rails.application.routes.draw do
     end
   end
 
-  scope ActiveStorage.routes_prefix do
-    get "/blobs/redirect/:signed_id/*filename" => "active_storage/secure_blobs#show"
-  end
-
   %w[404 422 500].each do |code|
     get code, to: "application#error", code: code
   end


### PR DESCRIPTION
On updating to Rails/ActiveStorage 6.1, our `ActiveStorage::BlobsController` stopped overriding the default.

I fixed this by renaming it to `ActiveStorage::SecureBlobsController` and referencing it directly in the routes.

As ActiveStorage is disabled when compiling assets, this caused a build failure when deploying to Staging.

I attempted to work around this, but there were further issues.

On further investigation, I identified that `ActiveStorage::BlobsController` had been renamed to `ActiveStorage::Blobs::RedirectController` which is why our custom controller was no longer automatically overriding it.

So, this PR reverts the previous changes to fix it, and implements the new fix, which is to rename our custom file accordingly,.