### PR TITLE
Accessibility:  information and relationships fixes

### DIFF
--- a/app/views/ips/_confirm_remove_ip.html.erb
+++ b/app/views/ips/_confirm_remove_ip.html.erb
@@ -7,13 +7,13 @@
     <table class="govuk-table">
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell govuk-!-width-one-third">IP address</td>
+          <th scope="row" class="govuk-table__cell govuk-body govuk-!-width-one-third">IP address</th>
           <td class="govuk-table__cell govuk-!-width-one-third">
             <%= render partial: "ip_address", locals: { ip: @ip_to_delete.address } %>
           </td>
         </tr>
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell govuk-!-width-one-third">Location</td>
+          <th scope="row" class="govuk-table__cell govuk-body govuk-!-width-one-third">Location</th>
           <td class="govuk-table__cell govuk-!-width-one-third"><%= @ip_to_delete.location.address %></td>
         </tr>
       </tbody>

--- a/app/views/ips/_confirm_rotate_radius_key.html.erb
+++ b/app/views/ips/_confirm_rotate_radius_key.html.erb
@@ -7,7 +7,8 @@
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <td class="govuk-table__cell govuk-!-width-one-third">
-          This rotation will take effect tomorrow morning and cannot be reverted once confirmed.
+            This rotation will take effect tomorrow morning and cannot be reverted once confirmed.
+          </td>
         </tr>
       </tbody>
     </table>

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -6,7 +6,8 @@
   <div class="govuk-body govuk-!-margin-bottom-2">
     RADIUS secret key:
     <div class="inline-block">
-      <span class="secret-key"><%= location.radius_secret_key %></span><% if current_user.can_manage_locations?(current_organisation) %><%= link_to "Rotate secret key", location_rotate_key_path(location, rotate: true), class: "red-link secret-key-rotate-link" %><% end %>
+      <span class="secret-key"><%= location.radius_secret_key %></span>
+      <% if current_user.can_manage_locations?(current_organisation) %><%= link_to "Rotate secret key", location_rotate_key_path(location, rotate: true), class: "red-link secret-key-rotate-link" %><% end %>
     </div>
   </div>
   <% if current_user.can_manage_locations?(current_organisation) %>

--- a/app/views/ips/_table.html.erb
+++ b/app/views/ips/_table.html.erb
@@ -1,21 +1,20 @@
-<table class="govuk-table result-row govuk-!-margin-bottom-7">
-  <caption class="govuk-table__caption text-left govuk-!-font-size-24">
-    <div class="filter-by govuk-!-margin-bottom-2">
-      <%= location.full_address %>
+<div class="result-row">
+  <h2 class="filter-by govuk-heading-m govuk-!-margin-bottom-2">
+    <%= location.full_address %>
+  </h2>
+
+  <div class="govuk-body govuk-!-margin-bottom-2">
+    RADIUS secret key:
+    <div class="inline-block">
+      <span class="secret-key"><%= location.radius_secret_key %></span><% if current_user.can_manage_locations?(current_organisation) %><%= link_to "Rotate secret key", location_rotate_key_path(location, rotate: true), class: "red-link secret-key-rotate-link" %><% end %>
     </div>
-    <div class="govuk-body govuk-!-margin-bottom-2">
-      RADIUS secret key:
-      <div class="inline-block">
-        <span class="secret-key"><%= location.radius_secret_key %></span><% if current_user.can_manage_locations?(current_organisation) %><%= link_to "Rotate secret key", location_rotate_key_path(location, rotate: true), class: "red-link secret-key-rotate-link" %><% end %>
-      </div>
-    </div>
-    <% if current_user.can_manage_locations?(current_organisation) %>
-      <%= link_to "Add IP addresses", location_add_ips_path(location_id: location.id), class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-5" %>
-      <% if location.ips.empty? %>
-        <p class="result-row-empty govuk-body">
-          Add the IP addresses of your authenticators to offer GovWifi at this location
-        </p>
-      <% end %>
+  </div>
+  <% if current_user.can_manage_locations?(current_organisation) %>
+    <%= link_to "Add IP addresses", location_add_ips_path(location_id: location.id), class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-5" %>
+    <% if location.ips.empty? %>
+      <p class="result-row-empty govuk-body">
+        Add the IP addresses of your authenticators to offer GovWifi at this location
+      </p>
     <% end %>
 
     <% if current_user.can_manage_locations?(current_organisation) && location.ips.empty? %>
@@ -23,35 +22,37 @@
         <%= link_to "Remove this location", location_remove_path(location, remove: true), class: "red-link" %>
       </p>
     <% end %>
-  </caption>
+  <% end %>
 
-  <tbody class="govuk-table__body" id="ips-table">
-    <% location.sorted_ip_addresses.each do |ip| %>
-      <tr class="govuk-table__row" id="ips-row-<%= ip.id %>">
-        <td class="govuk-table__cell govuk-!-width-one-third">
-          <%= render partial: "ip_address", locals: { ip: ip.address } %>
-        </td>
-        <% if ip.available? %>
-          <td class="govuk-table__cell ">
-            <% if ip.unused? %>
-              No traffic received yet
-            <% elsif ip.inactive? %>
-              No traffic in the last 10 days
-            <% else %>
-              Receiving traffic (<%= link_to "view logs", logs_path(ip: ip.address), class: "govuk-link" %>)
+  <table class="govuk-table govuk-!-margin-bottom-7">
+    <tbody class="govuk-table__body" id="ips-table">
+      <% location.sorted_ip_addresses.each do |ip| %>
+        <tr class="govuk-table__row" id="ips-row-<%= ip.id %>">
+          <td class="govuk-table__cell govuk-!-width-one-third">
+            <%= render partial: "ip_address", locals: { ip: ip.address } %>
+          </td>
+          <% if ip.available? %>
+            <td class="govuk-table__cell ">
+              <% if ip.unused? %>
+                No traffic received yet
+              <% elsif ip.inactive? %>
+                No traffic in the last 10 days
+              <% else %>
+                Receiving traffic (<%= link_to "view logs", logs_path(ip: ip.address), class: "govuk-link" %>)
+              <% end %>
+            </td>
+          <% else %>
+            <td class="govuk-table__cell text-dark-grey">
+              Available at 6am tomorrow
+            </td>
+          <% end %>
+          <td class="govuk-table__cell text-right">
+            <% if current_user.can_manage_locations?(current_organisation) %>
+              <%= link_to "Remove", ip_remove_path(ip), class: "govuk-link govuk-link--no-visited-state" %>
             <% end %>
           </td>
-        <% else %>
-          <td class="govuk-table__cell text-dark-grey">
-            Available at 6am tomorrow
-          </td>
-        <% end %>
-        <td class="govuk-table__cell text-right">
-          <% if current_user.can_manage_locations?(current_organisation) %>
-            <%= link_to "Remove", ip_remove_path(ip), class: "govuk-link govuk-link--no-visited-state" %>
-          <% end %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/super_admin/whitelists/steps/_sixth.html.erb
+++ b/app/views/super_admin/whitelists/steps/_sixth.html.erb
@@ -10,26 +10,26 @@
 
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell">Does the organisation need to create a GovWifi admin account?</td>
+      <th scope="row" class="govuk-table__cell govuk-body">Does the organisation need to create a GovWifi admin account?</th>
       <td class="govuk-table__cell"><%= params.dig(:whitelist, :admin) %></td>
     </tr>
 
     <% if params.dig(:whitelist, :register).present? %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell">Is the organisation's name on the register?</td>
+        <th scope="row" class="govuk-table__cell govuk-body">Is the organisation's name on the register?</th>
         <td class="govuk-table__cell"><%= params.dig(:whitelist, :register) %></td>
       </tr>
     <% end %>
 
     <% if params.dig(:whitelist, :organisation_name).present? %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell">Organisation name</td>
+        <th scope="row" class="govuk-table__cell govuk-body">Organisation name</th>
         <td class="govuk-table__cell"><%= params.dig(:whitelist, :organisation_name) %></td>
       </tr>
     <% end %>
 
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell">Email domain</td>
+      <th scope="row" class="govuk-table__cell govuk-body">Email domain</th>
       <td class="govuk-table__cell"><%= params.dig(:whitelist, :email_domain) %></td>
     </tr>
   </tbody>


### PR DESCRIPTION
## What

1. Move table caption content outside of table
2. Add headers to table rows

## Why 

1. Caption should be used as just that - our captions had heading, radius key, option to rotate, delete location button.
2. Some tables had rows with `label: value` - `label` in that context should be a `th`