### PR TITLE
Bump `govuk-frontend` from 3.14.0 to 4.0.1

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -66,7 +66,7 @@
     <footer class="govuk-footer " role="contentinfo">
       <div class="govuk-width-container ">
         <div class="govuk-footer__navigation">
-          <div class="govuk-footer__section">
+          <div class="govuk-footer__section govuk-grid-column-one-third">
             <h2 class="govuk-footer__heading govuk-heading-m">About</h2>
             <ul class="govuk-footer__list govuk-footer__list--columns-1">
               <li class="govuk-footer__list-item">
@@ -80,7 +80,7 @@
               </li>
             </ul>
           </div>
-          <div class="govuk-footer__section">
+          <div class="govuk-footer__section govuk-grid-column-one-third">
             <h2 class="govuk-footer__heading govuk-heading-m">Connect</h2>
             <ul class="govuk-footer__list govuk-footer__list--columns-1">
               <li class="govuk-footer__list-item">
@@ -94,7 +94,7 @@
               </li>
             </ul>
           </div>
-          <div class="govuk-footer__section">
+          <div class="govuk-footer__section govuk-grid-column-one-third">
             <h2 class="govuk-footer__heading govuk-heading-m">Admin</h2>
             <ul class="govuk-footer__list govuk-footer__list--columns-1">
               <li class="govuk-footer__list-item">

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "govwifi-admin",
   "private": true,
   "dependencies": {
-    "govuk-frontend": "^3.14.0",
+    "govuk-frontend": "^4.0.1",
     "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz",
     "html5shiv": "^3.7.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -749,10 +749,10 @@
   dependencies:
     "minimist" "^1.2.5"
 
-"govuk-frontend@^3.14.0":
-  "integrity" "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
-  "resolved" "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz"
-  "version" "3.14.0"
+"govuk-frontend@^4.0.1":
+  "integrity" "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ=="
+  "resolved" "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz"
+  "version" "4.0.1"
 
 "govwifi-shared-frontend@https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.8/govwifi-shared-frontend-0.6.8.tgz":
   "integrity" "sha512-T+v5yq2oDOhqKfGUCxsiLmvU3mBrgFHGUo6x+D6+66KOLTj9YEWBgQoh/xl5W0qc3IKMyBONB2FhzEXttslgkA=="


### PR DESCRIPTION
### What

Bump `govuk-frontend` from 3.14.0 to 4.0.1. Resolves this dependabot PR (#1555). Bumping the version required some minor tweaks (see commit history).

I _highly_ recommend reviewers also look at the [`govuk-frontend` change log](https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md). As part of this PR I went point by point to double check we won't be impacted by the breaking changes but I might have missed something.

### Why

Keeping up to date with third-party libraries reduces the risk for future errors and vulnerabilities.


Link to Trello card (if applicable): https://trello.com/c/LBxSFWom/2048-bump-govuk-frontend-from-3140-to-401-in-govwifi-admin
