### PR TITLE
Use different header/label when on non-production

### DIFF
--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -1,0 +1,3 @@
+.govuk-header__container--yellow {
+  border-bottom-color: govuk-colour("yellow");
+}

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="govuk-header" role="banner" data-module="govuk-header">
-  <div class="govuk-header__container govuk-width-container">
+  <div class="govuk-header__container govuk-width-container <% unless Rails.env.production? %>govuk-header__container--yellow<%- end %>">
     <div class="govuk-header__logo">
       <%= link_to SITE_CONFIG["product_page_link"], class: "govuk-header__link govuk-header__link--homepage" do %>
       <span class="govuk-header__logotype">
@@ -21,9 +21,15 @@
       </span>
       <span class="govuk-header__product-name">
         GovWifi
-        <strong class="govuk-tag govuk-phase-banner__content__tag">
-          beta
-        </strong>
+        <% if Rails.env.production? %>
+          <strong class="govuk-tag govuk-phase-banner__content__tag">
+            beta
+          </strong>
+        <% else %>
+          <strong class="govuk-tag govuk-tag--yellow govuk-phase-banner__content__tag">
+            <%= Rails.env %>
+          </strong>
+        <% end %>
       </span>
       <%- end %>
     </div>

--- a/spec/features/common/header_spec.rb
+++ b/spec/features/common/header_spec.rb
@@ -1,0 +1,22 @@
+describe "Page header", type: :feature do
+  context "when not on production" do
+    before do
+      visit root_path
+    end
+
+    it "contains the expected test tag" do
+      expect(page).to have_content("GOV.UK GovWifi test")
+    end
+  end
+
+  context "when on production" do
+    before do
+      allow(Rails.env).to receive(:production?).and_return(true)
+      visit root_path
+    end
+
+    it "contains the expected beta tag" do
+      expect(page).to have_content("GOV.UK GovWifi beta")
+    end
+  end
+end


### PR DESCRIPTION
### What

On non-production systems, the header border, and label tag are yellow, and the tag is named for the environment rather than "beta"

Note, I've made the border the "full" yellow, rather than the pastel to match the tag, as it reduces its visibility against the white.

<img width="1048" alt="Screenshot 2021-09-08 at 05 48 43" src="https://user-images.githubusercontent.com/825374/132487489-7cacd1eb-1862-4459-b1cd-578b0ca3bbc1.png">

### Why

We want to be able to see at a glance which environment we're in, and specifically know when we're on production, to avoid making any breaking changes to live data.


Link to Trello card (if applicable): https://trello.com/c/oXE4L3F0
