### PR TITLE
Update links to product pages

### DIFF
--- a/config/site.yml
+++ b/config/site.yml
@@ -2,7 +2,7 @@ default: &default
   end_user_docs_link: 'https://www.wifi.service.gov.uk/connect-to-govwifi/'
   end_user_troubleshooting_link: 'https://www.wifi.service.gov.uk/connect-to-govwifi/get-help-connecting/'
   organisation_docs_link: 'https://docs.wifi.service.gov.uk'
-  support_link: 'https://www.wifi.service.gov.uk/support'
+  support_link: 'https://www.wifi.service.gov.uk/connect-to-govwifi/get-help-connecting/'
   connect_to_govwifi_link: 'https://www.wifi.service.gov.uk/connect-to-govwifi/'
   cookies_docs_link: 'https://www.wifi.service.gov.uk/cookies'
   product_page_link: 'https://wifi.service.gov.uk'

--- a/config/site.yml
+++ b/config/site.yml
@@ -1,9 +1,9 @@
 default: &default
-  end_user_docs_link: 'https://www.gov.uk/government/collections/connect-to-govwifi'
-  end_user_troubleshooting_link: 'https://www.gov.uk/guidance/solve-problems-with-connecting-to-govwifi'
+  end_user_docs_link: 'https://www.wifi.service.gov.uk/connect-to-govwifi/'
+  end_user_troubleshooting_link: 'https://www.wifi.service.gov.uk/connect-to-govwifi/get-help-connecting/'
   organisation_docs_link: 'https://docs.wifi.service.gov.uk'
   support_link: 'https://www.wifi.service.gov.uk/support'
-  connect_to_govwifi_link: 'https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi'
+  connect_to_govwifi_link: 'https://www.wifi.service.gov.uk/connect-to-govwifi/'
   cookies_docs_link: 'https://www.wifi.service.gov.uk/cookies'
   product_page_link: 'https://wifi.service.gov.uk'
   organisation_register_url: 'https://government-organisation.register.gov.uk/records.json?page-size=5000'


### PR DESCRIPTION
We restructured the product pages when we added the text number to them. This is to use the new URLs.