### PR TITLE
Eliminate NULL postcodes in locations table

### DIFF
--- a/db/migrate/20210813083000_eliminate_null_postcodes.rb
+++ b/db/migrate/20210813083000_eliminate_null_postcodes.rb
@@ -1,0 +1,5 @@
+class EliminateNullPostcodes < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :locations, :postcode, false, ""
+  end
+end


### PR DESCRIPTION
### What

Adds a migration to set a non-NULL constraint on the postcode column of the locations table and changes any existing NULL values to an empty string.

### Why

Where organisations have created a location without a valid postcode (which the app no longer allows), IP addresses could not be added as this triggers a location validation.


Link to Trello card (if applicable): 

https://trello.com/c/nfH54Zzk/1495-enforce-database-rules-to-prevent-things-like-null-postcode-in-the-ui