### PR TITLE
Make side bar menu display consistently

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -21,7 +21,7 @@ class OrganisationsController < ApplicationController
       redirect_to root_path, notice: "#{@organisation.name} created"
     else
       @register_organisations = Organisation.fetch_organisations_from_register
-      
+
       @hide_sidebar = true
       render :new
     end

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -21,7 +21,8 @@ class OrganisationsController < ApplicationController
       redirect_to root_path, notice: "#{@organisation.name} created"
     else
       @register_organisations = Organisation.fetch_organisations_from_register
-
+      
+      @hide_sidebar = true
       render :new
     end
   end

--- a/app/views/organisations/new.html.erb
+++ b/app/views/organisations/new.html.erb
@@ -1,8 +1,8 @@
-<% content_for :page_title, "Register an organisation" %>
+<% content_for :page_title, "Add an organisation" %>
 
 <%= render "layouts/form_errors", resource: @organisation %>
 
-<h1 class="govuk-heading-l">Register an organisation for GovWifi</h1>
+<h1 class="govuk-heading-l">Add an organisation to GovWifi</h1>
 <%= form_for @organisation, url: organisations_path do |form| %>
   <div class="govuk-form-group <%= field_error(@organisation, "name") %>">
     <%= form.label :name, "Organisation name", class: "govuk-label" %>
@@ -39,7 +39,7 @@
     <% end %>
   </div>
   <div class="actions">
-    <%= form.submit "Create organisation", class: "govuk-button govuk-!-margin-top-2" %>
+    <%= form.submit "Add organisation", class: "govuk-button govuk-!-margin-top-2" %>
   </div>
 <% end %>
 

--- a/app/views/organisations/new.html.erb
+++ b/app/views/organisations/new.html.erb
@@ -40,7 +40,9 @@
   </div>
   <div class="actions">
     <%= form.submit "Add organisation", class: "govuk-button govuk-!-margin-top-2" %>
+
   </div>
+  <p class="govuk-body"><%= link_to "Cancel", :back, class: "govuk-link--no-visited-state" %></p>
 <% end %>
 
 <%= render "shared/organisation_register_dropdown" %>

--- a/spec/features/register_an_additional_organisation_spec.rb
+++ b/spec/features/register_an_additional_organisation_spec.rb
@@ -16,6 +16,11 @@ describe "Register an additional organisation", type: :feature do
     expect(page).to have_content("Register an organisation for GovWifi")
   end
 
+  it "does not display the sidebar menu" do
+    click_on "Add new organisation"
+    expect(page).not_to have_css("div.leftnav")
+  end
+
   context "when submitting the form with correct info" do
     let(:organisation_2_name) { "Gov Org 3" }
 
@@ -78,6 +83,10 @@ describe "Register an additional organisation", type: :feature do
 
       it "does not create the organisation" do
         expect { click_on "Create organisation" }.to change(Organisation, :count).by(0)
+      end
+
+      it "does not display the sidebar menu" do
+        expect(page).not_to have_css("div.leftnav")
       end
 
       it "displays the correct error to the user" do

--- a/spec/features/register_an_additional_organisation_spec.rb
+++ b/spec/features/register_an_additional_organisation_spec.rb
@@ -13,7 +13,7 @@ describe "Register an additional organisation", type: :feature do
 
   it "displays the new organisation form" do
     click_on "Add new organisation"
-    expect(page).to have_content("Register an organisation for GovWifi")
+    expect(page).to have_content("Add an organisation to GovWifi")
   end
 
   it "does not display the sidebar menu" do
@@ -31,40 +31,40 @@ describe "Register an additional organisation", type: :feature do
     end
 
     it "creates the organisation" do
-      expect { click_on "Create organisation" }.to change(Organisation, :count).by(1)
+      expect { click_on "Add organisation" }.to change(Organisation, :count).by(1)
     end
 
     it "associates the organisation to the user" do
-      click_on "Create organisation"
+      click_on "Add organisation"
       expect(user.reload.organisations.map(&:name)).to eq([organisation_1.name, organisation_2_name])
     end
 
     it "displays the success message to the user" do
-      click_on "Create organisation"
+      click_on "Add organisation"
       expect(page).to have_content("#{organisation_2_name} created")
     end
 
     it "sets the new organisation as the current organisation" do
-      click_on "Create organisation"
+      click_on "Add organisation"
       within ".subnav" do
         expect(page).to have_content(organisation_2_name)
       end
     end
 
     it "confirms the membership that joins the user to the organisation" do
-      click_on "Create organisation"
+      click_on "Add organisation"
       organisation = user.organisations.find_by(name: organisation_2_name)
       expect(user.membership_for(organisation)).to be_confirmed
     end
 
     it "gives the user can_manage_team privileges" do
-      click_on "Create organisation"
+      click_on "Add organisation"
       organisation = user.organisations.find_by(name: organisation_2_name)
       expect(user.can_manage_team?(organisation)).to eq(true)
     end
 
     it "gives the user can_manage_locations privileges" do
-      click_on "Create organisation"
+      click_on "Add organisation"
       organisation = user.organisations.find_by(name: organisation_2_name)
       expect(user.can_manage_locations?(organisation)).to eq(true)
     end
@@ -82,7 +82,7 @@ describe "Register an additional organisation", type: :feature do
       let(:service_email) { "" }
 
       it "does not create the organisation" do
-        expect { click_on "Create organisation" }.to change(Organisation, :count).by(0)
+        expect { click_on "Add organisation" }.to change(Organisation, :count).by(0)
       end
 
       it "does not display the sidebar menu" do
@@ -90,7 +90,7 @@ describe "Register an additional organisation", type: :feature do
       end
 
       it "displays the correct error to the user" do
-        click_on "Create organisation"
+        click_on "Add organisation"
         expect(page).to have_content("Service email must be a valid email address").twice
       end
     end
@@ -100,11 +100,11 @@ describe "Register an additional organisation", type: :feature do
       let(:service_email) { "info@gov.uk" }
 
       it "does not create the organisation" do
-        expect { click_on "Create organisation" }.to change(Organisation, :count).by(0)
+        expect { click_on "Add organisation" }.to change(Organisation, :count).by(0)
       end
 
       it "displays the correct error to the user" do
-        click_on "Create organisation"
+        click_on "Add organisation"
         expect(page).to have_content("Name can't be blank").twice
       end
     end

--- a/spec/features/register_an_additional_organisation_spec.rb
+++ b/spec/features/register_an_additional_organisation_spec.rb
@@ -21,6 +21,11 @@ describe "Register an additional organisation", type: :feature do
     expect(page).not_to have_css("div.leftnav")
   end
 
+  it "displays a cancel link" do
+    click_on "Add new organisation"
+    expect(page).to have_link("Cancel", href: "https://www.example.com/change_organisation")
+  end
+
   context "when submitting the form with correct info" do
     let(:organisation_2_name) { "Gov Org 3" }
 


### PR DESCRIPTION
### What
Prevents the side-bar menu from displaying when an email field error occurs, changes instances of 'register organisation' and 'create organisation' to 'add organisation' and adds a 'Cancel' (back) link.

### Why
To make the page display consistently in the case of all error types, use language consistently and match the design prototype


Link to Trello card (if applicable): 

https://trello.com/c/KvrKdbSM/1946-make-display-of-navigation-sidebar-consistent-between-the-default-register-organisation-page-and-the-page-displayed-in-case-of-i
