### PR TITLE
Set a higher max in flight threshold for the Concourse pipeline

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -113,7 +113,7 @@ jobs:
 
   - name: lint & test
     interruptible: true
-    max_in_flight: 1
+    max_in_flight: 6
     disable_manual_trigger: false
     build_logs_to_retain: 10
     plan:


### PR DESCRIPTION
### What
Set a higher max in flight threshold for the Concourse pipeline

### Why
So that Concourse can process multiple Pull Requests at once. This is
helpful when there are lots of Dependabot Pull Requests open.

