### PR TITLE
After resetting a password, immediately sign the user out.

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -263,7 +263,7 @@ Devise.setup do |config|
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.
-  # config.sign_in_after_reset_password = true
+  config.sign_in_after_reset_password = false
 
   # ==> Configuration for :encryptable
   # Allow you to use another hashing or encryption algorithm besides bcrypt (default).

--- a/spec/features/authentication/reset_password_spec.rb
+++ b/spec/features/authentication/reset_password_spec.rb
@@ -90,8 +90,8 @@ describe "Resetting a password", type: :feature do
         click_on "Change my password"
       end
 
-      it "automatically signs them in using the new password" do
-        expect(page).to have_content("Sign out")
+      it "automatically signs them out" do
+        expect(page).to_not have_content("Sign out")
       end
 
       it "tells the user their password has been changed" do


### PR DESCRIPTION
### What
After resetting a password, immediately sign the user out.
### Why
Otherwise the user can skip 2FA

Link to Trello card (if applicable): https://trello.com/c/StEsu73m/1417-bugfix-forgot-password-reset-process-logs-the-user-in-without-completing-2fa
