### PR TITLE
add hidden text for screen readers

### DIFF
--- a/app/views/memberships/_table.html.erb
+++ b/app/views/memberships/_table.html.erb
@@ -51,17 +51,20 @@
 
         <div class='govuk-grid-column-one-third govuk-list govuk-!-padding-right-4 govuk-!-margin-top-0 text-right'>
           <% if current_user.can_manage_team?(current_organisation) && member.id != current_user.id %>
-            <%= link_to "Edit permissions", edit_membership_path(member.membership_for(current_organisation)), class: "govuk-link govuk-link--no-visited-state" %>
+            <%= link_to edit_membership_path(member.membership_for(current_organisation)), class: "govuk-link govuk-link--no-visited-state" do %>
+              Edit permissions <span class='govuk-visually-hidden'>for <%= member.email %></span>
+            <% end %>
             <% if member.totp_enabled? %>
-              <%= link_to "Reset 2FA",
-                          { controller: "users/two_factor_authentication", action: "edit", id: member },
-                          class: "govuk-link govuk-link--no-visited-state" %>
+              <%= link_to({ controller: "users/two_factor_authentication", action: "edit", id: member },
+                          class: "govuk-link govuk-link--no-visited-state") do %>
+                Reset 2FA <span class='govuk-visually-hidden'>for <%= member.email %></span>
+              <% end %>
             <% end %>
 
             <% if member.invitation_pending? && current_user.can_manage_team?(current_organisation) %>
               <%= button_to("Resend invite",
                             user_invitation_path(user: { email: member.email }, resend: true),
-                            method: :post, class: "button-as-link govuk-body") %>
+                            "aria-label" => "Resend invite to #{member.email}", method: :post, class: "button-as-link govuk-body") %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/setup_instructions/_organisation.html.erb
+++ b/app/views/setup_instructions/_organisation.html.erb
@@ -18,7 +18,9 @@
         <%= current_organisation.service_email %>
       </td>
       <td class="govuk-table__cell govuk-table__cell--numeric">
-        <%= link_to "Change", edit_organisation_path(current_organisation.id), class: "govuk-link govuk-link--no-visited-state" %>
+        <%= link_to edit_organisation_path(current_organisation.id), class: "govuk-link govuk-link--no-visited-state" do %>
+          Change <span class='govuk-visually-hidden'>service email</span>
+        <% end %>
       </td>
     </tr>
     <tr class="govuk-table__row">
@@ -30,7 +32,9 @@
           Signed
         </td>
         <td class="govuk-table__cell govuk-table__cell--numeric">
-          <%= link_to "Review", mou_index_path, class: "govuk-link govuk-link--no-visited-state" %>
+          <%= link_to mou_index_path, class: "govuk-link govuk-link--no-visited-state" do %>
+            Review <span class='govuk-visually-hidden'>memorandum of understanding</span>
+          <% end %>
         </td>
       <% else %>
         <td class="govuk-table__cell" colspan="2">

--- a/app/views/shared/_manage_ips.html.erb
+++ b/app/views/shared/_manage_ips.html.erb
@@ -7,12 +7,17 @@
       RADIUS secret key:
       <div class="inline-block">
         <span class="secret-key"><%= location.radius_secret_key %></span>
-        <% if current_user.can_manage_locations?(current_organisation) %><%= link_to "Rotate secret key", location_rotate_key_path(location, rotate: true), class: "red-link secret-key-rotate-link" %>
+        <% if current_user.can_manage_locations?(current_organisation) %>
+          <%= link_to location_rotate_key_path(location, rotate: true), class: "red-link secret-key-rotate-link" do %>
+            Rotate secret key <span class='govuk-visually-hidden'>for <%= location.full_address %></span>
+          <% end %>
         <% end %>
       </div>
     </div>
     <% if current_user.can_manage_locations?(current_organisation) %>
-      <%= link_to "Add IP addresses", location_add_ips_path(location_id: location.id), class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-5" %>
+      <%= link_to location_add_ips_path(location_id: location.id), class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-5" do %>
+        Add IP addresses <span class='govuk-visually-hidden'>for <%= location.full_address %></span>
+      <% end %>
       <% if location.ips.empty? %>
         <p class="result-row-empty govuk-body">
           Add the IP addresses of your authenticators to offer GovWifi at this location
@@ -21,7 +26,9 @@
 
       <% if current_user.can_manage_locations?(current_organisation) && location.ips.empty? %>
         <p class="govuk-body govuk-!-margin-bottom-1">
-          <%= link_to "Remove this location", location_remove_path(location, remove: true), class: "red-link" %>
+          <%= link_to location_remove_path(location, remove: true), class: "red-link" do %>
+            Remove this location <span class='govuk-visually-hidden'>- <%= location.full_address %></span>
+          <% end %>
         </p>
       <% end %>
     <% end %>
@@ -57,7 +64,9 @@
         <% end %>
         <td class="govuk-table__cell text-right">
           <% if show_ip_controls && current_user.can_manage_locations?(current_organisation) %>
-            <%= link_to "Remove", ip_remove_path(ip), class: "govuk-link govuk-link--no-visited-state" %>
+            <%= link_to ip_remove_path(ip), class: "govuk-link govuk-link--no-visited-state" do %>
+              Remove <span class='govuk-visually-hidden'><%= ip.address %> from <%= location.full_address %></span>
+            <% end %>
           <% end %>
         </td>
       </tr>

--- a/app/views/super_admin/organisations/_team.html.erb
+++ b/app/views/super_admin/organisations/_team.html.erb
@@ -8,15 +8,17 @@
           <td class="govuk-table__cell" scope="row"><%= user.name %></td>
           <td class="govuk-table__cell text-right" scope="row"><%= user.email %></td>
           <td class="govuk-table__cell text-right" scope="row">
-            <%= link_to "Remove user",
-                        edit_membership_path(user.membership_for(@organisation), remove_team_member: true),
-                        class: "govuk-button red-button" %>
+            <%= link_to edit_membership_path(user.membership_for(@organisation), remove_team_member: true),
+                        class: "govuk-button red-button" do %>
+              Remove user <span class='govuk-visually-hidden'>- #{user.email}</span>
+            <% end %>
           </td>
           <td class="govuk-table__cell text-right" scope="row">
             <% if user.totp_enabled? %>
-            <%= link_to "Reset 2FA",
-                        { controller: "users/two_factor_authentication", action: "edit", id: user },
-                        class: "govuk-button govuk-button--secondary" %>
+              <%= link_to({ controller: "users/two_factor_authentication", action: "edit", id: user },
+                          class: "govuk-button govuk-button--secondary") do %>
+                Reset 2FA <span class='govuk-visually-hidden'>for #{user.email}</span>
+              <% end %>
             <% end %>
           </td>
         </tr>


### PR DESCRIPTION
### What

Add visually hidden text to make links with identical text clearer for screen readers. e.g. Add IP addresses [for {location}]

### Why

Screen readers can list all links on a page... if the text of the link is repeated, it can be unclear what it will do.

Link to Trello card (if applicable): https://trello.com/c/isClWtzI
