### PR TITLE
Remove links from the header

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -40,12 +40,6 @@
       </button>
       <nav>
         <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
-          <li class="govuk-header__navigation-item">
-            <%= link_to "Connect to GovWifi", SITE_CONFIG["connect_to_govwifi_link"], class: "govuk-header__link" %>
-          </li>
-          <li class="govuk-header__navigation-item">
-            <%= link_to "Offer GovWifi", SITE_CONFIG["organisation_docs_link"], class: "govuk-header__link" %>
-          </li>
           <% if user_signed_in? %>
           <li class="govuk-header__navigation-item">
             <%= link_to "Support", signed_in_new_help_path, class: "govuk-header__link" %>


### PR DESCRIPTION
### What

Remove links to ''connect to GovWifi'' and ''Offer GovWifi'' as these
are separate product page functions and not admin functions.


### Why
This simplifies the admin user experience and creates further distinction between product pages and admin specific pages


Link to Trello card (if applicable): 
https://trello.com/c/sr564a5z/2031-admin-site-header

<img width="1049" alt="image" src="https://user-images.githubusercontent.com/6050162/153088855-e6940f0a-b72d-436d-825f-3d491c12fe0c.png">
