### PR TITLE
Simplify Location Page

### DIFF
--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -5,8 +5,9 @@
     <%= render "confirm_remove_ip" if @ip_to_delete && current_user.can_manage_locations?(current_organisation) %>
     <%= render "confirm_remove_location" if @location_to_delete && current_user.can_manage_locations?(current_organisation) %>
     <%= render "confirm_rotate_radius_key" if @key_to_rotate && current_user.can_manage_locations?(current_organisation) %>
-
-    <div class="govuk-grid-column-two-thirds">
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-!-padding-0">
       <h1 class="govuk-heading-l">Locations</h1>
     </div>
     <div class="govuk-grid-column-one-third text-right">
@@ -28,22 +29,24 @@
     <% end %>
   <% end %>
 
-  <%== pagy_nav_govuk(@pagy) %>
-  <% if current_organisation.locations.empty? %>
-    <p class="govuk-body result-row-empty">
-      You need to add at least one location to offer GovWifi
-    </p>
-  <% else %>
-    <div role="status">
-      <p class="govuk-body" id="no-results" style="display: none">
-        <strong>No results found</strong>
-      </p>
-    </div>
-    <div aria-live="polite">
-      <% @locations.each do |location| %>
-        <%= render partial: "shared/manage_ips", locals: { location: location, show_ip_controls: true } %>
-      <% end %>
-    </div>
-  <% end %>
-  <%== pagy_nav_govuk(@pagy) %>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+
+    <%== pagy_nav_govuk(@pagy) %>
+
+    <% if current_organisation.locations.empty? %>
+      <div class="govuk-inset-text govuk-!-margin-top-0 govuk-!-margin-bottom-9">
+        You need to add at least one location to offer GovWifi
+      </div>
+    <% elsif @locations.count==0 %>
+      <h2 class="govuk-heading-m ">No results found</h2>
+    <% else %>
+      <div aria-live="polite">
+        <% @locations.each do |location| %>
+          <%= render partial: "shared/manage_ips", locals: { location: location, show_ip_controls: true } %>
+        <% end %>
+      </div>
+    <% end %>
+
+    <%== pagy_nav_govuk(@pagy) %>
+  </div>
 </div>

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -18,16 +18,14 @@
 
   <% if current_organisation.locations.length > 1 %>
     <div class="govuk-!-padding-bottom-7">
-      <%= form_with url: ips_path, method: "get", local: true, class: "govuk-form-group" do |form| %>
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend--m govuk-fieldset">
-            Search by location or postcode
-          </legend>
-          <span id="search_input-hint" class="govuk-hint">For example, 'SW1A 2AA' or 'High Street'</span>
-          <%= form.label :search, "Search by location or postcode", class: "govuk-label govuk-label--m govuk-visually-hidden" %>
-          <%= form.text_field :search, value: params.fetch(:search, ""), class: "govuk-input govuk-input--width-10" %>
-          <%= form.submit "Search", name: nil, class: "govuk-button" %>
-        </fieldset>
+      <%= form_with url: ips_path, method: "get", local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+        <%= form.govuk_fieldset legend: { text: "Search by location or postcode" } do %>
+          <%= form.govuk_text_field :search, value: params.fetch(:search, ""),
+                                             label: { text: "Search by location or postcode", hidden: true },
+                                             hint: { text: "For example, 'SW1A 2AA' or 'High Street'" },
+                                             width: 10 %>
+          <%= form.govuk_submit "Search" %>
+        <% end %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -15,19 +15,17 @@
       <% end %>
     </div>
   </div>
-
+  <div class="govuk-grid-row">
   <% if current_organisation.locations.length > 1 %>
-    <div class="govuk-!-padding-bottom-7">
-      <%= form_with url: ips_path, method: "get", local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
-        <%= form.govuk_fieldset legend: { text: "Search by location or postcode" } do %>
-          <%= form.govuk_text_field :search, value: params.fetch(:search, ""),
-                                             label: { text: "Search by location or postcode", hidden: true },
-                                             hint: { text: "For example, 'SW1A 2AA' or 'High Street'" },
-                                             width: 10 %>
-          <%= form.govuk_submit "Search" %>
-        <% end %>
+    <%= form_with url: ips_path, method: "get", local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+      <%= form.govuk_fieldset legend: { text: "Search by location or postcode" } do %>
+        <%= form.govuk_text_field :search, value: params.fetch(:search, ""),
+                                           label: { text: "Search by location or postcode", hidden: true },
+                                           hint: { text: "For example, 'SW1A 2AA' or 'High Street'" },
+                                           width: 20 %>
+        <%= form.govuk_submit "Search", class: "text-right" %>
       <% end %>
-    </div>
+    <% end %>
   <% end %>
 
   <%== pagy_nav_govuk(@pagy) %>

--- a/app/views/shared/_manage_ips.html.erb
+++ b/app/views/shared/_manage_ips.html.erb
@@ -3,34 +3,32 @@
     <%= location.full_address %>
   </h2>
   <% if show_ip_controls %>
-    <div class="govuk-body govuk-!-margin-bottom-2">
-      RADIUS secret key:
-      <div class="inline-block">
-        <span class="secret-key"><%= location.radius_secret_key %></span>
-        <% if current_user.can_manage_locations?(current_organisation) %>
-          <%= link_to location_rotate_key_path(location, rotate: true), class: "red-link secret-key-rotate-link" do %>
-            Rotate secret key <span class='govuk-visually-hidden'>for <%= location.full_address %></span>
-          <% end %>
-        <% end %>
-      </div>
-    </div>
+    <span class="govuk-caption-m govuk-!-margin-bottom-4">
+      RADIUS secret key: <%= location.radius_secret_key %>
+    </span>
     <% if current_user.can_manage_locations?(current_organisation) %>
-      <%= link_to location_add_ips_path(location_id: location.id), class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-5", role: "button", draggable: "false", "data-module" => "govuk-button" do %>
-        Add IP addresses <span class='govuk-visually-hidden'>for <%= location.full_address %></span>
-      <% end %>
-      <% if location.ips.empty? %>
-        <p class="result-row-empty govuk-body">
-          Add the IP addresses of your authenticators to offer GovWifi at this location
-        </p>
-      <% end %>
-
-      <% if current_user.can_manage_locations?(current_organisation) && location.ips.empty? %>
-        <p class="govuk-body govuk-!-margin-bottom-1">
-          <%= link_to location_remove_path(location, remove: true), class: "red-link" do %>
+      <div class="govuk-button-group">
+        <%= link_to location_add_ips_path(location_id: location.id),
+                    class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-5",
+                    role: "button", draggable: "false", "data-module" => "govuk-button" do %>
+          Add IP addresses <span class='govuk-visually-hidden'>for <%= location.full_address %></span>
+        <% end %>
+        <%= link_to location_rotate_key_path(location, rotate: true),
+                    class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-5",
+                    role: "button", draggable: "false", "data-module" => "govuk-button" do %>
+          Rotate secret key <span class='govuk-visually-hidden'>for <%= location.full_address %></span>
+        <% end %>
+        <% if location.ips.empty? %>
+          <%= link_to location_remove_path(location, remove: true),
+                      class: "govuk-button govuk-button--warning govuk-!-margin-bottom-5",
+                      role: "button", draggable: "false", "data-module" => "govuk-button" do %>
             Remove this location <span class='govuk-visually-hidden'>- <%= location.full_address %></span>
           <% end %>
-        </p>
-      <% end %>
+          <div class="govuk-inset-text govuk-!-margin-top-0 govuk-!-margin-bottom-9">
+            Add the IP addresses of your authenticators to offer GovWifi at this location
+          </div>
+        <% end %>
+      </div>
     <% end %>
   <% end %>
   <table class="govuk-table govuk-!-margin-bottom-7">

--- a/app/views/shared/_manage_ips.html.erb
+++ b/app/views/shared/_manage_ips.html.erb
@@ -31,8 +31,8 @@
       </div>
     <% end %>
   <% end %>
-  <table class="govuk-table govuk-!-margin-bottom-7">
-    <tbody class="govuk-table__body" id="ips-table">
+  <table class="govuk-table govuk-!-margin-bottom-9">
+    <tbody class="govuk-table__body">
     <% if location.sorted_ip_addresses.length == 0 %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
@@ -41,40 +41,44 @@
       </tr>
     <% end %>
     <% location.sorted_ip_addresses.each do |ip| %>
-      <tr class="govuk-table__row" id="ips-row-<%= ip.id %>">
-        <td class="govuk-table__cell govuk-!-width-one-third">
-          <%= render partial: "shared/ip_address", locals: { ip: ip.address } %>
-        </td>
-        <% if ip.available? %>
-          <td class="govuk-table__cell ">
-            <% if ip.unused? %>
-              No traffic received yet
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header govuk-!-width-one-quarter">
+            <%= ip.address %>
+          </th>
+          <td class="govuk-table__cell govuk-!-width-one-quarter">
+            <% if !ip.available? %>
+              Available at 6am tomorrow
+            <% elsif ip.unused? %>
+              No traffic received
             <% elsif ip.inactive? %>
               No traffic in the last 10 days
             <% else %>
-              Receiving traffic (<%= link_to "view logs", logs_path(ip: ip.address), class: "govuk-link" %>)
+              Receiving traffic
             <% end %>
           </td>
-          <td class="govuk-table__cell">
-            <% unless ip.unused? || ip.inactive? %>
+          <td class="govuk-table__cell govuk-!-width-one-quarter">
+            <% if ip.available? && !ip.unused? && !ip.inactive? %>
               <%= ip.percent_success %>% success rate
             <% end %>
           </td>
-        <% else %>
-          <td class="govuk-table__cell text-dark-grey">
-            Available at 6am tomorrow
+          <td class="govuk-table__cell govuk-!-width-one-quarter text-right">
+            <ul class="plain-list govuk-!-margin-0">
+              <% if ip.available? && !ip.unused? && !ip.inactive? %>
+                <li>
+                  <%= link_to "View logs", logs_path(ip: ip.address), class: "govuk-link" %>
+                </li>
+              <% end %>
+              <% if show_ip_controls && current_user.can_manage_locations?(current_organisation) %>
+                <li>
+                  <%= link_to ip_remove_path(ip), class: "govuk-link govuk-link--no-visited-state" do %>
+                    Remove <span class='govuk-visually-hidden'><%= ip.address %> from <%= location.full_address %></span>
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
           </td>
-          <td class="govuk-table__cell"></td>
-        <% end %>
-        <td class="govuk-table__cell text-right">
-          <% if show_ip_controls && current_user.can_manage_locations?(current_organisation) %>
-            <%= link_to ip_remove_path(ip), class: "govuk-link govuk-link--no-visited-state" do %>
-              Remove <span class='govuk-visually-hidden'><%= ip.address %> from <%= location.full_address %></span>
-            <% end %>
-          <% end %>
-        </td>
-      </tr>
-    <% end %>
+        </tr>
+      <% end %>
     </tbody>
   </table>
 </div>

--- a/app/views/shared/_manage_ips.html.erb
+++ b/app/views/shared/_manage_ips.html.erb
@@ -1,5 +1,5 @@
 <div class="result-row">
-  <h2 class="filter-by govuk-heading-m govuk-!-margin-bottom-2">
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">
     <%= location.full_address %>
   </h2>
   <% if show_ip_controls %>

--- a/spec/features/ips/remove_an_ip_spec.rb
+++ b/spec/features/ips/remove_an_ip_spec.rb
@@ -56,8 +56,7 @@ describe "Removing an IP", type: :feature do
 
     it "does not show the remove button" do
       visit ips_path
-
-      within("#ips-table") do
+      within(:xpath, "//tr[th[normalize-space(text())=\"#{ip.address}\"]]") do
         expect(page).not_to have_content("Remove")
       end
     end

--- a/spec/features/ips/view_ip_address_readiness_spec.rb
+++ b/spec/features/ips/view_ip_address_readiness_spec.rb
@@ -30,7 +30,7 @@ describe "Wiew whether IPs are ready", type: :feature do
       end
 
       it "shows it as available" do
-        expect(page).to have_content("No traffic received yet")
+        expect(page).to have_content("No traffic received")
       end
 
       it "does not shpow any IPs as available tomorrow" do

--- a/spec/features/ips/view_ip_addresses_spec.rb
+++ b/spec/features/ips/view_ip_addresses_spec.rb
@@ -3,6 +3,10 @@ describe "Viewing IP addresses", type: :feature do
 
   let(:user) { create(:user, :with_organisation) }
 
+  def xpath_row_containing_ip(ip)
+    "//tr[th[normalize-space(text())=\"#{ip.address}\"]]"
+  end
+
   context "with no IPs" do
     before do
       sign_in_user user
@@ -49,7 +53,7 @@ describe "Viewing IP addresses", type: :feature do
       end
 
       it "labels the IP as inactive" do
-        within("#ips-row-#{ip.id}") do
+        within(:xpath, xpath_row_containing_ip(ip)) do
           expect(page).to have_content("No traffic in the last 10 days")
         end
       end
@@ -61,8 +65,8 @@ describe "Viewing IP addresses", type: :feature do
 
     context "with newly created IPs with no activity" do
       it "labels the IP as created but unused" do
-        within("#ips-row-#{ip.id}") do
-          expect(page).to have_content("No traffic received yet")
+        within(:xpath, xpath_row_containing_ip(ip)) do
+          expect(page).to have_content("No traffic received")
         end
       end
     end
@@ -74,13 +78,13 @@ describe "Viewing IP addresses", type: :feature do
       end
 
       it "Does not label the IP as inactive" do
-        within("#ips-row-#{ip.id}") do
+        within(:xpath, xpath_row_containing_ip(ip)) do
           expect(page).not_to have_content("No traffic for the last 10 days")
         end
       end
 
       it "Does not label the IP as unused" do
-        within("#ips-row-#{ip.id}") do
+        within(:xpath, xpath_row_containing_ip(ip)) do
           expect(page).not_to have_content("No traffic received yet")
         end
       end

--- a/spec/features/locations/remove_a_location_spec.rb
+++ b/spec/features/locations/remove_a_location_spec.rb
@@ -56,7 +56,7 @@ describe "Remove a location", type: :feature do
 
     it "does not show the remove button" do
       visit ips_path
-      within("#ips-table") do
+      within("table") do
         expect(page).not_to have_content("Remove location")
       end
     end

--- a/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
@@ -14,8 +14,8 @@ describe "View authentication requests for an IP", type: :feature do
     before do
       visit ips_path
 
-      within("#ips-table") do
-        click_on "view logs"
+      within(:xpath, "//tr[th[normalize-space(text())=\"#{ip}\"]]") do
+        click_on "View logs"
       end
     end
 


### PR DESCRIPTION
### What
Represent 'Rotate key' and 'Remove Location' links as buttons as they are actions
Present the 'view logs' and 'remove ip' links in a list for each IP address
Use insets for messaging
Make various changes to make the layout more design system compliant

### Why
This will make the locations page simpler and more compliant with the GOV.UK design system

Link to Trello card (if applicable): 
https://trello.com/c/DcaU32qu/2058-simplify-location-page-building-actions
https://trello.com/c/Wtrfd94o/1261-simplify-location-page-ip-address-actions

<img width="1048" alt="image" src="https://user-images.githubusercontent.com/6050162/155566586-be1be895-d507-420e-8230-dec2ce8958e9.png">
<img width="946" alt="image" src="https://user-images.githubusercontent.com/6050162/155566644-8fbbff46-30ca-408a-a177-80c86d92ebc1.png">

