### PR TITLE
Just consider sessions for an IP within the last 6 hours

### DIFF
--- a/app/models/ip.rb
+++ b/app/models/ip.rb
@@ -33,8 +33,8 @@ class Ip < ApplicationRecord
 
 private
 
-  def sessions(within: 1.day)
-    Session.where(siteIp: address).where("start > ?", Time.zone.today - within)
+  def sessions(within: 6.hours)
+    Session.where(siteIp: address).where("start > ?", Time.zone.now - within)
   end
 
   def address_must_be_valid_ip

--- a/spec/models/ip_spec.rb
+++ b/spec/models/ip_spec.rb
@@ -133,26 +133,26 @@ describe Ip do
     end
     context "Only successes" do
       it "calculates 100% success" do
-        create_list(:session, 3, success: true, siteIP: ip_address.address, start: Time.zone.today)
+        create_list(:session, 3, success: true, siteIP: ip_address.address, start: Time.zone.now)
         expect(ip_address.percent_success).to eq(100)
       end
     end
     context "3 successes, 2 failures" do
       before :each do
-        create_list(:session, 3, success: true, siteIP: ip_address.address, start: Time.zone.today)
-        create_list(:session, 2, success: false, siteIP: ip_address.address, start: Time.zone.today)
+        create_list(:session, 3, success: true, siteIP: ip_address.address, start: Time.zone.now)
+        create_list(:session, 2, success: false, siteIP: ip_address.address, start: Time.zone.now)
       end
       it "calculates 3 success, 2 failed = 60%" do
         expect(ip_address.percent_success).to eq(60)
       end
-      it "ignores sessions older than 1 day" do
+      it "ignores sessions older than 6 hours" do
         create_list(:session, 2, success: true, siteIP: ip_address.address, start: Time.zone.today - 2.days)
         create_list(:session, 2, success: false, siteIP: ip_address.address, start: Time.zone.today - 2.days)
         expect(ip_address.percent_success).to eq(60)
       end
       it "ignores sessions with a different IP address" do
-        create_list(:session, 2, success: true, siteIP: "4.5.6.7", start: Time.zone.today)
-        create_list(:session, 2, success: false, siteIP: "4.5.6.7", start: Time.zone.today)
+        create_list(:session, 2, success: true, siteIP: "4.5.6.7", start: Time.zone.now)
+        create_list(:session, 2, success: false, siteIP: "4.5.6.7", start: Time.zone.now)
         expect(ip_address.percent_success).to eq(60)
       end
     end


### PR DESCRIPTION
### What
Just consider sessions for an IP within the last 6 hours

### Why
As this should be quicker than counting all the sessions since
midnight yesterday. I think slowness here may be causing timeouts for
the superadmin organisations page.