### PR TITLE
Update rexml to 3.2.5 for dependabot security alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,7 +271,7 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rotp (6.2.0)
     rqrcode (1.2.0)
       chunky_png (~> 1.0)


### PR DESCRIPTION
## What

Update rexml to 3.2.5

## Why

Dependabot wouldn't create this automatically for some reason