### PR TITLE
Wrap the "no results" messages in `aria-role="status"`

### DIFF
--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -27,9 +27,11 @@
       You need to add at least one location to offer GovWifi
     </p>
   <% else %>
-    <p class="govuk-body" id="no-results" style="display: none">
-      <strong>No results found</strong>
-    </p>
+    <div aria-role="status">
+      <p class="govuk-body" id="no-results" style="display: none">
+        <strong>No results found</strong>
+      </p>
+    </div>
     <% @locations.each do |location| %>
       <%= render "ips/table", location: location %>
     <% end %>

--- a/app/views/super_admin/locations/index.html.erb
+++ b/app/views/super_admin/locations/index.html.erb
@@ -26,9 +26,11 @@
         <% end %>
       </tbody>
     </table>
-    <p class="govuk-body" id="no-results" style="display: none">
-      <strong>No results found</strong>
-    </p>
+    <div aria-role="status">
+      <p class="govuk-body" id="no-results" style="display: none">
+        <strong>No results found</strong>
+      </p>
+    </div>
   </div>
 </div>
 <%= render "shared/filter_search" %>

--- a/app/views/super_admin/organisations/index.html.erb
+++ b/app/views/super_admin/organisations/index.html.erb
@@ -59,8 +59,10 @@
     <% end %>
   </tbody>
 </table>
-<p class="govuk-body" id="no-results" style="display: none">
-  <strong>No results found</strong>
-</p>
+<div aria-role="status">
+  <p class="govuk-body" id="no-results" style="display: none">
+    <strong>No results found</strong>
+  </p>
+</div>
 
 <%= render "shared/filter_search" %>


### PR DESCRIPTION
## What

Implement `aria-role="status"` on "no results" messages.

## Why

Screen readers don't automatically know to read the no results message when searching. This adds the hint that it's relevant content.

## Note

Based on [this](https://www.davidmacd.com/blog/test-aria-live-display-none.html) the role needs to be on a containing element, as it relates to the inner content, so setting it on the `p` that's being shown/hidden wouldn't have an effect.