### PR TITLE
Update erb_lint to `0.1.1` and add required `autocomplete` attribute to

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     diff-lcs (1.4.4)
     docile (1.4.0)
     encryptor (3.0.0)
-    erb_lint (0.0.37)
+    erb_lint (0.1.1)
       activesupport
       better_html (~> 1.0.7)
       html_tokenizer
@@ -222,7 +222,7 @@ GEM
       jwt (>= 1.5, < 3)
     orm_adapter (0.5.0)
     parallel (1.20.1)
-    parser (3.0.1.1)
+    parser (3.0.2.0)
       ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -19,7 +19,7 @@
   <% if current_organisation.locations.length > 1 %>
     <div class="govuk-!-padding-bottom-7">
       <label class="govuk-label" for="filter-input">Search by location or postcode</label>
-      <input type="search" id="filter-input" class="govuk-input">
+      <input type="search" id="filter-input" class="govuk-input" autocomplete="off">
     </div>
   <% end %>
 

--- a/app/views/super_admin/locations/index.html.erb
+++ b/app/views/super_admin/locations/index.html.erb
@@ -6,7 +6,7 @@
     <%= link_to "GovWifi map", map_super_admin_locations_path, class: "govuk-link" %>
     <p>
       <label class="govuk-label" for="filter-input">Search for an address or postcode</label>
-      <input type="search" id="filter-input" class="govuk-input">
+      <input type="search" id="filter-input" class="govuk-input" autocomplete="off">
     </p>
 
     <table class="govuk-table">

--- a/app/views/super_admin/organisations/index.html.erb
+++ b/app/views/super_admin/organisations/index.html.erb
@@ -23,7 +23,7 @@
 </div>
 <p>
   <label class="govuk-label" for="filter-input">Search by organisation name</label>
-  <input type="search" id="filter-input" class="govuk-input">
+  <input type="search" id="filter-input" class="govuk-input" autocomplete="off">
 </p>
 
 <table class="govuk-table">


### PR DESCRIPTION
search fields.

### What

* Update erb_lint to `0.1.1` - dependabot had tried to update to `0.1.0` but further changes were required to allow linter to pass.
* Set `autocomplete="off"` on search inputs. These forms are never actually submitted as it's live filtering, so the browser won't have any sensible input to autofill anyway.

### Why

Updates are good. Changing code to comply with new linter rule.


Link to Trello card (if applicable): https://trello.com/c/iAR5MpSz
