### PR TITLE
Fix the CSRF protection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,8 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+
   include Pagy::Backend
   include GovWifiAuthenticatable
-
-  protect_from_forgery with: :exception
 
   helper_method :current_organisation, :super_admin?
   helper_method :sidebar


### PR DESCRIPTION
The protect_from_forgery action needs to be the first in the sequence
of before_action handlers otherwise the exception
'ActionController::InvalidAuthenticityToken' is thrown,
