### PR TITLE
Add a warning page that 2fa is going to be mandatory soon.

### DIFF
--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -9,12 +9,6 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
   end
 
   def update
-    if params[:commit] == "Remind me next time"
-      flash[:notice] = "Two factor authentication setup skipped until next time"
-      disable_2fa_checks_for_session
-      return
-    end
-
     @otp_secret_key = params[:otp_secret_key]
     if current_user.authenticate_totp(params[:code], otp_secret_key: @otp_secret_key)
       current_user.update!(otp_secret_key: @otp_secret_key)

--- a/app/controllers/users/two_factor_authentication_unable_controller.rb
+++ b/app/controllers/users/two_factor_authentication_unable_controller.rb
@@ -1,0 +1,22 @@
+class Users::TwoFactorAuthenticationUnableController < ApplicationController
+  before_action :redirect_if_super_admin
+  skip_before_action :handle_two_factor_authentication
+  skip_before_action :confirm_two_factor_setup, :redirect_user_with_no_organisation
+
+  def show; end
+
+  def update
+    disable_2fa_checks_for_session
+    redirect_to stored_location_for(:user) || root_path
+  end
+
+private
+
+  def disable_2fa_checks_for_session
+    request.env["warden"].session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
+  end
+
+  def redirect_if_super_admin
+    redirect_to root_path if super_admin?
+  end
+end

--- a/app/views/users/two_factor_authentication_setup/show.html.erb
+++ b/app/views/users/two_factor_authentication_setup/show.html.erb
@@ -25,7 +25,11 @@
                              autofocus: true %>
         </div>
         <%= submit_tag t(".complete_setup"), class: "govuk-button govuk-!-margin-right-1" %>
-        <%= submit_tag t(".skip_setup"), class: "govuk-button govuk-button--secondary" %>
+      <% end %>
+      <% if !super_admin? %>
+        <%= link_to t(".unable_2fa"),
+                    users_two_factor_authentication_unable_path,
+                    class: "govuk-link" %>
       <% end %>
     </div>
   </div>

--- a/app/views/users/two_factor_authentication_unable/show.html.erb
+++ b/app/views/users/two_factor_authentication_unable/show.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title, "Enter two-factor authentication code" %>
+
+<div class="govuk-grid-column">
+  <%= link_to "Back", :back, class: "govuk-back-link" %>
+
+  <h2 class="govuk-heading-l">Two factor authentication will be mandatory from July 2021</h2>
+  <div class="govuk-body">
+    This is to keep GovWifi secure.
+  </div>
+  <div class="govuk-body">
+    You'll need to use an authentication app. If you cannot do this please email <a class="govuk-link" href="mailto:<%= t(".email") %>"><%= t(".email") %></a>
+  </div>
+  <div class="govuk-body">
+    <%= link_to t(".setup"), users_two_factor_authentication_setup_path, class: "govuk-button" %>
+  </div>
+  <div class="govuk-body">
+    <%= link_to t(".continue"), users_two_factor_authentication_unable_path, class: "govuk-link", method: :put %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,5 +38,10 @@ en:
     two_factor_authentication_setup:
       show:
         complete_setup: "Complete setup"
-        skip_setup: "Remind me next time"
+        unable_2fa: "I cannot set up two factor authentication"
+    two_factor_authentication_unable:
+      show:
+        email: "govwifi-support@digital.cabinet-office.gov.uk"
+        setup: "Setup two factor authentication"
+        continue: "Continue to GovWifi admin"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,9 @@ Rails.application.routes.draw do
     put "users/two_factor_authentication_setup", to: "users/two_factor_authentication_setup#update"
     get "users/two_factor_authentication_setup", to: "users/two_factor_authentication_setup#show"
 
+    get "users/two_factor_authentication_unable", to: "users/two_factor_authentication_unable#show"
+    put "users/two_factor_authentication_unable", to: "users/two_factor_authentication_unable#update"
+
     get "users/:id/two_factor_authentication/edit", to: "users/two_factor_authentication#edit"
     delete "users/:id/two_factor_authentication", to: "users/two_factor_authentication#destroy"
   end

--- a/spec/features/authentication/set_up_two_factor_authentication_spec.rb
+++ b/spec/features/authentication/set_up_two_factor_authentication_spec.rb
@@ -33,6 +33,15 @@ describe "Set up two factor authentication", type: :feature do
       expect(page).to have_field(:code)
     end
 
+    it "does not display a link to skip 2fa" do
+      expect(page).to_not have_link("I cannot set up two factor authentication")
+    end
+
+    it "rejects directly visiting the unable to two factor authentication page" do
+      visit users_two_factor_authentication_unable_path
+      expect(page).to_not have_current_path(users_two_factor_authentication_unable_path)
+    end
+
     context "when navigating to another page" do
       before { visit root_path }
 
@@ -83,15 +92,6 @@ describe "Set up two factor authentication", type: :feature do
         expect(user.otp_secret_key).to be nil
       end
     end
-
-    context "clicking on the remind me next time button" do
-      before do
-        click_on "Remind me next time"
-      end
-      it "redirects back to the 2fa setup page" do
-        expect(page).to have_current_path(users_two_factor_authentication_setup_path)
-      end
-    end
   end
 
   context "with a regular non-super-admin user" do
@@ -101,13 +101,36 @@ describe "Set up two factor authentication", type: :feature do
       expect(page).to have_current_path(users_two_factor_authentication_setup_path)
     end
 
-    context "clicking on the remind me next time button" do
+    context "clicking on I cannot set up 2fa" do
       before do
-        click_on "Remind me next time"
+        click_on "I cannot set up two factor authentication"
       end
-      it "disables 2fa for the session" do
-        expect(page).to have_content("Two factor authentication setup skipped until next time")
-        expect(page).to_not have_current_path(users_two_factor_authentication_setup_path)
+      it "goes to the 2fa unable page" do
+        expect(page).to have_current_path(users_two_factor_authentication_unable_path)
+      end
+      context "click on the setup 2fa button" do
+        before :each do
+          click_on "Setup two factor authentication"
+        end
+        it "shows the 2fa setup page" do
+          expect(page).to have_current_path(users_two_factor_authentication_setup_path)
+        end
+      end
+      context "click on the back link" do
+        before :each do
+          click_on "Back"
+        end
+        it "shows the 2fa setup page" do
+          expect(page).to have_current_path(users_two_factor_authentication_setup_path)
+        end
+      end
+      context "click on the Continue to GovWifi link" do
+        before :each do
+          click_on "Continue to GovWifi"
+        end
+        it "signs in" do
+          expect(page).to have_current_path new_organisation_setup_instructions_path
+        end
       end
     end
   end


### PR DESCRIPTION
Currently non-superadmins can skip setting up 2fa but that is
going to disappear soon. This commit adds a warning page that this
is happening and a link where users can get help.

![image](https://user-images.githubusercontent.com/6050162/119120806-9ff2a380-ba24-11eb-88f3-3ecf88a22710.png)

![image](https://user-images.githubusercontent.com/6050162/119120868-b00a8300-ba24-11eb-9ae6-1714ae3587ae.png)

Trello: https://trello.com/c/jCZwXfk6/1149-change-admin-site-to-warn-of-two-factor-authentication-changes