### PR TITLE
Fix headings

### DIFF
--- a/app/views/help/admin_account.erb
+++ b/app/views/help/admin_account.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= link_to 'Back', new_help_path, class: "govuk-back-link" %>
-    <h2 class="govuk-heading-l">Manage GovWifi in your organisation support</h2>
+    <h1 class="govuk-heading-l">Manage GovWifi in your organisation support</h1>
     <div class="govuk-inset-text">
       If you are experiencing difficulty setting up GovWifi in your organisation for the first time, please use our
       <%= link_to 'set up GovWifi support form.', technical_support_new_help_path, class: "govuk-link" %> contact form.

--- a/app/views/help/new.html.erb
+++ b/app/views/help/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">GovWifi administrator support</h2>
+    <h1 class="govuk-heading-l">GovWifi administrator support</h1>
     <div class="govuk-details">
     <p>
       We provide guidance on how to set up and manage GovWifi in your organisation in our
@@ -13,25 +13,31 @@
       If users in your organisation are having trouble connecting devices to GovWifi, please refer them to our <%= link_to "user support guidance", "https://www.wifi.service.gov.uk/support/", class: "govuk-link" %> on common issues.
     </p>
 
-      <h2 class="govuk-body-m">How can we help?</h2>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              How can we help?
+          </legend>
 
-      <%= form_tag new_help_path, class: "govuk-radios", method: "get" do %>
-        <div class="govuk-radio">
-          <div class="govuk-radios__item">
-            <%= radio_button_tag(:choice, :technical_support, nil, class: "govuk-radios__input") %>
-            <%= label_tag(:choice_technical_support, "Setting up GovWifi in your organisation support", class: "govuk-label govuk-radios__label") %>
-          </div>
-          <div class="govuk-radios__item">
-            <%= radio_button_tag(:choice, :admin_account, nil, class: "govuk-radios__input") %>
-            <%= label_tag(:choice_admin_account, "Managing GovWifi in your organisation support", class: "govuk-label govuk-radios__label") %>
-          </div>
-          <div class="govuk-radios__item">
-            <%= radio_button_tag(:choice, :user_support, nil, class: "govuk-radios__input") %>
-            <%= label_tag(:choice_user_support, "Request GovWifi user information", class: "govuk-label govuk-radios__label govuk-!-margin-bottom-4") %>
-          </div>
-        </div>
-        <%= submit_tag("Continue", class: "govuk-button") %>
-      <% end %>
+          <%= form_tag new_help_path, class: "govuk-radios", method: "get" do %>
+            <div class="govuk-radio">
+              <div class="govuk-radios__item">
+                <%= radio_button_tag(:choice, :technical_support, nil, class: "govuk-radios__input") %>
+                <%= label_tag(:choice_technical_support, "Setting up GovWifi in your organisation support", class: "govuk-label govuk-radios__label") %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= radio_button_tag(:choice, :admin_account, nil, class: "govuk-radios__input") %>
+                <%= label_tag(:choice_admin_account, "Managing GovWifi in your organisation support", class: "govuk-label govuk-radios__label") %>
+              </div>
+              <div class="govuk-radios__item">
+                <%= radio_button_tag(:choice, :user_support, nil, class: "govuk-radios__input") %>
+                <%= label_tag(:choice_user_support, "Request GovWifi user information", class: "govuk-label govuk-radios__label govuk-!-margin-bottom-4") %>
+              </div>
+            </div>
+            <%= submit_tag("Continue", class: "govuk-button") %>
+          <% end %>
+        </fieldset>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/help/signed_in.html.erb
+++ b/app/views/help/signed_in.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <h2 class="govuk-heading-l">Support</h2>
+    <h1 class="govuk-heading-l">Support</h1>
 
     <p class="govuk-body">
       If an <strong>individual user</strong> is having trouble connecting to GovWifi:

--- a/app/views/help/technical_support.html.erb
+++ b/app/views/help/technical_support.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= link_to "Back", new_help_path, class: "govuk-back-link" %>
-    <h2 class="govuk-heading-l">Set up GovWifi in your organisation support</h2>
+    <h1 class="govuk-heading-l">Set up GovWifi in your organisation support</h1>
     <p class="govuk-body">Contact us for technical help and support setting up GovWifi in your organisation for the first time.</p>
     <p class="govuk-inset-text">
       If you are experiencing difficulty managing an existing GovWifi installation in your organisation, please use our

--- a/app/views/help/user_support.html.erb
+++ b/app/views/help/user_support.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= link_to "Back", new_help_path, class: "govuk-back-link" %>
-    <h2 class="govuk-heading-l">User account support</h2>
+    <h1 class="govuk-heading-l">User account support</h1>
     <p class="govuk-body">Contact us for help and support with users connecting to GovWifi in your organisation.</p>
     <p class="govuk-inset-text">
       If users in your organisation are having trouble connecting devices to GovWifi, please advise them to review our

--- a/app/views/locations/add_ips.html.erb
+++ b/app/views/locations/add_ips.html.erb
@@ -31,9 +31,9 @@
   <div class="govuk-grid-column-three-quarters">
     <%= link_to "Back to locations", ips_path, class: "govuk-back-link" %>
 
-    <h2 class="govuk-heading-l">
+    <h1 class="govuk-heading-l">
       Add IP addresses
-    </h2>
+    </h1>
 
     <p class="govuk-heading-s">
       <%= @location.address %>, <%= @location.postcode %>

--- a/app/views/locations/new.erb
+++ b/app/views/locations/new.erb
@@ -5,19 +5,19 @@
 <div class='govuk-grid-row'>
   <div class='govuk-grid-column-full'>
     <%= link_to 'Back to list', ips_path, class: 'govuk-back-link' %>
-    <h2 class='govuk-heading-l'>Add a location</h2>
+    <h1 class='govuk-heading-l'>Add a location</h1>
   </div>
   <div class='govuk-grid-column-full'>
     <%= form_for @location, html: { autocomplete: "off" } do |f| %>
       <div class="govuk-form-group">
         <%= f.label :address, class: 'govuk-label' %>
-        <span class="govuk-hint">
+        <div id="address-hint" class="govuk-hint">
           For example, 10 High Street, London
-        </span>
+        </div>
         <% if @location.errors.attribute_names.include?(:address) %>
-          <%= f.text_field :address, class: 'govuk-input govuk-input--error' %>
+          <%= f.text_field :address, class: 'govuk-input govuk-input--error', 'aria-describedby': 'address-hint' %>
         <% else %>
-          <%= f.text_field :address, class: 'govuk-input' %>
+          <%= f.text_field :address, class: 'govuk-input', 'aria-describedby': 'address-hint' %>
         <% end %>
       </div>
       <div class="govuk-form-group">

--- a/app/views/logs/_no_logs_explanation.html.erb
+++ b/app/views/logs/_no_logs_explanation.html.erb
@@ -1,8 +1,8 @@
 <div class="govuk-grid-column-two-thirds">
   <% if super_admin? %>
-    <h3 class="govuk-body">
+    <p class="govuk-body">
       If you were expecting to see results, ask the organisation if:
-    </h3>
+    </p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>the IP addresses they entered into the GovWifi admin site match their access point IP addresses exactly?</li>
@@ -11,9 +11,9 @@
     </ul>
 
   <% else %>
-    <h3 class="govuk-body">
+    <p class="govuk-body">
       If you were expecting to see results:
-    </h3>
+    </p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>check your <%= link_to "configured IP addresses", ips_path, class: "govuk-link" %> match your authenticator IP addresses </li>

--- a/app/views/logs_searches/new.html.erb
+++ b/app/views/logs_searches/new.html.erb
@@ -12,46 +12,50 @@
 
     <%= form_with url: logs_searches_path, method: :post, local: true do |form| %>
       <div class="govuk-form-group">
-        <p class="govuk-body">
-          How do you want to filter these logs?
-        </p>
-        <div class="govuk-radios <%= field_error(@search, :filter) %>">
-          <%= render "error_message", key: :filter, message: "select an option" %>
-          <% if !super_admin? %>
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="choice-location" name="logs_search[filter]" type="radio" value="location">
-              <label class="govuk-label govuk-radios__label" for="choice-location">
-                Location
-              </label>
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend">
+              How do you want to filter these logs?
+            </legend>
+            <div class="govuk-radios <%= field_error(@search, :filter) %>">
+              <%= render "error_message", key: :filter, message: "select an option" %>
+              <% if !super_admin? %>
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="choice-location" name="logs_search[filter]" type="radio" value="location">
+                  <label class="govuk-label govuk-radios__label" for="choice-location">
+                    Location
+                  </label>
+                </div>
+              <% end %>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="choice-username" name="logs_search[filter]" type="radio" value="username">
+                <label class="govuk-label govuk-radios__label" for="choice-username">
+                  Username
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="choice-ip" name="logs_search[filter]" type="radio" value="ip">
+                <label class="govuk-label govuk-radios__label" for="choice-ip">
+                  IP address
+                </label>
+              </div>
+              <% if super_admin? %>
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="choice-email" name="logs_search[filter]" type="radio" value="contact">
+                  <label class="govuk-label govuk-radios__label" for="choice-email">
+                    Email address
+                  </label>
+                </div>
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="choice-phone" name="logs_search[filter]" type="radio" value="contact">
+                  <label class="govuk-label govuk-radios__label" for="choice-phone">
+                    Phone number
+                  </label>
+                </div>
+              <% end %>
             </div>
-          <% end %>
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="choice-username" name="logs_search[filter]" type="radio" value="username">
-            <label class="govuk-label govuk-radios__label" for="choice-username">
-              Username
-            </label>
           </div>
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="choice-ip" name="logs_search[filter]" type="radio" value="ip">
-            <label class="govuk-label govuk-radios__label" for="choice-ip">
-              IP address
-            </label>
-          </div>
-          <% if super_admin? %>
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="choice-email" name="logs_search[filter]" type="radio" value="contact">
-              <label class="govuk-label govuk-radios__label" for="choice-email">
-                Email address
-              </label>
-            </div>
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="choice-phone" name="logs_search[filter]" type="radio" value="contact">
-              <label class="govuk-label govuk-radios__label" for="choice-phone">
-                Phone number
-              </label>
-            </div>
-          <% end %>
-        </div>
+        </fieldset>
       </div>
       <input type='hidden' name='logs_search[first_step]' value='true'>
       <%= form.submit "Go to search", class: "govuk-button" %>

--- a/app/views/memberships/_table.html.erb
+++ b/app/views/memberships/_table.html.erb
@@ -6,13 +6,13 @@
       <div class='govuk-grid-row'>
         <div class='govuk-grid-column-two-thirds'>
           <% if member.invitation_pending? || member.pending_membership_for?(organisation: current_organisation) %>
-            <h3 class='govuk-heading-s govuk-!-margin-bottom-0'><%= member.name %>
+            <h2 class='govuk-heading-s govuk-!-margin-bottom-0'><%= member.name %>
               <span class='govuk-!-padding-left-1 govuk-body text-dark-grey'><%= member.email %> (invited)</span>
-            </h3>
+            </h2>
             <% else %>
-            <h3 class='govuk-heading-s govuk-!-margin-bottom-0'><%= member.name %>
+            <h2 class='govuk-heading-s govuk-!-margin-bottom-0'><%= member.name %>
               <span class='govuk-!-padding-left-1 govuk-body text-dark-grey'><%= member.email %></span>
-            </h3>
+            </h2>
           <% end %>
 
           <ul class='govuk-list govuk-!-margin-bottom-2 govuk-!-margin-top-1' id='member-<%= member.id %>-permissions'>

--- a/app/views/mou/index.html.erb
+++ b/app/views/mou/index.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <%= link_to "Back to settings", setup_instructions_path, class: "govuk-back-link" %>
-    <h2 class="govuk-heading-l">Sign the memorandum of understanding</h2>
+    <h1 class="govuk-heading-l">Sign the memorandum of understanding</h1>
     <p class="govuk-body">You must sign a memorandum of understanding (MOU) to use GovWifi.</p>
     <% if @mou %>
       <ol class="govuk-list govuk-list--number">
@@ -24,7 +24,7 @@
         A signed MOU was uploaded on <%= @current_org_signed_mou.created_at.strftime("%e %b %Y") %>,
         <%= link_to "Download and view your signed MOU.", rails_blob_path(@current_org_signed_mou, disposition: "attachment"), class: "govuk-link" %>
       </p>
-      <h3 class="govuk-heading-m">Replace your MOU</h3>
+      <h2 class="govuk-heading-m">Replace your MOU</h2>
       <p class="govuk-body">Manually replace your organisation's signed MOU. This will overwrite the existing document.</p>
     <% else %>
       <p class="govuk-body">You have not uploaded a signed MOU yet.</p>

--- a/app/views/organisations/new.html.erb
+++ b/app/views/organisations/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "layouts/form_errors", resource: @organisation %>
 
-<h2 class="govuk-heading-l">Register an organisation for GovWifi</h2>
+<h1 class="govuk-heading-l">Register an organisation for GovWifi</h1>
 <%= form_for @organisation, url: organisations_path do |form| %>
   <div class="govuk-form-group <%= field_error(@organisation, "name") %>">
     <%= form.label :name, "Organisation name", class: "govuk-label" %>

--- a/app/views/overview/index.html.erb
+++ b/app/views/overview/index.html.erb
@@ -15,12 +15,12 @@
 <% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full overview-section-alignment" id="overview">
-    <h2 class="govuk-heading-l govuk-grid-column-full">Overview</h2>
+    <h1 class="govuk-heading-l govuk-grid-column-full">Overview</h1>
     <div class="govuk-grid-column-one-third" id="team-members">
       <div class="overview-stats-panel govuk-panel--confirmation summary-background">
-        <h1 class="govuk-panel__title text-left" id="team-members-count">
+        <p class="govuk-panel__title text-left" id="team-members-count">
           <%= @team_members.count %>
-        </h1>
+        </p>
         <p class="govuk-panel__body text-left govuk-!-font-size-27">
           <%= link_to "Team members", memberships_path, class: "govuk-link govuk-link--no-visited-state summary-link-colour" %>
         </p>
@@ -28,9 +28,9 @@
     </div>
     <div class="govuk-grid-column-one-third" id="locations">
       <div class="overview-stats-panel govuk-panel--confirmation summary-background">
-        <h1 class="govuk-panel__title text-left" id="locations-count">
+        <p class="govuk-panel__title text-left" id="locations-count">
           <%= @locations.count %>
-        </h1>
+        </p>
         <p class="govuk-panel__body text-left govuk-!-font-size-27">
           <%= link_to "Locations", ips_path, class: "govuk-link govuk-link--no-visited-state summary-link-colour" %>
         </p>
@@ -38,9 +38,9 @@
     </div>
     <div class="govuk-grid-column-one-third" id="ips">
       <div class="overview-stats-panel govuk-panel--confirmation summary-background">
-        <h1 class="govuk-panel__title text-left" id="ips-count">
+        <p class="govuk-panel__title text-left" id="ips-count">
           <%= @ips.count %>
-        </h1>
+        </p>
         <p class="govuk-panel__body text-left govuk-!-font-size-27">
           <%= link_to "IP addresses", ips_path, class: "govuk-link govuk-link--no-visited-state summary-link-colour" %>
         </p>

--- a/app/views/setup_instructions/_account.html.erb
+++ b/app/views/setup_instructions/_account.html.erb
@@ -1,4 +1,4 @@
-<h3 class="govuk-heading-m">Your account</h3>
+<h2 class="govuk-heading-m">Your account</h2>
 
 <table class="govuk-table">
   <caption class="govuk-visually-hidden">Settings</caption>

--- a/app/views/setup_instructions/_organisation.html.erb
+++ b/app/views/setup_instructions/_organisation.html.erb
@@ -1,4 +1,4 @@
-<h3 class="govuk-heading-m">Organisation</h3>
+<h2 class="govuk-heading-m">Organisation</h2>
 
 <table class="govuk-table">
   <caption class="govuk-visually-hidden">Settings</caption>

--- a/app/views/setup_instructions/_servers.html.erb
+++ b/app/views/setup_instructions/_servers.html.erb
@@ -1,4 +1,4 @@
-<h3 class="govuk-heading-m">GovWifi servers</h3>
+<h2 class="govuk-heading-m">GovWifi servers</h2>
 
 <table class="govuk-table govuk-!-margin-bottom-3">
   <caption class="govuk-visually-hidden">Settings</caption>

--- a/app/views/setup_instructions/index.html.erb
+++ b/app/views/setup_instructions/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "Organisation settings" %>
 
-<h2 class="govuk-heading-l">Settings</h2>
+<h1 class="govuk-heading-l">Settings</h1>
 
 <%= render "account" %>
 

--- a/app/views/super_admin/mou/index.html.erb
+++ b/app/views/super_admin/mou/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Memorandum of understanding</h2>
+    <h1 class="govuk-heading-l">Memorandum of understanding</h1>
     <p class="govuk-body">Admins can upload a copy of a GDS signed MOU.</p>
     <p class="govuk-body">Be aware that any version of the MOU template that is uploaded will be visible to all organisations requesting to sign up to GovWifi.</p>
     <hr class="govuk-section-break--m govuk-section-break--visible">

--- a/app/views/super_admin/mou/index.html.erb
+++ b/app/views/super_admin/mou/index.html.erb
@@ -8,10 +8,10 @@
     <hr class="govuk-section-break--m govuk-section-break--visible">
     <% if @mou.unsigned_document.attached? %>
       <%= link_to "Download current template", rails_blob_path(@mou.unsigned_document, disposition: "attachment"), class: "govuk-link" %>
-      <h3 class="govuk-heading-m">Replace Template</h3>
+      <h2 class="govuk-heading-m">Replace Template</h2>
     <% else %>
       <p class="govuk-body">There is no uploaded MOU for organisations to access.</p>
-      <h3 class="govuk-heading-m">Upload template</h3>
+      <h2 class="govuk-heading-m">Upload template</h2>
     <% end %>
     <p class="govuk-body"> </p>
     <p class="govuk-body"> </p>

--- a/app/views/super_admin/organisations/_mou_form.html.erb
+++ b/app/views/super_admin/organisations/_mou_form.html.erb
@@ -6,11 +6,11 @@
     <%= link_to "download and view the document.", rails_blob_path(organisation.signed_mou, disposition: "attachment"), class: "govuk-link" %>
   </p>
 
-  <h3 class="govuk-heading-m">Replace MOU</h3>
+  <h2 class="govuk-heading-m">Replace MOU</h2>
   <p class="govuk-body">Manually replace this organisation's signed MOU. This will overwrite the existing document.</p>
 <% else %>
   <p class="govuk-body">This organisation has not uploaded an MOU.</p>
-  <h3 class="govuk-heading-m">Upload MOU</h3>
+  <h2 class="govuk-heading-m">Upload MOU</h2>
   <p class="govuk-body">Manually upload this organisation's signed MOU</p>
 <% end %>
 

--- a/app/views/super_admin/organisations/index.html.erb
+++ b/app/views/super_admin/organisations/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, "All organisations" %>
 
 <h1 class="govuk-heading-l">All organisations</h1>
-<h3 class="govuk-body">
+<p class="govuk-body">
   GovWifi is in
   <span class="govuk-!-font-weight-bold">
     <%= pluralize(@location_count, "location") %>
@@ -10,7 +10,7 @@
   <span class="govuk-!-font-weight-bold">
     <%= pluralize(@organisations.length, "organisation") %>.
   </span>
-</h3>
+</p>
 
 <div class="govuk-!-margin-top-1">
   <%= link_to "Download all organisations in CSV format",

--- a/app/views/super_admin/whitelists/email_domains/new.html.erb
+++ b/app/views/super_admin/whitelists/email_domains/new.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h2 class="govuk-heading-l">Allow a new email domain</h2>
+    <h1 class="govuk-heading-l">Allow a new email domain</h1>
 
     <%= form_for @authorised_email_domain, url: { action: :create } do |f| %>
       <%= f.label :name, "Name", class: "govuk-label" %>

--- a/app/views/super_admin/whitelists/organisation_names/index.html.erb
+++ b/app/views/super_admin/whitelists/organisation_names/index.html.erb
@@ -8,7 +8,7 @@
     <%= render "super_admin/whitelists/side_nav" %>
   </div>
   <div class="govuk-grid-column-three-quarters">
-    <h2 class="govuk-heading-l">Allow an organisation access to the admin platform</h2>
+    <h1 class="govuk-heading-l">Allow an organisation access to the admin platform</h1>
       <%= label_tag "search_orgs_label", "Search for existing organisations on GovWifi before adding them", class: "govuk-label" %>
       <%= select_tag "organisations_register", options_for_select(@fetched_organisations_from_register << "", "") %>
 

--- a/app/views/super_admin/whitelists/steps/_first.html.erb
+++ b/app/views/super_admin/whitelists/steps/_first.html.erb
@@ -1,11 +1,11 @@
 <h1 class="govuk-heading-l">Give an organisation access to GovWifi</h1>
-<h3 class="govuk-heading-s">Allowed organisation names</h3>
+<h2 class="govuk-heading-s">Allowed organisation names</h2>
 <p class="govuk-body">
   To offer GovWifi in its buildings, an organisation’s name needs to
   be on the list of known public sector organisations. If it's not on
   the list, you can add it.
 </p>
-<h3 class="govuk-heading-s">Allowed email domains</h3>
+<h2 class="govuk-heading-s">Allowed email domains</h2>
 <p class="govuk-body">
   To request a GovWifi username and password via email, the user’s
   email domain must be on the list of known public sector email

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Resend confirmation instructions</h2>
+    <h1 class="govuk-heading-l">Resend confirmation instructions</h1>
 
     <%= render "users/shared/end_user_warning" %>
 

--- a/app/views/users/confirmations/show.html.erb
+++ b/app/views/users/confirmations/show.html.erb
@@ -1,7 +1,7 @@
 <%= render "layouts/form_errors" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Create your GovWifi admin account</h2>
+    <h1 class="govuk-heading-l">Create your GovWifi admin account</h1>
 
     <%= render "users/shared/end_user_warning" %>
 

--- a/app/views/users/invitations/edit.html.erb
+++ b/app/views/users/invitations/edit.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Create your account</h2>
+    <h1 class="govuk-heading-l">Create your account</h1>
 
     <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
       <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put, novalidate: "" } do |f| %>

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -4,10 +4,10 @@
 
 <% if super_admin? %>
   <%= link_to "Back to organisation", super_admin_organisation_path(@target_organisation.id), class: "govuk-back-link" %>
-  <h2 class="govuk-heading-l">Invite a team member to <%= @target_organisation.name %> </h2>
+  <h1 class="govuk-heading-l">Invite a team member to <%= @target_organisation.name %> </h1>
 <% else %>
   <%= link_to "Back to list", memberships_path, class: "govuk-back-link" %>
-  <h2 class="govuk-heading-l">Invite a team member</h2>
+  <h1 class="govuk-heading-l">Invite a team member</h1>
 <% end %>
 <div class="govuk-grid-column-full govuk-!-padding-left-0">
   <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post, novalidate: "" } do |f| %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Change your password</h2>
+    <h1 class="govuk-heading-l">Change your password</h1>
 
     <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
       <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Reset your GovWifi admin account password</h2>
+    <h1 class="govuk-heading-l">Reset your GovWifi admin account password</h1>
 
     <%= render "users/shared/end_user_warning" %>
 

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Sign in to your GovWifi admin account</h2>
+    <h1 class="govuk-heading-l">Sign in to your GovWifi admin account</h1>
 
     <p class="govuk-body">
       Sign in to manage an existing GovWifi installation in your organisation.

--- a/app/views/users/two_factor_authentication/_show_app.html.erb
+++ b/app/views/users/two_factor_authentication/_show_app.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-l">Two factor authentication</h2>
+<h1 class="govuk-heading-l">Two factor authentication</h1>
 <div class="govuk-body">
   Please enter your 6 digit two factor authentication code.
 </div>

--- a/app/views/users/two_factor_authentication/show.html.erb
+++ b/app/views/users/two_factor_authentication/show.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-body">
     <%= form_tag user_two_factor_authentication_path, method: :put do %>
-      <h2 class="govuk-heading-l"><%= label nil, :code, "Enter your two factor authentication code" %></h2>
+      <h1 class="govuk-heading-l"><%= label nil, :code, "Enter your two factor authentication code" %></h1>
       <p id="code-hint">This is the 6-digit code in your authenticator app.</p>
 
       <div class="govuk-form-group">

--- a/app/views/users/two_factor_authentication_setup/show.html.erb
+++ b/app/views/users/two_factor_authentication_setup/show.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h2 class="govuk-heading-l">Two factor authentication setup</h2>
+    <h1 class="govuk-heading-l">Two factor authentication setup</h1>
     <div class="govuk-body">
       1. Scan the QR code below using an authentication app on your phone.
     </div>

--- a/app/views/users/two_factor_authentication_unable/show.html.erb
+++ b/app/views/users/two_factor_authentication_unable/show.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-column">
   <%= link_to "Back", :back, class: "govuk-back-link" %>
 
-  <h2 class="govuk-heading-l">Two factor authentication will be mandatory from July 2021</h2>
+  <h1 class="govuk-heading-l">Two factor authentication will be mandatory from July 2021</h1>
   <div class="govuk-body">
     This is to keep GovWifi secure.
   </div>

--- a/spec/features/guidance_after_sign_in_spec.rb
+++ b/spec/features/guidance_after_sign_in_spec.rb
@@ -9,7 +9,7 @@ describe "Guidance after sign in", type: :feature do
     before { visit root_path }
 
     it "displays information about GovWifi servers" do
-      expect(page).to have_selector("h3", text: "GovWifi servers")
+      expect(page).to have_selector("h2", text: "GovWifi servers")
     end
   end
 

--- a/spec/features/overview/view_overview_page_spec.rb
+++ b/spec/features/overview/view_overview_page_spec.rb
@@ -71,19 +71,19 @@ describe "Viewing the overview page", type: :feature do
       end
 
       it "shows the IPs summary" do
-        within("h1#ips-count") do
+        within("#ips-count") do
           expect(page).to have_content(3)
         end
       end
 
       it "shows the Locations summary" do
-        within("h1#locations-count") do
+        within("#locations-count") do
           expect(page).to have_content(2)
         end
       end
 
       it "displays the Team members summary" do
-        within("h1#team-members-count") do
+        within("#team-members-count") do
           expect(page).to have_content(1)
         end
       end

--- a/spec/features/support/setup_instructions.rb
+++ b/spec/features/support/setup_instructions.rb
@@ -1,5 +1,5 @@
 shared_examples "shows the setup instructions page" do
   it "shows the user the setup instructions page" do
-    expect(page).to have_selector("h2", text: "Settings")
+    expect(page).to have_selector("h1", text: "Settings")
   end
 end

--- a/spec/features/support/user_not_authorised.rb
+++ b/spec/features/support/user_not_authorised.rb
@@ -1,6 +1,6 @@
 shared_examples "user not authorised" do
   # Assumes that users created for the purpose of testing have no IPs initially, which routes them differently from root.
   it "redirects to setting up page" do
-    expect(page).to have_selector("h2", text: "Settings")
+    expect(page).to have_selector("h1", text: "Settings")
   end
 end


### PR DESCRIPTION
This PR includes accessibility fixes:
 - fixes pages to have only one H1, and the other headings in a hierarchy below that - H2, then H3 and so on
 - adds a fieldset and legend to the Help page and Log search radios
 - fixes Hint markup for New location
 - removes headings that aren't headings
 - updates tests