### PR TITLE
Switch to the Zeitwerk class loader

### DIFF
--- a/app/controllers/concerns/able_to_read_mou.rb
+++ b/app/controllers/concerns/able_to_read_mou.rb
@@ -1,4 +1,4 @@
-module AbleToReadMOU
+module AbleToReadMou
   extend ActiveSupport::Concern
 
   included do

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -11,7 +11,7 @@ class SettingsController < ApplicationController
 private
 
   def radius_ips
-    view_radius = UseCases::Organisation::ViewRadiusIPAddresses.new(organisation_id: current_organisation.id)
+    view_radius = UseCases::Organisation::ViewRadiusIpAddresses.new(organisation_id: current_organisation.id)
     view_radius.execute
   end
 end

--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -8,7 +8,7 @@ class AuthenticationMailer < ::Devise::Mailer
     template_id = GOV_NOTIFY_CONFIG["confirmation_email"]["template_id"]
 
     UseCases::Administrator::SendConfirmationEmail.new(
-      notifications_gateway: EmailGateway.new,
+      notifications_gateway: Gateways::EmailGateway.new,
     ).execute(
       email: record.email,
       confirmation_url: confirmation_link,
@@ -22,7 +22,7 @@ class AuthenticationMailer < ::Devise::Mailer
     template_id = GOV_NOTIFY_CONFIG["reset_password_email"]["template_id"]
 
     UseCases::Administrator::SendResetPasswordEmail.new(
-      notifications_gateway: EmailGateway.new,
+      notifications_gateway: Gateways::EmailGateway.new,
     ).execute(
       email: record.email,
       reset_url: reset_link,
@@ -35,7 +35,7 @@ class AuthenticationMailer < ::Devise::Mailer
     template_id = GOV_NOTIFY_CONFIG["unlock_account"]["template_id"]
 
     UseCases::Administrator::SendUnlockEmail.new(
-      notifications_gateway: EmailGateway.new,
+      notifications_gateway: Gateways::EmailGateway.new,
     ).execute(
       email: record.email,
       unlock_url: unlock_link,
@@ -48,7 +48,7 @@ class AuthenticationMailer < ::Devise::Mailer
     template_id = GOV_NOTIFY_CONFIG["invite_email"]["template_id"]
 
     UseCases::Administrator::SendInviteEmail.new(
-      notifications_gateway: EmailGateway.new,
+      notifications_gateway: Gateways::EmailGateway.new,
     ).execute(
       email: record.email,
       invite_url: invite_link,
@@ -61,7 +61,7 @@ class AuthenticationMailer < ::Devise::Mailer
     template_id = GOV_NOTIFY_CONFIG["cross_organisation_invitation"]["template_id"]
 
     UseCases::Administrator::SendMembershipInviteEmail.new(
-      notifications_gateway: EmailGateway.new,
+      notifications_gateway: Gateways::EmailGateway.new,
     ).execute(
       email: record.email,
       invite_url: invite_link,

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,13 +21,7 @@ module GovwifiAdmin
     config.exceptions_app = routes
 
     config.load_defaults 6.0
-
-    # our lib/ folder doesn't follow the Zeitwerk conventions for
-    # autoloading, so rely the classic loader instead.
-    config.autoloader = :classic
-
-    config.autoload_paths += %W[#{config.root}/lib]
-    config.autoload_paths += Dir["#{config.root}/lib/**/"]
+    config.autoloader = :zeitwerk
 
     # Force HTTPS for all requests except healthcheck endpoint
     config.force_ssl = true

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,2 +1,2 @@
 ActiveStorage::Blobs::RedirectController.include(GovWifiAuthenticatable)
-ActiveStorage::Blobs::RedirectController.include(AbleToReadMOU)
+ActiveStorage::Blobs::RedirectController.include(AbleToReadMou)

--- a/lib/facades/ips/publish.rb
+++ b/lib/facades/ips/publish.rb
@@ -19,7 +19,7 @@ module Facades
       end
 
       def publish_radius_whitelist
-        PublishWhitelist.new(
+        UseCases::Radius::PublishWhitelist.new(
           destination_gateway: Gateways::S3.new(
             bucket: ENV.fetch("S3_PUBLISHED_LOCATIONS_IPS_BUCKET"),
             key: ENV.fetch("S3_WHITELIST_OBJECT_KEY"),

--- a/lib/gateways/email_gateway.rb
+++ b/lib/gateways/email_gateway.rb
@@ -1,20 +1,22 @@
 require "notifications/client"
 
-class EmailGateway
-  def initialize
-    @client = Notifications::Client.new(ENV.fetch("NOTIFY_API_KEY"))
+module Gateways
+  class EmailGateway
+    def initialize
+      @client = Notifications::Client.new(ENV.fetch("NOTIFY_API_KEY"))
+    end
+
+    def send(opts)
+      client.send_email(
+        email_address: opts[:email],
+        template_id: opts[:template_id],
+        personalisation: opts[:locals],
+        reference: opts[:reference],
+      )
+    end
+
+  private
+
+    attr_reader :client
   end
-
-  def send(opts)
-    client.send_email(
-      email_address: opts[:email],
-      template_id: opts[:template_id],
-      personalisation: opts[:locals],
-      reference: opts[:reference],
-    )
-  end
-
-private
-
-  attr_reader :client
 end

--- a/lib/use_cases/organisation/view_radius_ip_addresses.rb
+++ b/lib/use_cases/organisation/view_radius_ip_addresses.rb
@@ -1,6 +1,6 @@
 module UseCases
   module Organisation
-    class ViewRadiusIPAddresses
+    class ViewRadiusIpAddresses
       def initialize(organisation_id:)
         @organisation_id = organisation_id
       end

--- a/lib/use_cases/radius/publish_whitelist.rb
+++ b/lib/use_cases/radius/publish_whitelist.rb
@@ -1,4 +1,4 @@
-class PublishWhitelist
+class UseCases::Radius::PublishWhitelist
   def initialize(destination_gateway:, generate_whitelist:)
     @destination_gateway = destination_gateway
     @generate_whitelist = generate_whitelist

--- a/spec/facades/ips/publish_spec.rb
+++ b/spec/facades/ips/publish_spec.rb
@@ -2,11 +2,11 @@ describe Facades::Ips::Publish do
   subject(:facade) { described_class.new }
 
   let(:publish_location_ips) { instance_spy(UseCases::PerformancePlatform::PublishLocationsIps, execute: nil) }
-  let(:publish_whitelist) { instance_spy(PublishWhitelist, execute: nil) }
+  let(:publish_whitelist) { instance_spy(UseCases::Radius::PublishWhitelist, execute: nil) }
 
   before do
     allow(UseCases::PerformancePlatform::PublishLocationsIps).to receive(:new).and_return(publish_location_ips)
-    allow(PublishWhitelist).to receive(:new).and_return(publish_whitelist)
+    allow(UseCases::Radius::PublishWhitelist).to receive(:new).and_return(publish_whitelist)
     facade.execute
   end
 

--- a/spec/gateways/email_gateway_spec.rb
+++ b/spec/gateways/email_gateway_spec.rb
@@ -1,6 +1,6 @@
 require "support/notifications_service"
 
-describe EmailGateway do
+describe Gateways::EmailGateway do
   subject(:email_gateway) { described_class.new }
 
   let(:notification) { instance_spy(Notifications::Client, send_email: nil) }

--- a/spec/use_cases/organisation/view_radius_ip_addresses_spec.rb
+++ b/spec/use_cases/organisation/view_radius_ip_addresses_spec.rb
@@ -1,4 +1,4 @@
-describe UseCases::Organisation::ViewRadiusIPAddresses do
+describe UseCases::Organisation::ViewRadiusIpAddresses do
   subject(:use_case) { described_class.new(organisation_id: org_id) }
 
   let(:radius_ip_1) { "111.111.111.111" }

--- a/spec/use_cases/publish_whitelist_spec.rb
+++ b/spec/use_cases/publish_whitelist_spec.rb
@@ -1,4 +1,4 @@
-describe UseCases::PublishWhitelist do
+describe UseCases::Radius::PublishWhitelist do
   subject(:use_case) do
     described_class.new(
       destination_gateway: s3_gateway,


### PR DESCRIPTION
### What
We are using the classic rails autoloader and this PR makes the switch to the newer Zeitwerk one

### Why
Zeitwerk is the new Classloader for Rails. The classic version will soon be deprecated when Rails 7 is released. Furthermore it is good to follow the new class/module naming convention

Link to Trello card (if applicable): 
https://trello.com/c/gQXR8Usc/1241-switch-to-zeitwerk-autoloader