### PR TITLE
Use stub_const to redefine constants in specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,19 +36,19 @@ RSpec.configure do |config|
     stub_request(:get, "https://local-authority-eng.register.gov.uk/records.json?page-size=5000")
       .to_return(status: 200, body: File.read(Rails.root.join("spec/fixtures/local_auths_payload.json")))
 
-    Gateways::GovukOrganisationsRegisterGateway::GOVERNMENT_ORGS = [
+    stub_const("Gateways::GovukOrganisationsRegisterGateway::GOVERNMENT_ORGS", [
       "Gov Org 1",
       "Gov Org 2",
       "Gov Org 3",
       "Gov Org 4",
-    ].freeze
+    ].freeze)
 
-    Gateways::GovukOrganisationsRegisterGateway::LOCAL_AUTHORITIES = [
+    stub_const("Gateways::GovukOrganisationsRegisterGateway::LOCAL_AUTHORITIES", [
       "Local Auth 1",
       "Local Auth 2",
       "Local Auth 3",
       "Local Auth 4",
-    ].freeze
+    ].freeze)
   end
 
   config.around do |example|


### PR DESCRIPTION
the GOVERNMENT_ORGS and LOCAL_AUTHORITIES constants were redefined
in the spec_helper, causing a lot of warnings to appear.

The correct way to redefine them is by using stub_const which
supresses the warnings