### PR TITLE
DAC Validation Pattern fixes

### DIFF
--- a/app/views/ips/_confirm_remove_ip.html.erb
+++ b/app/views/ips/_confirm_remove_ip.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-error-summary">
+<div class="govuk-error-summary" role="alert">
   <h2 class="govuk-error-summary__title">
     Remove this IP address?
   </h2>

--- a/app/views/ips/_confirm_remove_location.html.erb
+++ b/app/views/ips/_confirm_remove_location.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-error-summary">
+<div class="govuk-error-summary" role="alert">
   <h2 class="govuk-error-summary__title">
     Are you sure you want to remove this location?
   </h2>

--- a/app/views/ips/_confirm_rotate_radius_key.html.erb
+++ b/app/views/ips/_confirm_rotate_radius_key.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-error-summary">
+<div class="govuk-error-summary" role="alert">
   <h2 class="govuk-error-summary__title">
     Are you sure you want to rotate this RADIUS secret key?
   </h2>

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -27,7 +27,7 @@
       You need to add at least one location to offer GovWifi
     </p>
   <% else %>
-    <div aria-role="status">
+    <div role="status">
       <p class="govuk-body" id="no-results" style="display: none">
         <strong>No results found</strong>
       </p>

--- a/app/views/layouts/_flash_notices.html.erb
+++ b/app/views/layouts/_flash_notices.html.erb
@@ -8,7 +8,7 @@
     </div>
   <% end %>
   <% if name == 'alert' %>
-    <div class="govuk-error-summary">
+    <div class="govuk-error-summary" role="alert">
       <h2 class="govuk-error-summary__title">
         There is a problem
       </h2>

--- a/app/views/layouts/_form_errors.html.erb
+++ b/app/views/layouts/_form_errors.html.erb
@@ -1,14 +1,19 @@
-<% if defined? resource %>
-  <% if resource&.errors&.any? %>
-    <div class="govuk-error-summary" id="error-summary">
-      <h2 class="govuk-error-summary__title">There is a problem</h2>
-      <div class="govuk-error-summary__body">
-        <ul class="govuk-list govuk-error-summary__list">
-          <% resource.errors.full_messages.each do |message| %>
-            <li id="error-message"><%= message.html_safe %></li>
+<% if defined?(resource) && resource&.errors&.any? %>
+  <% content_for :page_title, "Error: #{yield :page_title}", flush: true %>
+
+  <div class="govuk-error-summary" role="alert" id="error-summary" tabindex="-1" autofocus>
+    <h2 class="govuk-error-summary__title">There is a problem</h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <%= form_for resource, url: "" do |f| %>
+          <% resource.errors.each do |error| %>
+            <li><%= f.label(error.attribute.to_sym, raw(error.full_message))
+                  .gsub(/label/, "a")
+                  .gsub(/for="/, "href=\"#")
+                  .html_safe %></li>
           <% end %>
-        </ul>
-      </div>
+        <% end %>
+      </ul>
     </div>
-  <% end %>
+  </div>
 <% end %>

--- a/app/views/locations/add_ips.html.erb
+++ b/app/views/locations/add_ips.html.erb
@@ -1,16 +1,26 @@
-<% content_for :page_title, "Add IP addresses" %>
-
-<%= render "layouts/form_errors", resource: @ip %>
+<% content_for :page_title, if action_name == "update_ips"
+                              "Error: Add IP addresses"
+                            else
+                              "Add IP addresses"
+                            end %>
 
 <% if action_name == 'update_ips' %>
-  <div class="govuk-error-summary">
+  <div class="govuk-error-summary" role="alert" tabindex="-1" autofocus>
     <h2 class="govuk-error-summary__title">There is a problem</h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
         <% if @location.ips_unable_to_be_persisted.empty? %>
           <li>Enter at least one IP address</li>
         <% else %>
-          <li>There’s a problem with these IP addresses</li>
+          <%= form_for @location, url: location_update_ips_path(location_id: @location.id) do |form| %>
+            <%= form.fields_for(:ips, @location.blank_ips) do |ip| %>
+              <% if ip.object.errors.key?(:address) %>
+                <li><a href="#ip_<%= ip.index + 1 %>">
+                  <span class="govuk-visually-hidden">Error:</span> <%= ip.object.errors.full_messages_for(:address).first %>
+                </a></li>
+              <% end %>
+            <% end %>
+          <% end %>
         <% end %>
       </ul>
     </div>
@@ -43,16 +53,16 @@
         IPv4 only
       </span>
       <%= form.fields_for(:ips, @location.blank_ips) do |ip| %>
-        <div class='govuk-!-margin-bottom-3'>
+        <div class='govuk-!-margin-bottom-3' id="ip_<%= ip.index + 1 %>">
           <% style = "govuk-input govuk-input--width-10" + (ip.object.errors.key?(:address) ? " govuk-input--error" : "") %>
-          <% if ip.object.errors.has_key?(:address) %>
-            <span class="govuk-error-message">
+          <% if ip.object.errors.key?(:address) %>
+            <span class="govuk-error-message" id="ip_<%= ip.index + 1 %>_error">
               <span class="govuk-visually-hidden">Error:</span> <%= ip.object.errors.full_messages_for(:address).first %>
             </span>
           <% end %>
           <label class='label-inside-input'>
             <span class='govuk-body'><%= ip.index + 1 %>.</span>
-            <%= ip.text_field :address, class: style %>
+            <%= ip.text_field :address, class: style, "aria-described-by" => ip.object.errors.key?(:address) && "ip_#{ip.index + 1}_error" %>
           </label>
         </div>
       <% end %>

--- a/app/views/locations/new.erb
+++ b/app/views/locations/new.erb
@@ -1,20 +1,6 @@
 <% content_for :page_title, "Add location" %>
 
-<% if @location.errors.any? %>
-  <div class="govuk-error-summary">
-    <h2 class="govuk-error-summary__title">There is a problem</h2>
-    <div class="govuk-error-summary__body">
-      <ul class="govuk-list govuk-error-summary__list">
-        <% @location.errors.full_messages_for(:address).each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-        <% @location.errors.full_messages_for(:postcode).each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  </div>
-<% end %>
+<%= render "layouts/form_errors", resource: @location %>
 
 <div class='govuk-grid-row'>
   <div class='govuk-grid-column-full'>

--- a/app/views/memberships/_confirm_remove_team_member.html.erb
+++ b/app/views/memberships/_confirm_remove_team_member.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-error-summary">
+<div class="govuk-error-summary" role="alert">
    <h2 class="govuk-error-summary__title">
      Are you sure you want to remove <%= @membership.user.name %>?
    </h2>

--- a/app/views/organisations/edit.html.erb
+++ b/app/views/organisations/edit.html.erb
@@ -1,17 +1,6 @@
 <% content_for :page_title, "Edit service email" %>
 
-<% if @organisation.errors.any? %>
-  <div class="govuk-error-summary">
-    <h2 class="govuk-error-summary__title">There is a problem</h2>
-    <div class="govuk-error-summary__body">
-      <ul class="govuk-list govuk-error-summary__list">
-        <% @organisation.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  </div>
-<% end %>
+<%= render "layouts/form_errors", resource: @organisation %>
 
 <%= link_to "Back to settings", setup_instructions_path, class: "govuk-back-link" %>
 <h1 class="govuk-heading-l">Edit service email</h1>

--- a/app/views/super_admin/locations/index.html.erb
+++ b/app/views/super_admin/locations/index.html.erb
@@ -26,7 +26,7 @@
         <% end %>
       </tbody>
     </table>
-    <div aria-role="status">
+    <div role="status">
       <p class="govuk-body" id="no-results" style="display: none">
         <strong>No results found</strong>
       </p>

--- a/app/views/super_admin/organisations/_confirm_remove_organisation.html.erb
+++ b/app/views/super_admin/organisations/_confirm_remove_organisation.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-error-summary">
+<div class="govuk-error-summary" role="alert">
   <h2 class="govuk-error-summary__title">
     Are you sure you want to delete <%= @organisation.name %>?
   </h2>

--- a/app/views/super_admin/whitelists/email_domains/_confirm_remove_email_domain.html.erb
+++ b/app/views/super_admin/whitelists/email_domains/_confirm_remove_email_domain.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-error-summary">
+<div class="govuk-error-summary" role="alert">
   <h2 class="govuk-error-summary__title">
     Are you sure you want to remove this email domain?
   </h2>

--- a/app/views/super_admin/whitelists/organisation_names/_confirm_remove_custom_organisation.html.erb
+++ b/app/views/super_admin/whitelists/organisation_names/_confirm_remove_custom_organisation.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-error-summary">
+<div class="govuk-error-summary" role="alert">
    <h2 class="govuk-error-summary__title">
      Are you sure you want to remove this organisation?
    </h2>

--- a/app/views/users/invitations/edit.html.erb
+++ b/app/views/users/invitations/edit.html.erb
@@ -7,11 +7,10 @@
     <h2 class="govuk-heading-l">Create your account</h2>
 
     <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-
       <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put, novalidate: "" } do |f| %>
         <%= f.hidden_field :invitation_token, readonly: true %>
 
-        <div class="govuk-form-group">
+        <div class="govuk-form-group <%= field_error(resource, :name) %>">
           <%= f.label :name, "Your name", class: "govuk-label" %>
           <%= f.text_field :name, class: "govuk-input" %>
         </div>

--- a/app/views/users/two_factor_authentication/edit.html.erb
+++ b/app/views/users/two_factor_authentication/edit.html.erb
@@ -1,6 +1,6 @@
 <%= link_to "Back", :back, class: "govuk-back-link" %>
 
-<div class="govuk-error-summary">
+<div class="govuk-error-summary" role="alert">
   <h2 class="govuk-error-summary__title">
     Are you sure you want to reset two factor authentication for <%= @user.name %>?
   </h2>

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -230,7 +230,7 @@ describe "Sign up as an organisation", type: :feature do
       update_user_details(organisation_name: org_name_left_blank)
       skip_two_factor_authentication
       within("div#error-summary") do
-        expect(page).to have_selector("li#error-message", count: 1, text: "Organisations name can't be blank")
+        expect(page).to have_selector("li", count: 1, text: "Organisations name can't be blank")
       end
     end
   end


### PR DESCRIPTION
## What

* Update form errors template to repeat errors and link to fields
* Use form errors template where previously not used
* Set "Error: " prefix on page title within form errors template
* Repeat on Add IPs as this has custom errors

## Why

Because the DAC Doc says so.

## Note

The implementation of the links in the top errors is a bit of a hack - Devise just isn't designed to do that, but this works pretty well. 

Additionally adding the "Error: " prefix to the page titles is a similar hack. [In the top error template](https://github.com/alphagov/govwifi-admin/pull/1312/files#diff-66b69dc0610365d039ef8e12646a3e263511ec7e3deffec7914747225c6318b4R2) If we're displaying the errors, then we also take the previously set page title and add the prefix there.