### PR TITLE
Switch to using puma directly in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,4 @@ ARG RUN_PRECOMPILATION=true
 RUN if [ ${RUN_PRECOMPILATION} = 'true' ]; then \
   SECRET_KEY_BASE=unused RAILS_ENV=production bundle exec rails assets:precompile; \
   fi
-CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]
+CMD ["bundle", "exec", "puma", "-p", "3000", "--quiet", "--threads", "8:32"]


### PR DESCRIPTION
### What
Switch to using puma directly in the Dockerfile

### Why
As this allows passing options like --threads, to increase the number
of threads being run.

Currently there are only a maximum of 5 threads being run, which leads
to poor utilisation of the tasks in ECS.
