### PR TITLE
Removed logged out 'Support' link in header

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -48,18 +48,10 @@
           <li class="govuk-header__navigation-item">
             <%= link_to "Support", signed_in_new_help_path, class: "govuk-header__link" %>
           </li>
-          <% else %>
-          <li class="govuk-header__navigation-item">
-            <%= link_to "Support", SITE_CONFIG["support_link"], class: "govuk-header__link" %>
-          </li>
           <% end %>
           <% if user_signed_in? %>
           <li class="govuk-header__navigation-item">
             <%= link_to "Sign out", destroy_user_session_path, method: :delete, class: "govuk-header__link" %>
-          </li>
-          <% else %>
-          <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
-            <%= link_to "Admin", new_user_session_path, class: "govuk-header__link govuk-header__link" %>
           </li>
           <% end %>
         </ul>


### PR DESCRIPTION
The page this went to is now only aimed at end users. 

There's no point changing the logged out version to match the logged in version, because it will just redirect them to the login page they'll already be on.