### PR TITLE
Display the Radius server in the logs for super admins.

### DIFF
--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -17,6 +17,9 @@
         <th class="govuk-table__header" scope="col">IP</th>
         <th class="govuk-table__header" scope="col">Time</th>
         <th class="govuk-table__header" scope="col">Status</th>
+        <% if super_admin? %>
+          <th class="govuk-table__header" scope="col">Radius Server</th>
+        <% end %>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -28,6 +31,9 @@
           <td class="govuk-table__cell"><%= log.fetch(:site_ip) %></td>
           <td class="govuk-table__cell"><%= log.fetch(:start) %></td>
           <td class="govuk-table__cell"><%= log.fetch(:success) ? "successful" : "failed" %></td>
+          <% if super_admin? %>
+            <td class="govuk-table__cell"><%= log.fetch(:task_id) %></td>
+          <% end %>
         </tr>
       <% end %>
     </tbody>

--- a/lib/gateways/sessions.rb
+++ b/lib/gateways/sessions.rb
@@ -24,6 +24,7 @@ module Gateways
           site_ip: log.siteIP,
           start: log.start,
           success: log.success,
+          task_id: log.task_id,
         }
       end
     end

--- a/mysql/rr_schema.sql
+++ b/mysql/rr_schema.sql
@@ -22,6 +22,7 @@ CREATE TABLE `sessions` (
   `ap` char(17) DEFAULT NULL,
   `building_identifier` varchar(20) DEFAULT NULL,
   `success` tinyint(1) DEFAULT NULL,
+  `task_id` varchar(100) DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `siteIP` (`siteIP`,`username`),
   KEY `sessions_username` (`username`),

--- a/spec/features/logging/view_logs_spec.rb
+++ b/spec/features/logging/view_logs_spec.rb
@@ -1,0 +1,54 @@
+describe "View authentication requests for an IP", type: :feature do
+  let(:ip) { "1.2.3.4" }
+  let(:username) { "ABCDEF" }
+  let(:ap) { "govwifi-ap" }
+  let(:mac) { "govwifi-mac" }
+  let(:time) { 3.days.ago }
+  let(:task_id) { "arn:12345" }
+
+  before do
+    create(:session,
+           ap: ap,
+           mac: mac,
+           start: time,
+           username: username,
+           siteIP: ip,
+           success: true,
+           task_id: task_id)
+  end
+
+  context "as a super admin" do
+    before do
+      super_admin_user = create(:user, :with_organisation, :super_admin)
+      sign_in_user super_admin_user
+      visit logs_path(ip: ip)
+    end
+    it "displays the log" do
+      expect(page).to have_content("Found 1 result for \"#{ip}\"")
+      expect(page).to have_css("td", text: username)
+      expect(page).to have_css("td", text: ap)
+      expect(page).to have_css("td", text: mac)
+      expect(page).to have_css("td", text: ip)
+      expect(page).to have_css("td", text: time)
+      expect(page).to have_css("td", text: "successful")
+    end
+    it "displays the radius server" do
+      expect(page).to have_css("th", text: "Radius Server")
+      expect(page).to have_css("td", text: task_id)
+    end
+  end
+  context "as a regular admin" do
+    before do
+      admin_user = create(:user, :with_organisation)
+      location = create(:location, organisation: admin_user.organisations.first)
+      create(:ip, location_id: location.id, address: ip, created_at: 5.days.ago)
+      sign_in_user admin_user
+      visit logs_path(ip: ip)
+    end
+    it "does not display the radius server" do
+      expect(page).to have_content("Found 1 result for \"#{ip}\"")
+      expect(page).to_not have_css("td", text: task_id)
+      expect(page).to_not have_css("th", text: "Radius Server")
+    end
+  end
+end

--- a/spec/gateways/sessions_spec.rb
+++ b/spec/gateways/sessions_spec.rb
@@ -7,11 +7,12 @@ describe Gateways::Sessions do
   let(:two_days_ago) { (Time.zone.now - 2.days).to_s }
   let(:three_weeks_ago) { (Time.zone.now - 3.weeks).to_s }
   let(:username) { "BOBABC" }
+  let(:task_id) { "arn:12345" }
 
   context "when searching by username" do
     context "when recent log entries contain none of my IP addresses" do
       before do
-        create(:session, start: today_date, username: username, siteIP: "7.7.7.7")
+        create(:session, start: today_date, username: username, siteIP: "7.7.7.7", task_id: task_id)
       end
 
       it "finds no results" do
@@ -30,6 +31,7 @@ describe Gateways::Sessions do
             start: today_date,
             success: true,
             username: "BOBABC",
+            task_id: task_id,
           },
           {
             ap: nil,
@@ -38,12 +40,13 @@ describe Gateways::Sessions do
             start: yesterday,
             success: true,
             username: "BOBABC",
+            task_id: task_id,
           },
         ]
       end
 
       before do
-        create(:session, start: today_date, success: true, username: username, siteIP: "127.0.0.1")
+        create(:session, start: today_date, success: true, username: username, siteIP: "127.0.0.1", task_id: task_id)
       end
 
       it "finds one result" do
@@ -53,7 +56,7 @@ describe Gateways::Sessions do
       end
 
       it "finds multiple results" do
-        create(:session, start: yesterday, success: true, username: username, siteIP: "127.0.0.1")
+        create(:session, start: yesterday, success: true, username: username, siteIP: "127.0.0.1", task_id: task_id)
 
         expect(session_gateway.search(username: "BOBABC")).to eq(expected_result)
       end


### PR DESCRIPTION
### What
Recently the Logging API has started recording the Radius server task ARN for
each request so it can now be included in the log table.
### Why
It can be useful to know which request has been served by which Radius server
so that potential problems can be diagnosed.

Link to Trello card (if applicable): https://trello.com/c/htMbaqCQ/1469-show-which-radius-server-was-used-to-serve-a-request-in-the-admin-portal2
