### PR TITLE
Remove the success message on 2fa authentication

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -3,7 +3,7 @@
 en:
   devise:
     two_factor_authentication:
-      success: "Two factor authentication setup successful."
+      success: ""
       attempt_failed: "Six digit code is not valid"
     confirmations:
       confirmed: ""


### PR DESCRIPTION
## What

When you sign in and complete 2FA, there's a message telling you it's been set up successfully. Remove it.

## Why
[](url)
There's already the [same message, defined separately](https://github.com/alphagov/govwifi-admin/blob/343ae2a5f039604072afff4e630402ffe6f365ac/app/controllers/users/two_factor_authentication_setup_controller.rb#L16) when you do _set up_ 2FA. Having the same message when you sign in is incorrect - it would correctly say "you have successfully signed in" however this is superfluous.