### PR TITLE
Add more mail related gems to the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem "google-apis-drive_v3"
 gem "govuk_design_system_formbuilder"
 gem "httparty", "~> 0.20.0"
 gem "mysql2", "~> 0.5.2"
+gem "net-imap", require: false
+gem "net-pop", require: false
 gem "net-smtp", require: false
 gem "notifications-ruby-client", "~> 5.3.0"
 gem "pagy", "~> 5.10.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,6 +248,14 @@ GEM
     multipart-post (2.1.1)
     mysql2 (0.5.3)
     nenv (0.3.0)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
     net-protocol (0.1.2)
       io-wait
       timeout
@@ -430,6 +438,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    strscan (3.0.1)
     terminal-table (3.0.1)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.1)
@@ -494,6 +503,8 @@ DEPENDENCIES
   httparty (~> 0.20.0)
   listen (~> 3)
   mysql2 (~> 0.5.2)
+  net-imap
+  net-pop
   net-smtp
   nokogiri
   notifications-ruby-client (~> 5.3.0)
@@ -523,7 +534,7 @@ DEPENDENCIES
   zendesk_api
 
 RUBY VERSION
-   ruby 3.0.3p157
+   ruby 3.1.1p18
 
 BUNDLED WITH
    2.2.32


### PR DESCRIPTION
### What
Add more mail related gems to the Gemfile

### Why
net-smtp was added when upgrading to Ruby 3.1.1, as the tests failed
without it. This wasn't sufficient though to get the app running in
the production Rails environment though, since eager loading is enable
there, and the mail gem also tries to require net/imap and net/pop.

I think there's something wrong with how ActionMailer is being handled
here, as I'm not aware that the app actually uses the mail gem, let
alone SMTP, POP or IMAP, I think GOV.UK Notify is used for all the
sending of emails.

Anyway, as a quick fix, just include more gems in the Gemfile.
