### PR TITLE
Add the `GOOGLE_` prefix to align with Terraform

### DIFF
--- a/lib/tasks/backup_service_emails.rake
+++ b/lib/tasks/backup_service_emails.rake
@@ -2,7 +2,7 @@ namespace :backup do
   desc "Backup Service Emails"
   task service_emails: :environment do
     UseCases::BackupServiceEmails.new(
-      writer: Gateways::GoogleDrive.new(credentials: ENV["SERVICE_ACCOUNT_BACKUP_CREDENTIALS"]),
+      writer: Gateways::GoogleDrive.new(credentials: ENV["GOOGLE_SERVICE_ACCOUNT_BACKUP_CREDENTIALS"]),
     ).execute
   end
 end


### PR DESCRIPTION
### What
Add the required prefix

### Why
So that it aligns with the configuration
