### PR TITLE
Limit username to 6 characters

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -99,7 +99,7 @@ FactoryBot.create_list(:session, 50,
                        start: Time.zone.now,
                        mac: Faker::Internet.mac_address,
                        ap: Faker::Internet.mac_address,
-                       username: Faker::Name.first_name)
+                       username: SecureRandom.alphanumeric(6).downcase)
 FactoryBot.create_list(:session, 20,
                        success: false,
                        siteIP: ip.address,


### PR DESCRIPTION
### What
Limit username to 6 characters
### Why
Because the database field is only 6 characters long. It sometimes
throws an error using Faker. It also more accurately reflects
the type of usernames we use.

Link to Trello card (if applicable): 
https://trello.com/c/Ri0gKF0S/1558-prevent-faker-from-generating-long-names-causing-mysql-errors-when-building-govwifi-admin