### PR TITLE
Display the success rate of requests per IP in the last day

### DIFF
--- a/app/models/ip.rb
+++ b/app/models/ip.rb
@@ -5,7 +5,7 @@ class Ip < ApplicationRecord
   validate :address_must_be_valid_ip
 
   def inactive?
-    Session
+    @inactive ||= Session
       .where(siteIP: address)
       .where("start > ?", Time.zone.today - 10.days)
       .limit(1)
@@ -25,7 +25,7 @@ class Ip < ApplicationRecord
   end
 
   def unused?
-    Session
+    @unused ||= Session
       .where(siteIP: address)
       .limit(1)
       .empty?

--- a/app/models/ip.rb
+++ b/app/models/ip.rb
@@ -12,6 +12,14 @@ class Ip < ApplicationRecord
       .empty?
   end
 
+  def percent_success
+    all_count = sessions.count
+    return 0 if all_count.zero?
+
+    success_count = sessions.successful.count
+    (success_count * 100 / all_count)
+  end
+
   def available?
     created_at < Time.zone.today.beginning_of_day
   end
@@ -24,6 +32,10 @@ class Ip < ApplicationRecord
   end
 
 private
+
+  def sessions(within: 1.day)
+    Session.where(siteIp: address).where("start > ?", Time.zone.today - within)
+  end
 
   def address_must_be_valid_ip
     checker = UseCases::Administrator::CheckIfValidIp.new

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,2 +1,9 @@
 class Session < ReadReplicaBase
+  scope :unsuccessful, lambda {
+    where(success: false)
+  }
+
+  scope :successful, lambda {
+    where(success: true)
+  }
 end

--- a/app/views/shared/_manage_ips.html.erb
+++ b/app/views/shared/_manage_ips.html.erb
@@ -57,10 +57,16 @@
               Receiving traffic (<%= link_to "view logs", logs_path(ip: ip.address), class: "govuk-link" %>)
             <% end %>
           </td>
+          <td class="govuk-table__cell">
+            <% unless ip.unused? || ip.inactive? %>
+              <%= ip.percent_success %>% success rate
+            <% end %>
+          </td>
         <% else %>
           <td class="govuk-table__cell text-dark-grey">
             Available at 6am tomorrow
           </td>
+          <td class="govuk-table__cell"></td>
         <% end %>
         <td class="govuk-table__cell text-right">
           <% if show_ip_controls && current_user.can_manage_locations?(current_organisation) %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,9 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
 require "faker"
+require "factory_bot"
 
+FactoryBot.find_definitions
 CustomOrganisationName.create!(name: "GovWifi Super Administrators")
 
 def create_user_for_organisations(
@@ -88,6 +90,21 @@ location_two = Location.create!(
   )
 end
 
+ip = FactoryBot.create(:ip, address: Faker::Internet.unique.public_ip_v4_address,
+                            location: location_one,
+                            created_at: Time.zone.now - 10.days)
+FactoryBot.create_list(:session, 50,
+                       success: true,
+                       siteIP: ip.address,
+                       start: Time.zone.now,
+                       mac: Faker::Internet.mac_address,
+                       ap: Faker::Internet.mac_address,
+                       username: Faker::Name.first_name)
+FactoryBot.create_list(:session, 20,
+                       success: false,
+                       siteIP: ip.address,
+                       start: Time.zone.now)
+
 3.times do
   Ip.create!(
     address: Faker::Internet.unique.public_ip_v4_address,
@@ -95,21 +112,21 @@ end
   )
 end
 
-location_one.ips.each_with_index do |ip, index|
+location_one.ips.each_with_index do |location_one_ip, index|
   Session.create(
     start: (Time.zone.now - (index + 5).day).to_s,
     success: index.even?,
     username: "Gerry",
-    siteIP: ip.address,
+    siteIP: location_one_ip.address,
   )
 end
 
-location_two.ips.each_with_index do |ip, index|
+location_two.ips.each_with_index do |location_two_ip, index|
   Session.create(
     start: (Time.zone.now - index.day).to_s,
     success: index.even?,
     username: "Garry",
-    siteIP: ip.address,
+    siteIP: location_two_ip.address,
   )
 end
 

--- a/spec/features/ips/view_ip_addresses_spec.rb
+++ b/spec/features/ips/view_ip_addresses_spec.rb
@@ -25,7 +25,6 @@ describe "Viewing IP addresses", type: :feature do
   context "with IPs" do
     let(:location) { create(:location, organisation: user.organisations.first) }
     let!(:ip) { create(:ip, location: location, created_at: 9.days.ago) }
-
     before do
       sign_in_user user
       visit ips_path
@@ -54,6 +53,10 @@ describe "Viewing IP addresses", type: :feature do
           expect(page).to have_content("No traffic in the last 10 days")
         end
       end
+
+      it "does not show success rate" do
+        expect(page).to_not have_content("success rate")
+      end
     end
 
     context "with newly created IPs with no activity" do
@@ -80,6 +83,10 @@ describe "Viewing IP addresses", type: :feature do
         within("#ips-row-#{ip.id}") do
           expect(page).not_to have_content("No traffic received yet")
         end
+      end
+
+      it "shows the success rate" do
+        expect(page).to_not have_content("100% success rate")
       end
     end
   end

--- a/spec/models/ip_spec.rb
+++ b/spec/models/ip_spec.rb
@@ -124,4 +124,37 @@ describe Ip do
       it { is_expected.to be_unused }
     end
   end
+
+  describe "#percent_success" do
+    context "No sessions" do
+      it "returns 0" do
+        expect(ip_address.percent_success).to eq(0)
+      end
+    end
+    context "Only successes" do
+      it "calculates 100% success" do
+        create_list(:session, 3, success: true, siteIP: ip_address.address, start: Time.zone.today)
+        expect(ip_address.percent_success).to eq(100)
+      end
+    end
+    context "3 successes, 2 failures" do
+      before :each do
+        create_list(:session, 3, success: true, siteIP: ip_address.address, start: Time.zone.today)
+        create_list(:session, 2, success: false, siteIP: ip_address.address, start: Time.zone.today)
+      end
+      it "calculates 3 success, 2 failed = 60%" do
+        expect(ip_address.percent_success).to eq(60)
+      end
+      it "ignores sessions older than 1 day" do
+        create_list(:session, 2, success: true, siteIP: ip_address.address, start: Time.zone.today - 2.days)
+        create_list(:session, 2, success: false, siteIP: ip_address.address, start: Time.zone.today - 2.days)
+        expect(ip_address.percent_success).to eq(60)
+      end
+      it "ignores sessions with a different IP address" do
+        create_list(:session, 2, success: true, siteIP: "4.5.6.7", start: Time.zone.today)
+        create_list(:session, 2, success: false, siteIP: "4.5.6.7", start: Time.zone.today)
+        expect(ip_address.percent_success).to eq(60)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What
We want to display the rate of successful vs unsuccessful requests for an IP address

### Why
As an admin, I want to be able to see quickly if an IP address has a high error rate so I can take
action if something is misconfigured.

Link to Trello card (if applicable): 

https://trello.com/c/4SN3SpTB/1488-show-successful-failed-requests-in-the-last-hour-in-admin-portal2

Added the "71% success rate" column in the screenshot below
![image](https://user-images.githubusercontent.com/6050162/128848160-0205ba5a-c77f-4895-95ce-77c45a02c176.png)
