### PR TITLE
Remove Ruby Setup From GitHub Actions workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
       - name: Run lint
         run: make lint
 
@@ -21,7 +19,5 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
       - name: Run tests
         run: make test


### PR DESCRIPTION
### What
Remove Ruby Setup From GitHub Actions workflow

### Why
This is redundant, since Docker is used for providing dependencies.

