### PR TITLE
Remove `hr` under main heading.

### DIFF
--- a/app/assets/stylesheets/components/sub_nav.scss
+++ b/app/assets/stylesheets/components/sub_nav.scss
@@ -1,4 +1,6 @@
 .subnav {
+  border-bottom: 1px solid #b1b4b6;
+
   .organisation-name {
     // Organisation name centred on mobile
     text-align: center;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,7 +48,6 @@
     <div class="govuk-width-container">
       <% if user_signed_in? %>
         <%= render "shared/subnav/#{subnav}" %>
-        <hr class="govuk-section-break govuk-section-break--xs govuk-section-break--visible">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-one-quarter">
             <%= render "shared/sidebar/#{sidebar}" %>


### PR DESCRIPTION
## What

The line under the heading was implemented with an `hr` tag. Remove it.

## Why

`hr` now has semantic meaning - "paragraph-level thematic break" - this doesn't make sense under the heading and the same appearance can be easily achieved with CSS.