### PR TITLE
Force the use of the sessions_start_username index in session calc

### DIFF
--- a/app/models/ip.rb
+++ b/app/models/ip.rb
@@ -34,7 +34,7 @@ class Ip < ApplicationRecord
 private
 
   def sessions(within: 1.day)
-    Session.where(siteIp: address).where("start > ?", Time.zone.today - within)
+    Session.use_index(:sessions_start_username).where(siteIp: address).where("start > ?", Time.zone.today - within)
   end
 
   def address_must_be_valid_ip

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,4 +1,8 @@
 class Session < ReadReplicaBase
+  def self.use_index(index)
+    from("#{table_name} USE INDEX(#{index})")
+  end
+
   scope :unsuccessful, lambda {
     where(success: false)
   }


### PR DESCRIPTION
### What
Force the use of the sessions_start_username index in session calc

### Why
Mysql uses the SiteIP index instead of the much faster sessions_start_username
index when calculating the number of sessions for an IP address.
This change forces the use of this index.

In future we may add a new index which could speed things up
even more if necessary

Link to Trello card (if applicable): https://trello.com/c/QMqQGD6i/1545-handle-504-when-accessing-hmctss-page-in-the-super-admin-site
