### PR TITLE
Correct the button text. Add class to link, to style it as link.

### DIFF
--- a/app/views/users/two_factor_authentication/show.html.erb
+++ b/app/views/users/two_factor_authentication/show.html.erb
@@ -14,7 +14,7 @@
                            autocomplete: "off",
                            "aria-describedby" => "code-hint" %>
       </div>
-      <input type="submit" class="govuk-button" value="Authenticate" />
+      <input type="submit" class="govuk-button" value="Continue" />
     <% end %>
 
     <details class="govuk-details" data-module="govuk-details">
@@ -26,7 +26,7 @@
       <div class="govuk-details__text">
         <p>Ask a team member to reset your two factor authentication. They can do this from the ‘Team members’ section of their GovWifi admin account.</p>
         <p>Once they have done this, you can set up two factor authentication again the next time you sign in.</p>
-        <p>Contact <a href="mailto:govwifi-support@digital.cabinet-office.gov.uk">govwifi-support@digital.cabinet-office.gov.uk</a> if you’re having problems.</p>
+        <p>Contact <a href="mailto:govwifi-support@digital.cabinet-office.gov.uk" class="govuk-link">govwifi-support@digital.cabinet-office.gov.uk</a> if you’re having problems.</p>
        </div>
     </details>
   </div>


### PR DESCRIPTION
## What

* Change button "Authenticate" to "Continue"
* add `govuk-link` class to the email link

## Why

Because these were missed on earlier PR