### PR TITLE
Remove `autofocus` attribute from form fields

### DIFF
--- a/app/views/super_admin/whitelists/organisation_names/index.html.erb
+++ b/app/views/super_admin/whitelists/organisation_names/index.html.erb
@@ -15,7 +15,7 @@
     <%= form_for(:custom_organisations, url: super_admin_whitelist_organisation_names_path, html: { novalidate: "" }) do |f| %>
       <div class="govuk-form-group <%= field_error(@custom_organisation, :name) %>">
         <%= f.label :name, "Enter the organisation's full name", class: "govuk-label  govuk-!-margin-top-6" %>
-        <%= f.text_field :name, autofocus: true, class: "govuk-input" %>
+        <%= f.text_field :name, class: "govuk-input" %>
       </div>
 
       <div class="actions">

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -12,7 +12,6 @@
       <div class="govuk-form-group <%= field_error(resource, :email) %>">
         <%= f.label :email, "Enter your email address", class: "govuk-label" %>
         <%= f.email_field :email,
-                          autofocus: true,
                           autocomplete: "email",
                           class: "govuk-input",
                           value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -14,7 +14,7 @@
 
     <div class="govuk-form-group <%= field_error(resource, :email) %>">
       <%= f.label :email, "Email address", class: "govuk-label" %>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input" %>
+      <%= f.email_field :email, autocomplete: "email", class: "govuk-input" %>
     </div>
 
     <div class="actions">

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -12,7 +12,7 @@
 
         <div class="govuk-form-group <%= field_error(resource, :password) %>">
           <%= f.label :password, "New password", class: "govuk-label" %>
-          <%= f.password_field :password, autofocus: true, class: "govuk-input", autocomplete: "off" %>
+          <%= f.password_field :password, class: "govuk-input", autocomplete: "off" %>
         </div>
 
         <div class="actions">

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -12,7 +12,7 @@
       <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, novalidate: "" }) do |f| %>
         <div class="govuk-form-group">
           <%= f.label :email, "Provide your email address", class: "govuk-label" %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input" %>
+          <%= f.email_field :email, autocomplete: "email", class: "govuk-input" %>
         </div>
 
         <div class="actions">

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -12,7 +12,7 @@
       <div class="govuk-form-group <%= field_error(resource, :email) %>">
         <%= f.label :email, "Enter your email address", class: "govuk-label" %>
         <div class="govuk-hint">The email address must be from a government or a public sector domain.</div>
-        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input" %>
+        <%= f.email_field :email, autocomplete: "email", class: "govuk-input" %>
       </div>
 
       <div class="actions">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -20,7 +20,7 @@
 
         <div class="govuk-form-group">
           <%= f.label :email, class: "govuk-label" %>
-          <%= f.email_field :email, autofocus: true, class: "govuk-input" %>
+          <%= f.email_field :email, class: "govuk-input" %>
         </div>
         <div class="govuk-form-group">
           <%= f.label :password, class: "govuk-label" %>

--- a/app/views/users/two_factor_authentication/_show_app.html.erb
+++ b/app/views/users/two_factor_authentication/_show_app.html.erb
@@ -9,8 +9,7 @@
                          class: "govuk-input mfa-code",
                          maxlength: 6,
                          placeholder: "123456",
-                         autocomplete: "off",
-                         autofocus: true %>
+                         autocomplete: "off" %>
     </div>
     <input type="submit" class="govuk-button" value="Authenticate" />
   <% end %>

--- a/app/views/users/two_factor_authentication/show.html.erb
+++ b/app/views/users/two_factor_authentication/show.html.erb
@@ -12,8 +12,7 @@
                            class: "govuk-input mfa-code",
                            maxlength: 6,
                            placeholder: "123456",
-                           autocomplete: "off",
-                           autofocus: true %>
+                           autocomplete: "off" %>
       </div>
       <input type="submit" class="govuk-button" value="Authenticate" />
     <% end %>

--- a/app/views/users/two_factor_authentication_setup/show.html.erb
+++ b/app/views/users/two_factor_authentication_setup/show.html.erb
@@ -21,8 +21,7 @@
                              class: "govuk-input mfa-code",
                              maxlength: 6,
                              placeholder: "123456",
-                             autocomplete: "off",
-                             autofocus: true %>
+                             autocomplete: "off" %>
         </div>
         <%= submit_tag t(".complete_setup"), class: "govuk-button govuk-!-margin-right-1" %>
       <% end %>


### PR DESCRIPTION
## What

Remove `autofocus` attribute from form fields

## Why

Autofocus is frowned upon for accessibility purposes, as "users would expect to navigate the page in reading order, from top to bottom and left to right."