### PR TITLE
Delete orphan users older than a week

### DIFF
--- a/lib/gateways/orphan_users.rb
+++ b/lib/gateways/orphan_users.rb
@@ -1,0 +1,9 @@
+module Gateways
+  class OrphanUsers
+    def fetch
+      User.left_joins(:memberships)
+      .where(memberships: { id: nil })
+      .where("users.created_at < ?", 1.week.ago)
+    end
+  end
+end

--- a/lib/tasks/delete_orphans.rake
+++ b/lib/tasks/delete_orphans.rake
@@ -1,0 +1,8 @@
+namespace :cleanup do
+  desc "Clean up orphan users"
+  task orphans: :environment do
+    gateway = Gateways::OrphanUsers.new
+
+    gateway.fetch.destroy_all
+  end
+end

--- a/spec/gateways/orphan_users_spec.rb
+++ b/spec/gateways/orphan_users_spec.rb
@@ -1,0 +1,27 @@
+describe Gateways::OrphanUsers do
+  subject(:gateway) { described_class.new }
+
+  before do
+    create(:user, :with_organisation)
+    create(:user, :with_organisation, created_at: 5.days.ago)
+    create(:user, :with_organisation, created_at: 8.days.ago)
+    create(:user, :with_organisation, created_at: 14.days.ago)
+    create(:user)
+    create(:user, created_at: 5.days.ago)
+  end
+
+  describe "when there are no orphan users older than a week" do
+    it "returns an empty set" do
+      expect(gateway.fetch.count).to be(0)
+    end
+  end
+
+  describe "when there is an orphan older than a week" do
+    let!(:user1) { create(:user, created_at: 8.days.ago) }
+    let!(:user2) { create(:user, created_at: 14.days.ago) }
+
+    it "includes only the orphan users" do
+      expect(gateway.fetch).to contain_exactly(user1, user2)
+    end
+  end
+end


### PR DESCRIPTION
### What
Delete users that aren't associated with an organisation and are older than a week.

### Why
When a user is removed from an organisation, and that is the last organisation they are a member of, their user record is also deleted. There appear to be historical users where this has not happened - possibly prior to a code fix.

Additionally, it seems some users who intend to sign up for an end-user account, mistakenly sign up for an admin account instead. As they never create an organisation (presumably due to realising they've made a mistake) their user record remains and can pollute stats (e.g. on 2FA uptake).


Link to Trello card (if applicable): https://trello.com/c/M13twt1f
