### PR TITLE
Disable the IP spoofing check that's being problematic with proxies.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,5 +49,8 @@ module GovwifiAdmin
     config.eager_load_paths << Rails.root.join("lib")
 
     config.enable_enhanced_2fa_experience = false
+
+    # Disable IP spoofing check as we get too many false positives due to proxies
+    config.action_dispatch.ip_spoofing_check = false
   end
 end


### PR DESCRIPTION
## What

Set the config to skip the IP spoofing check

## Why

There are lots of false positives for this, due to proxies we have no control over. As it's not a big risk for us, the solution is to just disable the check.