### PR TITLE
Only validate postcode on pattern if not blank

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -9,7 +9,7 @@ class Location < ApplicationRecord
   validates_associated :ips
 
   validates :address, :postcode, presence: true
-  validate :validate_postcode
+  validate :validate_postcode_format, if: ->(l) { l.postcode.present? }
 
   before_create :set_radius_secret_key
 
@@ -36,7 +36,7 @@ class Location < ApplicationRecord
 
 private
 
-  def validate_postcode
+  def validate_postcode_format
     unless UKPostcode.parse(postcode.to_s).valid?
       errors.add(:postcode, "must be valid")
     end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -32,24 +32,32 @@ describe Location do
     end
   end
 
+  # rubocop:disable Rails/SaveBang
   context "when validating postcode" do
     subject(:location) { described_class.new }
 
     it "errors when the postcode does not match the correct format" do
-      location.postcode = "WHATEVER POSTCODE"
-      expect(location).not_to be_valid
+      location.update(postcode: "WHATEVER POSTCODE")
+      expect(location.errors[:postcode]).to eq([
+        "must be valid",
+      ])
     end
 
     it "errors when the postcode is empty" do
-      location.postcode = ""
-      expect(location).not_to be_valid
+      location.update(postcode: "")
+      expect(location.errors[:postcode]).to eq([
+        "can't be blank",
+      ])
     end
 
     it "errors when the postcode is nil" do
-      location.postcode = nil
-      expect(location).not_to be_valid
+      location.update(postcode: nil)
+      expect(location.errors[:postcode]).to eq([
+        "can't be blank",
+      ])
     end
   end
+  # rubocop:enable Rails/SaveBang
 
   context "when adding IPs with a mix of hash and strong parameters" do
     let(:location) do


### PR DESCRIPTION
### What
Only display one validation message for postcode (blank or valid)

### Why
When you don't enter a postcode, both validations fire, but it's only really relevant that you haven't entered it.
