### PR TITLE
Start using the form builder gem for a couple more forms

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -27,7 +27,7 @@ protected
 
   def set_user_object_with_errors
     @user = User.new(sign_up_params)
-    @user.errors.add(:email, "address must be from a government or a public sector domain. If you're having trouble signing up, #{view_context.link_to('contact us', new_help_path)}.")
+    @user.errors.add(:email, "Email address must be from a government or a public sector domain. If you're having trouble signing up, contact us.")
   end
 
   def return_user_to_registration_page

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -1,27 +1,24 @@
 <% content_for :page_title, "Invite a team member" %>
 
-<%= render "layouts/form_errors" %>
+<%= form_for(resource,
+             as: resource_name,
+             url: invitation_path(resource_name),
+             builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+             html: { method: :post, novalidate: "" }) do |f| %>
 
-<% if super_admin? %>
-  <%= link_to "Back to organisation", super_admin_organisation_path(@target_organisation.id), class: "govuk-back-link" %>
-  <h1 class="govuk-heading-l">Invite a team member to <%= @target_organisation.name %> </h1>
-<% else %>
-  <%= link_to "Back to list", memberships_path, class: "govuk-back-link" %>
-  <h1 class="govuk-heading-l">Invite a team member</h1>
-<% end %>
-<div class="govuk-grid-column-full govuk-!-padding-left-0">
-  <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post, novalidate: "" } do |f| %>
-    <div class="govuk-form-group <%= field_error(resource, :email) %>">
-      <%= f.label :email, "Email address", class: "govuk-label" %>
-      <% if resource.errors.attribute_names.include?(:email) %>
-          <span class="govuk-error-message" id="email_address_error">
-            <span class="govuk-visually-hidden">Error:</span><%= resource.errors.full_messages_for(:email).first %>
-          </span>
-        <%= f.email_field :email, autocomplete: "email", class: "govuk-input govuk-input--error" %>
-      <% else %>
-        <%= f.email_field :email, autocomplete: "email", class: "govuk-input" %>
-      <% end %>
-    </div>
+  <%= f.govuk_error_summary %>
+
+  <% if super_admin? %>
+    <%= link_to "Back to organisation", super_admin_organisation_path(@target_organisation.id), class: "govuk-back-link" %>
+    <h1 class="govuk-heading-l">Invite a team member to <%= @target_organisation.name %> </h1>
+  <% else %>
+    <%= link_to "Back to list", memberships_path, class: "govuk-back-link" %>
+    <h1 class="govuk-heading-l">Invite a team member</h1>
+  <% end %>
+
+  <div class="govuk-grid-column-full govuk-!-padding-left-0">
+    <%= f.govuk_email_field :email, label: { text: "Email address" } %>
+
     <div class="actions">
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
@@ -55,8 +52,6 @@
       </div>
     </div>
 
-    <div class="actions">
-      <%= f.submit "Send invitation email", class: "govuk-button govuk-!-margin-top-0 govuk-!-margin-bottom-8" %>
-    </div>
-  <% end %>
-</div>
+    <%= f.govuk_submit "Send invitation email" %>
+  </div>
+<% end %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,24 +1,26 @@
 <% content_for :page_title, "Sign up your organisation to GovWifi" %>
 
-<%= render "layouts/form_errors", resource: resource %>
+<%= form_for(resource,
+             as: resource_name,
+             url: registration_path(resource_name),
+             builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+             html: { novalidate: "" }) do |f| %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Sign up your organisation to GovWifi</h1>
+  <%= f.govuk_error_summary %>
 
-    <%= render "users/shared/end_user_warning" %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Sign up your organisation to GovWifi</h1>
 
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { novalidate: "" }) do |f| %>
-      <div class="govuk-form-group <%= field_error(resource, :email) %>">
-        <%= f.label :email, "Enter your email address", class: "govuk-label" %>
-        <div class="govuk-hint">The email address must be from a government or a public sector domain.</div>
-        <%= f.email_field :email, autocomplete: "email", class: "govuk-input" %>
-      </div>
+      <%= render "users/shared/end_user_warning" %>
 
-      <div class="actions">
-        <%= f.submit "Sign up", class: "govuk-button" %>
-      </div>
-    <% end %>
-    <%= link_to "Sign in", new_session_path(resource_name), class: "govuk-link govuk-body" %>
+      <%= f.govuk_email_field(:email,
+                              label: { text: "Email address" },
+                              hint: { text: "The email address must be from a government or a public sector domain." }) %>
+
+      <%= f.govuk_submit "Sign up" %>
+    </div>
   </div>
-</div>
+<% end %>
+
+<%= link_to "Sign in", new_session_path(resource_name), class: "govuk-link govuk-body" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,8 +8,9 @@ en:
         user:
           attributes:
             email:
-              taken: " is already associated with an account. If you can't sign in, <a href='/users/password/new'>reset your password</a>."
-              invalid: " must be a valid email address"
+              taken: "This email address is already associated with an account. If you can't sign in, reset your password."
+              invalid: "Enter an email address in the correct format, like name@example.com"
+              blank: "Email can't be blank"
         organisation:
           attributes:
             name:

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -71,13 +71,6 @@ describe "Sign up as an organisation", type: :feature do
       it "tells me my email is not valid" do
         expect(page).to have_content("Email address must be from a government or a public sector domain. If you're having trouble signing up, contact us.")
       end
-
-      it "provides a link to a support form" do
-        visit new_user_registration_path
-        click_on "Sign up"
-        click_on "contact us"
-        expect(page).to have_content("Setting up GovWifi in your organisation support")
-      end
     end
 
     context "with a blank email" do
@@ -211,7 +204,7 @@ describe "Sign up as an organisation", type: :feature do
 
     it "will tell the user the email is already in use" do
       sign_up_for_account(email: email)
-      expect(page).to have_content("Email is already associated with an account. If you can't sign in, reset your password")
+      expect(page).to have_content("This email address is already associated with an account. If you can't sign in, reset your password")
     end
   end
 

--- a/spec/features/support/sign_up_helpers.rb
+++ b/spec/features/support/sign_up_helpers.rb
@@ -3,7 +3,7 @@ require "warden"
 
 def sign_up_for_account(email: "default@gov.uk")
   visit new_user_registration_path
-  fill_in "user_email", with: email
+  fill_in "Email address", with: email
   click_on "Sign up"
 end
 

--- a/spec/features/team/invite_a_team_member_spec.rb
+++ b/spec/features/team/invite_a_team_member_spec.rb
@@ -87,7 +87,7 @@ describe "Inviting a team member", type: :feature do
       end
 
       it "displays the correct error message" do
-        expect(page).to have_content("Email is already associated with an account. If you can't sign in, reset your password")
+        expect(page).to have_content("This email address is already associated with an account. If you can't sign in, reset your password")
       end
     end
 
@@ -163,7 +163,7 @@ describe "Inviting a team member", type: :feature do
       end
 
       it "displays the correct error message" do
-        expect(page).to have_content("Email must be a valid email address").twice
+        expect(page).to have_content("Enter an email address in the correct format, like name@example.com").twice
       end
     end
   end


### PR DESCRIPTION
### What
Start using the form builder gem for a couple more forms

### Why
This is mostly aimed at adjusting the error messages shown by the
invite team member form. Since there's some overlap with validation
for the sign up form, I've ended up changing that as well.

Using the form builder gem means that the error messages don't all
start with the name of the field, which makes the format less
constrained.

I haven't changed the invite team member form checkboxes to be
generated through the gem provided helpers since I believe this part
of the form is changing shortly.


Link to Trello card: https://trello.com/c/CwZ50yCx/1950-make-error-messages-produced-by-devise-gem-design-system-compliant

### Before
![image](https://user-images.githubusercontent.com/1130010/154066922-cd0067f1-b7d3-43db-aa25-8687b8b421ab.png)
### After
![image](https://user-images.githubusercontent.com/1130010/154067019-d794db95-9ede-4fd1-9e80-199010c1ba05.png)

### Before
![image](https://user-images.githubusercontent.com/1130010/154067248-bf53a028-c90c-4e96-9aa9-f1022d6176a5.png)
### After
![image](https://user-images.githubusercontent.com/1130010/154067453-ee9fa919-dba2-4d09-9aa0-1597a5065bbb.png)


