### PR TITLE
Fix search in the locations view.

### DIFF
--- a/app/controllers/ips_controller.rb
+++ b/app/controllers/ips_controller.rb
@@ -4,8 +4,11 @@ class IpsController < ApplicationController
     set_radius_key_rotation
     locations_scope = Location.includes(:ips)
       .where(organisation: current_organisation)
-      .order(:address)
-    @pagy, @locations = pagy(locations_scope)
+    if params[:search].present?
+      locations_scope = locations_scope.where("postcode like ?", "%#{params[:search]}%")
+                                       .or(locations_scope.where("address like ?", "%#{params[:search]}%"))
+    end
+    @pagy, @locations = pagy(locations_scope.order(:address))
   end
 
   def destroy

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -18,8 +18,17 @@
 
   <% if current_organisation.locations.length > 1 %>
     <div class="govuk-!-padding-bottom-7">
-      <label class="govuk-label" for="filter-input">Search by location or postcode</label>
-      <input type="search" id="filter-input" class="govuk-input" autocomplete="off">
+      <%= form_with url: ips_path, method: "get", local: true, class: "govuk-form-group" do |form| %>
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend--m govuk-fieldset">
+            Search by location or postcode
+          </legend>
+          <span id="search_input-hint" class="govuk-hint">For example, 'SW1A 2AA' or 'High Street'</span>
+          <%= form.label :search, "Search by location or postcode", class: "govuk-label govuk-label--m govuk-visually-hidden" %>
+          <%= form.text_field :search, class: "govuk-input govuk-input--width-10" %>
+          <%= form.submit "Search", name: nil, class: "govuk-button" %>
+        </fieldset>
+      <% end %>
     </div>
   <% end %>
 
@@ -42,4 +51,3 @@
   <% end %>
   <%== pagy_nav_govuk(@pagy) %>
 </div>
-<%= render "shared/filter_search" %>

--- a/spec/features/ips/search_locations_spec.rb
+++ b/spec/features/ips/search_locations_spec.rb
@@ -1,0 +1,38 @@
+describe "Search Locations", type: :feature do
+  let(:user) { create(:user, :with_organisation) }
+  let(:organisation) { user.organisations.first }
+
+  context "10 organisations with the same name, 1 different and alphabetically last" do
+    before :each do
+      FactoryBot.create_list(:location, 10, address: "BB123BB", postcode: "AA11AA", organisation: organisation)
+      FactoryBot.create(:location, address: "QQQ123QQQ", postcode: "ZZ99ZZ", organisation: organisation)
+      sign_in_user user
+      visit ips_path
+    end
+
+    it "Does not filter anything if presented with a blank string" do
+      fill_in "search", with: " "
+      click_button("Search")
+      expect(page).to have_content("AA11AA", minimum: 10)
+      expect(page).not_to have_content("ZZ99ZZ")
+    end
+
+    it "Filters on postcodes that are not in the current page" do
+      fill_in "search", with: "Z99Z"
+      expect {
+        click_button("Search")
+      }.to change {
+        page.has_content?("ZZ99ZZ")
+      }.from(false).to(true)
+    end
+
+    it "Filters on addresses that are not in the current page" do
+      fill_in "search", with: "Q12"
+      expect {
+        click_button("Search")
+      }.to change {
+        page.has_content?("ZZ99ZZ")
+      }.from(false).to(true)
+    end
+  end
+end


### PR DESCRIPTION
The search box to find a location on postcode was broken when the paging feature was introduced. 
This feature used to depend on Javascript
and would only work on locations that were displayed on the current page.

This commit now enables search without javascript by loading a new page
from the server.

This also ensures that the search functionality works even though Javascript is disabled.

Link to Trello card (if applicable): https://trello.com/c/BV9KYkX5/1605-fix-search-functionality-for-locations-in-admin-portal

![image](https://user-images.githubusercontent.com/6050162/135068694-c0d5e146-5487-4598-8b99-ad7eac0da8bc.png)

