### PR TITLE
Revert session to cookies and handle overflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-gem "activerecord-session_store"
 gem "aws-sdk-route53", "~> 1.44.0"
 gem "aws-sdk-s3", "~> 1.86.0"
 gem "cancancan"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,12 +47,6 @@ GEM
     activerecord (6.1.3)
       activemodel (= 6.1.3)
       activesupport (= 6.1.3)
-    activerecord-session_store (1.1.3)
-      actionpack (>= 4.0)
-      activerecord (>= 4.0)
-      multi_json (~> 1.11, >= 1.11.2)
-      rack (>= 1.5.2, < 3)
-      railties (>= 4.0)
     activestorage (6.1.3)
       actionpack (= 6.1.3)
       activejob (= 6.1.3)
@@ -207,7 +201,6 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
-    multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     mysql2 (0.5.3)
@@ -411,7 +404,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord-session_store
   aws-sdk-route53 (~> 1.44.0)
   aws-sdk-s3 (~> 1.86.0)
   bullet (~> 6.0)

--- a/config/initializers/devise_safe_store_location.rb
+++ b/config/initializers/devise_safe_store_location.rb
@@ -1,0 +1,9 @@
+module SafeStoreLocation
+  MAX_LOCATION_SIZE = ActionDispatch::Cookies::MAX_COOKIE_SIZE / 2
+
+  def store_location_for(resource_or_scope, location)
+    super unless location && location.size > MAX_LOCATION_SIZE
+  end
+end
+
+Devise::FailureApp.include SafeStoreLocation

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,1 +1,0 @@
-Rails.application.config.session_store :active_record_store, key: "_govwifi_admin_session"

--- a/db/migrate/20210322122355_drop_sessions_table.rb
+++ b/db/migrate/20210322122355_drop_sessions_table.rb
@@ -1,0 +1,12 @@
+class DropSessionsTable < ActiveRecord::Migration[6.1]
+  def change
+    drop_table :sessions do |t|
+      t.string :session_id, null: false
+      t.text :data
+      t.timestamps
+
+      t.index :session_id, unique: true
+      t.index :updated_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_26_140906) do
+ActiveRecord::Schema.define(version: 2021_03_22_122355) do
 
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -107,15 +107,6 @@ ActiveRecord::Schema.define(version: 2021_02_26_140906) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_permissions_on_user_id"
-  end
-
-  create_table "sessions", charset: "utf8", force: :cascade do |t|
-    t.string "session_id", null: false
-    t.text "data"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
-    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
   create_table "users", charset: "utf8", force: :cascade do |t|

--- a/spec/requests/large_request_spec.rb
+++ b/spec/requests/large_request_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+RSpec.describe "A very large request", type: :request do
+  before do
+    https!
+  end
+
+  it "should not overflow cookies" do
+    get "/", params: { foo: "x" * ActionDispatch::Cookies::MAX_COOKIE_SIZE }
+    expect(response).to redirect_to "/users/sign_in"
+  end
+end


### PR DESCRIPTION
As we've now established the cause of the large cookies leading to the cookie overflow error, we can now revert the switch to ActiveRecord storage.

We now check the length of the requested URL, and if it is more than 1/2 of the cookie storage available (4096) then the URL is not stored for redirection. 