### PR TITLE
Add action prefixes to page titles.

### DIFF
--- a/app/views/ips/_confirm_remove_ip.html.erb
+++ b/app/views/ips/_confirm_remove_ip.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Remove IP address -  #{yield :page_title}", flush: true %>
+
 <div class="govuk-error-summary" role="alert">
   <h2 class="govuk-error-summary__title">
     Remove this IP address?

--- a/app/views/ips/_confirm_remove_location.html.erb
+++ b/app/views/ips/_confirm_remove_location.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Remove location -  #{yield :page_title}", flush: true %>
+
 <div class="govuk-error-summary" role="alert">
   <h2 class="govuk-error-summary__title">
     Are you sure you want to remove this location?

--- a/app/views/ips/_confirm_rotate_radius_key.html.erb
+++ b/app/views/ips/_confirm_rotate_radius_key.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Rotate secret key -  #{yield :page_title}", flush: true %>
+
 <div class="govuk-error-summary" role="alert">
   <h2 class="govuk-error-summary__title">
     Are you sure you want to rotate this RADIUS secret key?

--- a/app/views/memberships/_confirm_remove_team_member.html.erb
+++ b/app/views/memberships/_confirm_remove_team_member.html.erb
@@ -1,3 +1,5 @@
+ <% content_for :page_title, "Remove team member - #{yield :page_title}", flush: true %>
+
 <div class="govuk-error-summary" role="alert">
    <h2 class="govuk-error-summary__title">
      Are you sure you want to remove <%= @membership.user.name %>?

--- a/app/views/users/two_factor_authentication/edit.html.erb
+++ b/app/views/users/two_factor_authentication/edit.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, "Reset two factor authentication" %>
+
 <%= link_to "Back", :back, class: "govuk-back-link" %>
 
 <div class="govuk-error-summary" role="alert">


### PR DESCRIPTION
## What

Add action titles... e.g. when you click "Remove Location" and you get a confirmation dialog, now the title changes to indicate the action

## Why

So that the page is more accessible.