### PR TITLE
Prevent double render error when calling invitation `create` when not logged in

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -58,7 +58,7 @@ private
   def authenticate_inviter!
     # https://github.com/scambra/devise_invitable#controller-filter
     unless current_user&.can_manage_team?(current_organisation)
-      redirect_to(root_path)
+      redirect_to(root_path) and return
     end
   end
 

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe Users::InvitationsController, type: :controller do
+  describe "POST /users/invitation" do
+    context "when the user is not logged in" do
+      it "redirects to root_path" do
+        response = post :create
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION

The solution to this alert is as the exception suggests - adding `and return` however it is not for the reason suggested.

The intent of this message is that if you have a method:

```ruby
def check_something
  if (something)
    redirect_to some_path
  end

  redirect_to some_other_path
end
```

Then both redirects are triggered, causing the error. Adding `and return` to the one in the `if` block solves this.

In our case, there was only one redirect, so this couldn’t be the problem.

In debugging, I noticed that the `authenticate_inviter!` method was being called twice. The second call is from the `current_inviter` method which is called through `has_invitations_left?` at https://github.com/scambra/devise_invitable/blob/cf77519ca9d02c112d99fd176a8852272c1b8d99/app/controllers/devise/invitations_controller.rb#L91

If `current_user` returns a non-nil value, then this block runs, which then runs `respond_with_navigational`. Our `authenticate_inviter!` method returns the redirect, rather than `nil`, causing this block to be executed.

Our before_action then additionally runs, triggering a redirect, and the subsequent error.

So - returning `nil` when we redirect solves the problem, but not for the originally expected reason.


I have replicated this issue as a test with the following:

```ruby
  prepend_before_action :action1
  prepend_before_action :action2

  def action1
    logger.debug "action 1"
    redirect_to root_path
  end

  def action2
    logger.debug "action 2"
    action1
    redirect_to root_path
  end

```