### PR TITLE
Replace placeholders with labels, and add `aria-live` to results region

### DIFF
--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -18,7 +18,8 @@
 
   <% if current_organisation.locations.length > 1 %>
     <div class="govuk-!-padding-bottom-7">
-      <input type="search" id="filter-input" placeholder="Search by location or postcode" class="govuk-input">
+      <label class="govuk-label" for="filter-input">Search by location or postcode</label>
+      <input type="search" id="filter-input" class="govuk-input">
     </div>
   <% end %>
 
@@ -32,9 +33,11 @@
         <strong>No results found</strong>
       </p>
     </div>
-    <% @locations.each do |location| %>
-      <%= render "ips/table", location: location %>
-    <% end %>
+    <div aria-live="polite">
+      <% @locations.each do |location| %>
+        <%= render "ips/table", location: location %>
+      <% end %>
+    </div>
   <% end %>
 </div>
 <%= render "shared/filter_search" %>

--- a/app/views/super_admin/locations/index.html.erb
+++ b/app/views/super_admin/locations/index.html.erb
@@ -4,7 +4,10 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">GovWifi locations</h1>
     <%= link_to "GovWifi map", map_super_admin_locations_path, class: "govuk-link" %>
-    <p><input type="search" id="filter-input" placeholder="Search for an address or postcode" class="govuk-input"></p>
+    <p>
+      <label class="govuk-label" for="filter-input">Search for an address or postcode</label>
+      <input type="search" id="filter-input" class="govuk-input">
+    </p>
 
     <table class="govuk-table">
       <thead class="govuk-table__head">
@@ -13,7 +16,7 @@
           <th class="govuk-table__header">Organisation</th>
         </tr>
       </thead>
-      <tbody class="govuk-table__body">
+      <tbody class="govuk-table__body" aria-live="polite">
         <% @locations.each do |location| %>
           <tr class="govuk-table__row result-row">
             <td class="govuk-table__cell filter-by">

--- a/app/views/super_admin/organisations/index.html.erb
+++ b/app/views/super_admin/organisations/index.html.erb
@@ -21,7 +21,10 @@
               service_emails_super_admin_organisations_path(format: "csv"),
               class: "govuk-link" %>
 </div>
-<p><input type="search" id="filter-input" placeholder="Search by organisation name" class="govuk-input"></p>
+<p>
+  <label class="govuk-label" for="filter-input">Search by organisation name</label>
+  <input type="search" id="filter-input" class="govuk-input">
+</p>
 
 <table class="govuk-table">
   <thead class="govuk-table__head">
@@ -33,7 +36,7 @@
       <th class="govuk-table__header govuk-table__header--numeric"><%= sort_link "ips_count", "IPs" %></th>
     </tr>
   </thead>
-  <tbody class="govuk-table__body">
+  <tbody class="govuk-table__body" aria-live="polite">
     <% @organisations.each do |organisation| %>
       <tr class="govuk-table__row result-row">
         <td class="govuk-table__cell govuk-!-width-one-half" scope="row">


### PR DESCRIPTION
### What

Add labels to search fields that are only "labelled" with placeholder. Remove placeholders.

### Why

Labels are required for accessibility. Raised in DAC report. Adding a submit button doesn't really work, so have added aria-live instead.

> Users were not presented instructions or labels to identify the controls in a form and
> describe what input data is expected. Placeholder text has been used as the only visible
> labelling technique. Those with cognitive, language, and learning disabilities may find labels
> help them to enter information correctly. Labels may also help to prevent users from
> making submission errors. For voice activation users, visible labels can be used to indicate
> the accessible name by which this component may be referenced to assistive technology.
> Otherwise, users are required to use general commands such as ‘click box’.
>
> When a user types, results update dynamically. However, there is nothing to inform screen
> reader users that this is happening. Users who mistakenly type into the field, or users who
> partially enter a search into the field without deleting the text again, may not realise that
> the Locations on the page are not the full list, but rather the search results corresponding to
> the text in the search field.
> 
>There is no explicit submit button to allow users to feel confident they have submitted their
search.

> Solution:
> Ensure that users are informed that a change in content has occurred in response to
entering text into the text field. An explicit search button is recommended.

Link to Trello card (if applicable): https://trello.com/c/tehYEQAG
