### PR TITLE
Make permissions more accessible

### DIFF
--- a/app/views/memberships/_table.html.erb
+++ b/app/views/memberships/_table.html.erb
@@ -6,43 +6,52 @@
       <div class='govuk-grid-row'>
         <div class='govuk-grid-column-two-thirds'>
           <% if member.invitation_pending? || member.pending_membership_for?(organisation: current_organisation) %>
-            <h2 class='govuk-heading-s govuk-!-margin-bottom-0'><%= member.name %>
+            <h2 class='govuk-heading-m'><%= member.name %>
               <span class='govuk-!-padding-left-1 govuk-body text-dark-grey'><%= member.email %> (invited)</span>
             </h2>
             <% else %>
-            <h2 class='govuk-heading-s govuk-!-margin-bottom-0'><%= member.name %>
+            <h2 class='govuk-heading-m'><%= member.name %>
               <span class='govuk-!-padding-left-1 govuk-body text-dark-grey'><%= member.email %></span>
             </h2>
           <% end %>
 
-          <ul class='govuk-list govuk-!-margin-bottom-2 govuk-!-margin-top-1' id='member-<%= member.id %>-permissions'>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Permissions</h3>
+
+          <ul role="list" class='govuk-list govuk-!-margin-bottom-2 govuk-!-margin-top-1' id='member-<%= member.id %>-permissions'>
             <li>
-              <%= image_tag "tick.svg", class: "list-item-padding", height: "30", alt: "allowed" %>
+              <%= image_tag "tick.svg", class: "list-item-padding", height: "30", alt: "" %>
+              <span class="govuk-visually-hidden">Can</span>
               <span class='govuk-!-padding-left-1'>View logs</span>
             </li>
             <li>
-              <%= image_tag "tick.svg", class: "list-item-padding", height: "30", alt: "allowed" %>
+              <%= image_tag "tick.svg", class: "list-item-padding", height: "30", alt: "" %>
+              <span class="govuk-visually-hidden">Can</span>
               <span class='govuk-!-padding-left-1'>View team members</span>
             </li>
             <li>
               <% if member.can_manage_team?(current_organisation) %>
-                <%= image_tag "tick.svg", class: "list-item-padding", height: "30", alt: "allowed" %>
+                <%= image_tag "tick.svg", class: "list-item-padding", height: "30", alt: "" %>
+                <span class="govuk-visually-hidden">Can</span>
                 <span class='govuk-!-padding-left-1'>Add and remove team members</span>
               <% else %>
-                <%= image_tag "cross.svg", class: "list-item-padding", height: "30", alt: "not allowed" %>
+                <%= image_tag "cross.svg", class: "list-item-padding", height: "30", alt: "" %>
+                <span class="govuk-visually-hidden">Cannot</span>
                 <span class='govuk-!-padding-left-1 text-dark-grey'>Add and remove team members</span>
               <% end %>
             </li>
             <li>
-              <%= image_tag "tick.svg", class: "list-item-padding", height: "30", alt: "allowed" %>
+              <%= image_tag "tick.svg", class: "list-item-padding", height: "30", alt: "" %>
+              <span class="govuk-visually-hidden">Can</span>
               <span class='govuk-!-padding-left-1'>View locations and IP addresses</span>
             </li>
             <li>
               <% if member.can_manage_locations?(current_organisation) %>
-                <%= image_tag "tick.svg", class: "list-item-padding", height: "30", alt: "allowed" %>
+                <%= image_tag "tick.svg", class: "list-item-padding", height: "30", alt: "" %>
+                <span class="govuk-visually-hidden">Can</span>
                 <span class='govuk-!-padding-left-1'>Add and remove locations and IP addresses</span>
               <% else %>
-                <%= image_tag "cross.svg", class: "list-item-padding", height: "30", alt: "not allowed" %>
+                <%= image_tag "cross.svg", class: "list-item-padding", height: "30", alt: "" %>
+                <span class="govuk-visually-hidden">Cannot</span>
                 <span class='govuk-!-padding-left-1 text-dark-grey'>Add and remove locations and IP addressess</span>
               <% end %>
             </li>

--- a/spec/features/team/view_team_members_spec.rb
+++ b/spec/features/team/view_team_members_spec.rb
@@ -17,11 +17,11 @@ describe "View team members of my organisation", type: :feature do
     context "when there is only one user in an organisation" do
       let(:correct_permissions) do
         [
-          "View logs",
-          "View team members",
-          "Add and remove team members",
-          "View locations and IP addresses",
-          "Add and remove locations and IP addresses",
+          "Can View logs",
+          "Can View team members",
+          "Can Add and remove team members",
+          "Can View locations and IP addresses",
+          "Can Add and remove locations and IP addresses",
         ]
       end
 


### PR DESCRIPTION
### What
- add a Permissions heading to explain the list
- add role=list so Voiceover treats it as a list
- make image alt blank and use hidden text instead on recommendation in the audit
- Changes 'allowed' to 'can' and 'not allowed' to 'cannot' so for example 'Can view team members'

### Why

From the audit:

> Users did not understand the purpose of the allowed/ not allowed images and assumed them to be decorative. This may be because the fact that these are presented to users as ‘images’ obscures the primary purpose of the information they are delivering.

Screen reader user comments:
>“When navigating in context, I located a multitude of images on the page described as ‘Allowed’. It seems that these images are present for decorative purposes, therefore providing no benefit to a screen reader user.”

When I tested the original page, the fact that the permissions do not have a heading, and are not read out as a list, seemed to contribute to the confusion so I have fixed those too.

Link to Trello card:

https://trello.com/c/JPF4EX90/1205-a11y-issue-non-text-content-missing-alts-page-14-dependency-on-testing-with-real-users-in-trello-card-no-1200 

Screenshot before:
![image](https://user-images.githubusercontent.com/1132904/129221020-e7311530-c5cd-47c6-b66d-e95a4a07f21b.png)

Screenshot after:
![image](https://user-images.githubusercontent.com/1132904/129220887-e93cc269-dac3-4ebc-913e-97cbce2871e6.png)

