### PR TITLE
Remove ASSET_PRECOMPILATION_ONLY references.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,6 @@ COPY . .
 
 ARG RUN_PRECOMPILATION=true
 RUN if [ ${RUN_PRECOMPILATION} = 'true' ]; then \
-  ASSET_PRECOMPILATION_ONLY=true RAILS_ENV=production bundle exec rails assets:precompile; \
+  SECRET_KEY_BASE=unused RAILS_ENV=production bundle exec rails assets:precompile; \
   fi
 CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
-require "active_storage/engine" unless ENV["ASSET_PRECOMPILATION_ONLY"]
+require "active_storage/engine"
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,9 +1,6 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-
-  unless ENV["ASSET_PRECOMPILATION_ONLY"]
-    config.active_storage.service = :amazon
-  end
+  config.active_storage.service = :amazon
 
   # Code is not reloaded between requests.
   config.cache_classes = true


### PR DESCRIPTION
This was introduced to get around the fact that activestorage
requires the secret key base to be set

This no longer works because in config/initializers/activestorage.rb
explicit references are made to the ActiveStorage module.

An easier fix is to set the SECRET_KEY_BASE to a random string
when compiling assets

This also ensures production and staging are more alike

(see https://github.com/alphagov/govwifi-admin/pull/186#discussion_r224438529)