### PR TITLE
Update default staging url

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
   config.active_record.dump_schema_after_migration = false
-  config.action_mailer.default_url_options = { host: "admin.staging.wifi.service.gov.uk" }
+  config.action_mailer.default_url_options = { host: "admin.staging-temp.wifi.service.gov.uk" }
   config.s3_aws_config = {}
   config.route53_aws_config = {}
   config.enable_enhanced_2fa_experience = false


### PR DESCRIPTION
### What

Update default staging URL to point to `staging-temp`.

### Why

* The staging components in the primary AWS account have been decommissioned therefore there is no more URL for `admin.staging.wifi.service.gov.uk`.
* We need to point to the URL for our secondary AWS account where staging components now run.
* This fixes broken email links generated when inviting a new user to Staging Admin site, they were pointing to the decommissioned `admin.staging.wifi.service.gov.uk` URL.
