### PR TITLE
Revert "Force the use of the sessions_start_username index in session calc"

### DIFF
--- a/app/models/ip.rb
+++ b/app/models/ip.rb
@@ -34,7 +34,7 @@ class Ip < ApplicationRecord
 private
 
   def sessions(within: 1.day)
-    Session.use_index(:sessions_start_username).where(siteIp: address).where("start > ?", Time.zone.today - within)
+    Session.where(siteIp: address).where("start > ?", Time.zone.today - within)
   end
 
   def address_must_be_valid_ip

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,8 +1,4 @@
 class Session < ReadReplicaBase
-  def self.use_index(index)
-    from("#{table_name} USE INDEX(#{index})")
-  end
-
   scope :unsuccessful, lambda {
     where(success: false)
   }


### PR DESCRIPTION
Reverts alphagov/govwifi-admin#1393

This is a good idea on MySQL 8 but not so on MySQL 5 where the query planner chooses the
correct index.

This PR will also interfere when we add a new index to solve the problem this PR was trying to
address