### PR TITLE
Fix ITHC weakness with reflected user input

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -22,7 +22,7 @@ class Organisation < ApplicationRecord
 
   def validate_in_register?
     unless Organisation.fetch_organisations_from_register.include?(name)
-      errors.add(:base, "#{name} isn't in the organisations allow list")
+      errors.add(:name, "isn't in the organisations allow list")
     end
   end
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -49,7 +49,7 @@ describe Organisation do
     it "explains why it is invalid" do
       organisation.valid?
       expect(organisation.errors.full_messages).to eq([
-        "#{organisation.name} isn't in the organisations allow list",
+        "Name isn't in the organisations allow list",
       ])
     end
   end


### PR DESCRIPTION
### What
Removed user input from an error message in the Organisation model

### Why
Error messages are not escaped and so we should not include unescaped
user input in error messages as this runs the risk of introducing a reflected
XSS vulnerability

Link to Trello card (if applicable): 
https://trello.com/c/Sft4bDMo/1824-sanitise-error-messages-in-admin-portal