### PR TITLE
Make link buttons behave like buttons

### DIFF
--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -11,7 +11,7 @@
     </div>
     <div class="govuk-grid-column-one-third text-right">
       <% if current_user.can_manage_locations?(current_organisation) %>
-        <%= link_to "Add a location", new_location_path, class: "govuk-button govuk-!-margin-bottom-0" %>
+        <%= link_to "Add a location", new_location_path, class: "govuk-button govuk-!-margin-bottom-0", role: "button", draggable: "false", "data-module" => "govuk-button" %>
       <% end %>
     </div>
   </div>

--- a/app/views/memberships/index.html.erb
+++ b/app/views/memberships/index.html.erb
@@ -7,7 +7,7 @@
 
   <div class="govuk-grid-column-one-third text-right">
     <% if current_user.can_manage_team?(current_organisation) %>
-      <%= link_to "Invite team member", new_user_invitation_path, class: "govuk-button" %>
+      <%= link_to "Invite team member", new_user_invitation_path, class: "govuk-button", role: "button", draggable: "false", "data-module" => "govuk-button" %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_manage_ips.html.erb
+++ b/app/views/shared/_manage_ips.html.erb
@@ -15,7 +15,7 @@
       </div>
     </div>
     <% if current_user.can_manage_locations?(current_organisation) %>
-      <%= link_to location_add_ips_path(location_id: location.id), class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-5" do %>
+      <%= link_to location_add_ips_path(location_id: location.id), class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-5", role: "button", draggable: "false", "data-module" => "govuk-button" do %>
         Add IP addresses <span class='govuk-visually-hidden'>for <%= location.full_address %></span>
       <% end %>
       <% if location.ips.empty? %>

--- a/app/views/super_admin/organisations/show.html.erb
+++ b/app/views/super_admin/organisations/show.html.erb
@@ -26,7 +26,7 @@
 
     <%= render "section", heading: "Team" do %>
       <% if current_user.can_manage_team?(current_organisation) %>
-        <%= link_to "Add team member", new_user_invitation_path(organisation_id: @organisation.id), class: "govuk-button" %>
+        <%= link_to "Add team member", new_user_invitation_path(organisation_id: @organisation.id), class: "govuk-button", role: "button", draggable: "false", "data-module" => "govuk-button" %>
       <% end %>
       <%= render "team", team: @team %>
     <% end %>
@@ -45,6 +45,6 @@
       <% end %>
     <% end %>
 
-    <%= link_to "Delete organisation", super_admin_organisation_path(@organisation, remove_organisation: true), class: "govuk-button red-button" %>
+    <%= link_to "Delete organisation", super_admin_organisation_path(@organisation, remove_organisation: true), class: "govuk-button red-button", role: "button", draggable: "false", "data-module" => "govuk-button" %>
   </div>
 </div>

--- a/app/views/super_admin/whitelists/email_domains/index.html.erb
+++ b/app/views/super_admin/whitelists/email_domains/index.html.erb
@@ -13,7 +13,7 @@
       </div>
 
       <div class="govuk-grid-column-one-third text-right">
-        <%= link_to "Allow a domain", new_super_admin_whitelist_email_domain_path, class: "govuk-button" %>
+        <%= link_to "Allow a domain", new_super_admin_whitelist_email_domain_path, class: "govuk-button", role: "button", draggable: "false", "data-module" => "govuk-button" %>
       </div>
     </div>
 

--- a/app/views/super_admin/whitelists/steps/_first.html.erb
+++ b/app/views/super_admin/whitelists/steps/_first.html.erb
@@ -16,4 +16,4 @@
   the allow lists.
 </p>
 
-<%= link_to "Start", new_super_admin_whitelist_path(step: "second"), class: "govuk-button" %>
+<%= link_to "Start", new_super_admin_whitelist_path(step: "second"), class: "govuk-button", role: "button", draggable: "false", "data-module" => "govuk-button" %>

--- a/app/views/super_admin/whitelists/steps/_second.html.erb
+++ b/app/views/super_admin/whitelists/steps/_second.html.erb
@@ -1,4 +1,4 @@
 <h1 class="govuk-heading-l">Does the organisation need to create a GovWifi admin account?</h1>
 
-<%= link_to "Yes", new_super_admin_whitelist_path(step: "third", admin: "Yes"), class: "govuk-button" %>
-<%= link_to "No", new_super_admin_whitelist_path(step: "fifth", admin: "No", organisation_name: ""), class: "govuk-button" %>
+<%= link_to "Yes", new_super_admin_whitelist_path(step: "third", admin: "Yes"), class: "govuk-button", role: "button", draggable: "false", "data-module" => "govuk-button" %>
+<%= link_to "No", new_super_admin_whitelist_path(step: "fifth", admin: "No", organisation_name: ""), class: "govuk-button", role: "button", draggable: "false", "data-module" => "govuk-button" %>

--- a/app/views/super_admin/whitelists/steps/_third.html.erb
+++ b/app/views/super_admin/whitelists/steps/_third.html.erb
@@ -2,7 +2,7 @@
 <div class="govuk-form-group">
   <%= select_tag "organisations_register", options_for_select(@organisation_names << "", "") %>
 </div>
-<%= link_to "Yes", new_super_admin_whitelist_path(step: "fifth", register: "Yes", organisation_name: "", admin: params[:admin]), class: "govuk-button" %>
-<%= link_to "No", new_super_admin_whitelist_path(step: "fourth", register: "No", admin: params[:admin]), class: "govuk-button" %>
+<%= link_to "Yes", new_super_admin_whitelist_path(step: "fifth", register: "Yes", organisation_name: "", admin: params[:admin]), class: "govuk-button", role: "button", draggable: "false", "data-module" => "govuk-button" %>
+<%= link_to "No", new_super_admin_whitelist_path(step: "fourth", register: "No", admin: params[:admin]), class: "govuk-button", role: "button", draggable: "false", "data-module" => "govuk-button" %>
 
 <%= render "shared/organisation_register_dropdown" %>

--- a/app/views/users/two_factor_authentication_unable/show.html.erb
+++ b/app/views/users/two_factor_authentication_unable/show.html.erb
@@ -11,7 +11,7 @@
     You'll need to use an authentication app. If you cannot do this please email <a class="govuk-link" href="mailto:<%= t(".email") %>"><%= t(".email") %></a>
   </div>
   <div class="govuk-body">
-    <%= link_to t(".setup"), users_two_factor_authentication_setup_path, class: "govuk-button" %>
+    <%= link_to t(".setup"), users_two_factor_authentication_setup_path, class: "govuk-button", role: "button", draggable: "false", "data-module" => "govuk-button" %>
   </div>
   <div class="govuk-body">
     <%= link_to t(".continue"), users_two_factor_authentication_unable_path, class: "govuk-link", method: :put %>


### PR DESCRIPTION

### What

Add role, draggable, and data-module attributes to links styled as buttons.

### Why

As they're styled as buttons they should also behave like buttons, so as not to confuse the user.


Link to Trello card (if applicable): https://trello.com/c/SLDfWeAe
