### PR TITLE
Improve edit password form

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,6 +5,10 @@ module ApplicationHelper
     resource&.errors&.include?(key.to_sym) ? "govuk-form-group--error" : ""
   end
 
+  def input_error(resource, key)
+    resource&.errors&.include?(key.to_sym) ? "govuk-input--error" : ""
+  end
+
   def active_tab(*identifiers)
     classes = %w[govuk-link govuk-link--no-visited-state]
 

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -10,27 +10,48 @@
   </legend>
 
 <%= form_for(current_user, url: user_registration_path, method: :put) do |f| %>
-  <div class="govuk-form-group">
+  <div class="govuk-form-group <%= field_error(resource, :current_password) %>">
     <%= f.label :current_password, class: "govuk-label" %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
-        <%= f.password_field :current_password, class: "govuk-input" %>
+        <% if resource.errors.attribute_names.include?(:current_password) %>
+          <span class="govuk-error-message" id="current_password_error">
+            <span class="govuk-visually-hidden">Error:</span>
+            <%= resource.errors.full_messages_for(:current_password).first %>
+          </span>
+        <% end %>
+
+        <%= f.password_field :current_password, class: "govuk-input #{input_error(resource, :current_password)}" %>
       </div>
     </div>
   </div>
-  <div id="password" class="govuk-form-group">
+  <div id="password" class="govuk-form-group <%= field_error(resource, :password) %>">
     <%= f.label :password, class: "govuk-label" %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
-        <%= f.password_field :password, class: "govuk-input" %>
+        <% if resource.errors.attribute_names.include?(:password) %>
+          <span class="govuk-error-message" id="password_error">
+            <span class="govuk-visually-hidden">Error:</span>
+            <%= resource.errors.full_messages_for(:password).first %>
+          </span>
+        <% end %>
+
+        <%= f.password_field :password, class: "govuk-input #{input_error(resource, :password)}" %>
       </div>
     </div>
   </div>
-  <div class="govuk-form-group">
+  <div class="govuk-form-group <%= field_error(resource, :password_confirmation) %>">
     <%= f.label :password_confirmation, class: "govuk-label" %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-three-quarters">
-        <%= f.password_field :password_confirmation, class: "govuk-input" %>
+        <% if resource.errors.attribute_names.include?(:password_confirmation) %>
+          <span class="govuk-error-message" id="password_confirmation_error">
+            <span class="govuk-visually-hidden">Error:</span>
+            <%= resource.errors.full_messages_for(:password_confirmation).first %>
+          </span>
+        <% end %>
+
+        <%= f.password_field :password_confirmation, class: "govuk-input #{input_error(resource, :password_confirmation)}" %>
       </div>
     </div>
   </div>

--- a/spec/features/authentication/edit_password_spec.rb
+++ b/spec/features/authentication/edit_password_spec.rb
@@ -52,6 +52,8 @@ describe "Editing password", type: :feature do
     click_on "Submit"
 
     expect(page).to have_content "Current password is invalid"
+    expect(page).to have_css "#user_current_password.govuk-input--error"
+    expect(page).to have_css ".govuk-form-group.govuk-form-group--error"
   end
 
   it "stays on the same page and does not change the password, if the new password is too short" do
@@ -64,6 +66,8 @@ describe "Editing password", type: :feature do
     click_on "Submit"
 
     expect(page).to have_content "Password is too short"
+    expect(page).to have_css "#user_password.govuk-input--error"
+    expect(page).to have_css ".govuk-form-group.govuk-form-group--error"
   end
 
   it "stays on the same page and does not change the password, if the confirmation does not match" do
@@ -76,5 +80,7 @@ describe "Editing password", type: :feature do
     click_on "Submit"
 
     expect(page).to have_content "Password confirmation doesn't match Password"
+    expect(page).to have_css "#user_password_confirmation.govuk-input--error"
+    expect(page).to have_css ".govuk-form-group.govuk-form-group--error"
   end
 end

--- a/spec/features/authentication/edit_password_spec.rb
+++ b/spec/features/authentication/edit_password_spec.rb
@@ -42,6 +42,30 @@ describe "Editing password", type: :feature do
     expect(page).to have_content "Sign out"
   end
 
+  it "stays on the same page and does not change the password, if the current password is invalid" do
+    visit edit_user_registration_path
+
+    fill_in "Current password", with: "wrong password"
+    fill_in "Password", with: pw
+    fill_in "Password confirmation", with: pw
+
+    click_on "Submit"
+
+    expect(page).to have_content "Current password is invalid"
+  end
+
+  it "stays on the same page and does not change the password, if the new password is too short" do
+    visit edit_user_registration_path
+
+    fill_in "Current password", with: user.password
+    fill_in "Password", with: "a"
+    fill_in "Password confirmation", with: "a"
+
+    click_on "Submit"
+
+    expect(page).to have_content "Password is too short"
+  end
+
   it "stays on the same page and does not change the password, if the confirmation does not match" do
     visit edit_user_registration_path
 


### PR DESCRIPTION
### What
Improve error display on the change password form.

#### Before
![image](https://user-images.githubusercontent.com/1130010/152763884-bd21ab6c-3b3e-44ee-a9b1-bfba41712b57.png)

#### After
![image](https://user-images.githubusercontent.com/1130010/152763804-caded800-d5e8-4c08-9a5c-bc02c0a85c9b.png)

### Why
This makes the form easier to use.


Link to Trello card: https://trello.com/c/CwZ50yCx/1950-make-error-messages-produced-by-devise-gem-design-system-compliant
