### PR TITLE
Error messages on the 'register new org' pages are design system compliant

### DIFF
--- a/app/views/organisations/new.html.erb
+++ b/app/views/organisations/new.html.erb
@@ -14,10 +14,10 @@
         <span class="govuk-visually-hidden">Error:</span>
         <%= @organisation.errors.full_messages_for(:name).first %>
       </span>
-      <%= form.select :name, options_for_select(@register_organisations << "", ""),
+      <%= form.select :name, options_for_select(@register_organisations << "", @organisation.name || ""),
                       {}, class: "govuk-select govuk-input--error" %>
     <% else %>
-      <%= form.select :name, options_for_select(@register_organisations << "", ""), {}, class: "govuk-select" %>
+      <%= form.select :name, options_for_select(@register_organisations << "", @organisation.name || ""), {}, class: "govuk-select" %>
     <% end %>
   </div>
 
@@ -31,11 +31,11 @@
       </span>
       <%= form.text_field :service_email,
                           class: "govuk-input govuk-input--error",
-                          value: (params || {}).dig(:user, :organisation_attributes, :service_email) %>
+                          value: @organisation.service_email || "" %>
     <% else %>
       <%= form.text_field :service_email,
                           class: "govuk-input",
-                          value: (params || {}).dig(:user, :organisation_attributes, :service_email) %>
+                          value: @organisation.service_email || "" %>
     <% end %>
   </div>
   <div class="actions">

--- a/app/views/shared/_organisation_register_dropdown.html.erb
+++ b/app/views/shared/_organisation_register_dropdown.html.erb
@@ -4,7 +4,7 @@
 <script>
   accessibleAutocomplete.enhanceSelectElement({
     selectElement: document.querySelector('#organisation_name'),
-    required: true,
+    required: false,
     defaultValue: '',
     showNoOptionsFound: true,
     showAllValues: true,

--- a/spec/features/register_an_additional_organisation_spec.rb
+++ b/spec/features/register_an_additional_organisation_spec.rb
@@ -98,6 +98,11 @@ describe "Register an additional organisation", type: :feature do
         click_on "Add organisation"
         expect(page).to have_content("Service email must be a valid email address").twice
       end
+
+      it "retains the selected organisation value" do
+        click_on "Add organisation"
+        expect(page).to have_select("name", selected: "Gov Org 3")
+      end
     end
 
     context "with an invalid organisation name" do
@@ -111,6 +116,11 @@ describe "Register an additional organisation", type: :feature do
       it "displays the correct error to the user" do
         click_on "Add organisation"
         expect(page).to have_content("Name can't be blank").twice
+      end
+
+      it "retains the service email" do
+        click_on "Add organisation"
+        expect(page).to have_field("Service email", with: service_email)
       end
     end
   end


### PR DESCRIPTION
Ensure error messages display as intended on 'register new org' admin page

When leaving the organisation empty, a design-system compliant error message
is now shown. Value are now also retained if the input is not valid

Link to Trello card (if applicable): 
https://trello.com/c/coP1mjaU/1951-ensure-error-messages-display-as-intended-on-register-new-org-admin-page

<img width="1014" alt="image" src="https://user-images.githubusercontent.com/6050162/152820993-2f5ee6b7-4a86-4d11-9a9c-3242f2cafe9e.png">
