### PR TITLE
Change team member related page designs

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,3 +30,16 @@ $govuk-font-url-function: "font-url";
 @import "./utilities/colours";
 @import "./components/*";
 @import "./utilities/*";
+
+// TODO: This shouldn't be needed, but fixes the display for actions
+// within a summary list, like on the team members page
+@include govuk-media-query($from: tablet) {
+  .govuk-summary-list__actions-list {
+    .govuk-summary-list__actions-list-item {
+      display: block;
+      border: 0;
+      margin: 0;
+      padding: 0;
+    }
+  }
+}

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -15,7 +15,28 @@ class MembershipsController < ApplicationController
   end
 
   def index
-    @team_members = sorted_team_members(current_organisation)
+    all_members = current_organisation.memberships.includes(:user)
+
+    @member_groups = [
+      {
+        heading: "Administrators",
+        users: all_members.filter_map { |membership| membership.user if membership.administrator? },
+      },
+      {
+        heading: "Manage locations",
+        users: all_members.filter_map { |membership| membership.user if membership.manage_locations? },
+      },
+      {
+        heading: "View only",
+        users: all_members.filter_map { |membership| membership.user if membership.view_only? },
+      },
+    ]
+
+    @member_groups.each do |entry|
+      entry[:users].sort! do |a, b|
+        [a.name || "", a.email || ""] <=> [b.name || "", b.email || ""]
+      end
+    end
   end
 
   def destroy
@@ -42,11 +63,5 @@ private
     unless current_user.can_manage_team?(current_organisation)
       raise ActionController::RoutingError, "Not Found"
     end
-  end
-
-  def sorted_team_members(organisation)
-    UseCases::Administrator::SortUsers.new(
-      users_gateway: Gateways::OrganisationUsers.new(organisation:),
-    ).execute
   end
 end

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -5,7 +5,11 @@ class MembershipsController < ApplicationController
   def edit; end
 
   def update
-    @membership.update!(membership_params)
+    permission_level = params[:permission_level]
+    @membership.update!(
+      can_manage_team: permission_level == "administrator",
+      can_manage_locations: %w[administrator manage_locations].include?(permission_level),
+    )
     flash[:notice] = "Permissions updated"
     redirect_to updated_permissions_memberships_path
   end
@@ -44,9 +48,5 @@ private
     UseCases::Administrator::SortUsers.new(
       users_gateway: Gateways::OrganisationUsers.new(organisation:),
     ).execute
-  end
-
-  def membership_params
-    params.require(:membership).permit(%i[can_manage_team can_manage_locations])
   end
 end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -25,7 +25,13 @@ private
 
   def add_user_to_organisation(organisation)
     membership = invited_user.memberships.find_or_create_by!(invited_by_id: current_user.id, organisation:)
-    membership.update!(can_manage_team: params[:can_manage_team], can_manage_locations: params[:can_manage_locations])
+
+    permission_level = params[:permission_level]
+    membership.update!(
+      can_manage_team: permission_level == "administrator",
+      can_manage_locations: %w[administrator manage_locations].include?(permission_level),
+    )
+
     send_invite_email(membership) if user_has_confirmed_account?
   end
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -16,4 +16,16 @@ class Membership < ApplicationRecord
   def confirmed?
     !!confirmed_at
   end
+
+  def administrator?
+    can_manage_team? && can_manage_locations?
+  end
+
+  def manage_locations?
+    !can_manage_team? && can_manage_locations?
+  end
+
+  def view_only?
+    !can_manage_team? && !can_manage_locations?
+  end
 end

--- a/app/views/memberships/_table.html.erb
+++ b/app/views/memberships/_table.html.erb
@@ -1,85 +1,57 @@
-<div class='govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0 govuk-!-margin-bottom-3'></div>
 
-<ul class='govuk-list membership-list govuk-width-container govuk-!-margin-left-0'>
-  <% team_members.each do |member| %>
-    <li class='govuk-!-margin-bottom-1'>
-      <div class='govuk-grid-row'>
-        <div class='govuk-grid-column-two-thirds'>
+<% @member_groups.each do |group| %>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+    <%= group[:heading] %>
+    <span class="govuk-hint govuk-!-margin-bottom-0 govuk-!-display-inline-block">
+      (<%= group[:users].length %>)
+    </span>
+  </h2>
+
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <% group[:users].each do |member| %>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= member.name %>
           <% if member.invitation_pending? || member.pending_membership_for?(organisation: current_organisation) %>
-            <h2 class='govuk-heading-m'><%= member.name %>
-              <span class='govuk-!-padding-left-1 govuk-body text-dark-grey'><%= member.email %> (invited)</span>
-            </h2>
-            <% else %>
-            <h2 class='govuk-heading-m'><%= member.name %>
-              <span class='govuk-!-padding-left-1 govuk-body text-dark-grey'><%= member.email %></span>
-            </h2>
+            <span class="govuk-hint govuk-!-margin-bottom-0 govuk-!-display-inline-block">(invited)</span>
           <% end %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= member.email %>
+        </dd>
 
-          <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Permissions</h3>
-
-          <ul role="list" class='govuk-list govuk-!-margin-bottom-2 govuk-!-margin-top-1' id='member-<%= member.id %>-permissions'>
-            <li>
-              <%= image_tag "tick.svg", class: "list-item-padding", height: "30", alt: "" %>
-              <span class="govuk-visually-hidden">Can</span>
-              <span class='govuk-!-padding-left-1'>View logs</span>
-            </li>
-            <li>
-              <%= image_tag "tick.svg", class: "list-item-padding", height: "30", alt: "" %>
-              <span class="govuk-visually-hidden">Can</span>
-              <span class='govuk-!-padding-left-1'>View team members</span>
-            </li>
-            <li>
-              <% if member.can_manage_team?(current_organisation) %>
-                <%= image_tag "tick.svg", class: "list-item-padding", height: "30", alt: "" %>
-                <span class="govuk-visually-hidden">Can</span>
-                <span class='govuk-!-padding-left-1'>Add and remove team members</span>
-              <% else %>
-                <%= image_tag "cross.svg", class: "list-item-padding", height: "30", alt: "" %>
-                <span class="govuk-visually-hidden">Cannot</span>
-                <span class='govuk-!-padding-left-1 text-dark-grey'>Add and remove team members</span>
+        <dd class="govuk-summary-list__actions">
+          <ul class="govuk-summary-list__actions-list">
+            <% if current_user.can_manage_team?(current_organisation) && member.id != current_user.id %>
+              <li class="govuk-summary-list__actions-list-item">
+                <%= link_to(
+                      edit_membership_path(member.membership_for(current_organisation)),
+                      class: "govuk-link govuk-link--no-visited-state",
+                    ) do %>
+                  Edit permissions <span class='govuk-visually-hidden'>for <%= member.email %></span>
+                <% end %>
+              </li>
+              <% if member.totp_enabled? %>
+                <li class="govuk-summary-list__actions-list-item">
+                  <%= link_to({ controller: "users/two_factor_authentication", action: "edit", id: member },
+                              class: "govuk-link govuk-link--no-visited-state") do %>
+                    Reset 2FA <span class='govuk-visually-hidden'>for <%= member.email %></span>
+                  <% end %>
+                </li>
               <% end %>
-            </li>
-            <li>
-              <%= image_tag "tick.svg", class: "list-item-padding", height: "30", alt: "" %>
-              <span class="govuk-visually-hidden">Can</span>
-              <span class='govuk-!-padding-left-1'>View locations and IP addresses</span>
-            </li>
-            <li>
-              <% if member.can_manage_locations?(current_organisation) %>
-                <%= image_tag "tick.svg", class: "list-item-padding", height: "30", alt: "" %>
-                <span class="govuk-visually-hidden">Can</span>
-                <span class='govuk-!-padding-left-1'>Add and remove locations and IP addresses</span>
-              <% else %>
-                <%= image_tag "cross.svg", class: "list-item-padding", height: "30", alt: "" %>
-                <span class="govuk-visually-hidden">Cannot</span>
-                <span class='govuk-!-padding-left-1 text-dark-grey'>Add and remove locations and IP addressess</span>
+              <% if member.invitation_pending? %>
+                <li class="govuk-summary-list__actions-list-item">
+                  <%= button_to("Resend invite",
+                                user_invitation_path(user: { email: member.email }, resend: true),
+                                "aria-label" => "Resend invite to #{member.email}",
+                                method: :post,
+                                class: "button-as-link govuk-body") %>
+                </li>
               <% end %>
-            </li>
+            <% end %>
           </ul>
-        </div>
-
-        <div class='govuk-grid-column-one-third govuk-list govuk-!-padding-right-4 govuk-!-margin-top-0 text-right'>
-          <% if current_user.can_manage_team?(current_organisation) && member.id != current_user.id %>
-            <%= link_to edit_membership_path(member.membership_for(current_organisation)), class: "govuk-link govuk-link--no-visited-state" do %>
-              Edit permissions <span class='govuk-visually-hidden'>for <%= member.email %></span>
-            <% end %>
-            <% if member.totp_enabled? %>
-              <%= link_to({ controller: "users/two_factor_authentication", action: "edit", id: member },
-                          class: "govuk-link govuk-link--no-visited-state") do %>
-                Reset 2FA <span class='govuk-visually-hidden'>for <%= member.email %></span>
-              <% end %>
-            <% end %>
-
-            <% if member.invitation_pending? && current_user.can_manage_team?(current_organisation) %>
-              <%= button_to("Resend invite",
-                            user_invitation_path(user: { email: member.email }, resend: true),
-                            "aria-label" => "Resend invite to #{member.email}", method: :post, class: "button-as-link govuk-body") %>
-            <% end %>
-          <% end %>
-        </div>
+        </dd>
       </div>
-    </li>
-
-    <div class='govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-0 govuk-!-margin-bottom-4'></div>
-  <% end %>
-</ul>
+    <% end %>
+  </dl>
+<% end %>

--- a/app/views/memberships/edit.html.erb
+++ b/app/views/memberships/edit.html.erb
@@ -6,43 +6,84 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-2 govuk-!-margin-bottom-3"><%= @membership.user.name %></h1>
 <p class="govuk-body govuk-!-margin-bottom-4"> <%= @membership.user.email %> </p>
 
-<div class="actions">
-  <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-1"><span class="govuk-label">Permissions </span></legend>
-      <div class="govuk-checkboxes">
-          <%= form_for @membership, url: membership_path(@membership), method: :patch do |form| %>
-           <div class="govuk-checkboxes__item">
-              <input type="checkbox" class='govuk-checkboxes__input' checked disabled>
-              <label class="govuk-label govuk-checkboxes__label">View logs</label>
-            </div>
-             <div class="govuk-checkboxes__item">
-              <input type="checkbox" class='govuk-checkboxes__input' checked disabled>
-              <label class="govuk-label govuk-checkboxes__label">View team members</label>
-            </div>
-            <div class="govuk-checkboxes__item">
-              <%= form.check_box :can_manage_team, class: "govuk-checkboxes__input" %>
-              <label class="govuk-label govuk-checkboxes__label"><%= form.label :can_manage_team, "Add and remove team members" %></label>
-            </div>
-            <div class="govuk-checkboxes__item">
-              <input type="checkbox" class='govuk-checkboxes__input' checked disabled>
-              <label class="govuk-label govuk-checkboxes__label">View locations and IP addresses</label>
-            </div>
-            <div class="govuk-checkboxes__item">
-              <%= form.check_box :can_manage_locations, class: "govuk-checkboxes__input" %>
-              <label class="govuk-label govuk-checkboxes__label"><%= form.label :can_manage_locations, "Add and remove locations and IP addresses" %></label>
-            </div>
-          <div class="govuk-!-margin-top-6">
-            <%= form.submit "Save", class: "govuk-button govuk-!-margin-0 govuk-!-margin-right-4 inline-block" %>
+<%= form_for @membership, url: membership_path(@membership), method: :patch do |form| %>
 
-            <% unless params[:remove_team_member] %>
-              <div class="govuk-body govuk-!-margin-top-2 inline-block">
-                <%= link_to "Remove user from GovWifi admin", edit_membership_path(@membership, remove_team_member: true), class: "govuk-link red-link" %>
-              </div>
-            <% end %>
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset" aria-describedby="sign-in-hint">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+        Permission level
+      </legend>
+      <div class="govuk-radios" data-module="govuk-radios">
+        <div class="govuk-radios__item">
+          <%= radio_button_tag(
+                :permission_level,
+                "administrator",
+                @membership.administrator?,
+                class: "govuk-radios__input",
+                "aria-described-by" => "permission_level_administrator_hint",
+              ) %>
+          <%= label_tag(
+                :permission_level_administrator,
+                "Administrator",
+                class: "govuk-label govuk-radios__label govuk-!-font-weight-bold",
+              ) %>
+          <div id="permission_level_administrator_hint" class="govuk-hint govuk-radios__hint">
+            View locations and IPs, team members, and logs<br>
+            Manage locations and IPs<br>
+            Add or remove team members
           </div>
-          <% end %>
+        </div>
+        <div class="govuk-radios__item">
+          <%= radio_button_tag(
+                :permission_level,
+                "manage_locations",
+                @membership.manage_locations?,
+                class: "govuk-radios__input",
+                "aria-described-by" => "permission_level_manage_locations_hint",
+              ) %>
+          <%= label_tag(
+                :permission_level_manage_locations,
+                "Manage locations",
+                class: "govuk-label govuk-radios__label govuk-!-font-weight-bold",
+              ) %>
+          <div id="permission_level_manage_locations_hint" class="govuk-hint govuk-radios__hint">
+            View locations and IPs, team members, and logs<br>
+            Manage locations and IPs<br>
+            Cannot add or remove team members
+          </div>
+        </div>
+        <div class="govuk-radios__item">
+          <%= radio_button_tag(
+                :permission_level,
+                "view_only",
+                @membership.view_only?,
+                class: "govuk-radios__input",
+                "aria-described-by" => "permission_level_view_only_hint",
+              ) %>
+          <%= label_tag(
+                :permission_level_view_only,
+                "View only",
+                class: "govuk-label govuk-radios__label govuk-!-font-weight-bold",
+              ) %>
+          <div id="permission_level_view_only_hint" class="govuk-hint govuk-radios__hint">
+            View locations and IPs, team members, and logs<br>
+            Cannot manage locations and IPs<br>
+            Cannot add or remove team members
+          </div>
+        </div>
       </div>
     </fieldset>
+  </div>
+
+  <div class="govuk-!-margin-top-6">
+    <%= form.submit "Save", class: "govuk-button govuk-!-margin-0 govuk-!-margin-right-4 inline-block" %>
+
+    <% unless params[:remove_team_member] %>
+      <div class="govuk-body govuk-!-margin-top-2 inline-block">
+        <%= link_to "Remove user from GovWifi admin", edit_membership_path(@membership, remove_team_member: true), class: "govuk-link red-link" %>
+      </div>
+    <% end %>
+  </div>
+<% end %>
   </div>
 </div>

--- a/app/views/memberships/index.html.erb
+++ b/app/views/memberships/index.html.erb
@@ -7,7 +7,7 @@
 
   <div class="govuk-grid-column-one-third text-right">
     <% if current_user.can_manage_team?(current_organisation) %>
-      <%= link_to "Invite team member", new_user_invitation_path, class: "govuk-button", role: "button", draggable: "false", "data-module" => "govuk-button" %>
+      <%= link_to "Invite a team member", new_user_invitation_path, class: "govuk-button", role: "button", draggable: "false", "data-module" => "govuk-button" %>
     <% end %>
   </div>
 </div>

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -19,38 +19,76 @@
   <div class="govuk-grid-column-full govuk-!-padding-left-0">
     <%= f.govuk_email_field :email, label: { text: "Email address" } %>
 
-    <div class="actions">
-      <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-1"><span class="govuk-label">Permissions </span></legend>
-          <div class="govuk-checkboxes">
-              <div class="govuk-checkboxes__item">
-                <input type="checkbox" class='govuk-checkboxes__input' checked disabled>
-                <label class="govuk-label govuk-checkboxes__label">View logs</label>
-              </div>
-              <div class="govuk-checkboxes__item">
-                <input type="checkbox" class='govuk-checkboxes__input' checked disabled>
-                <label class="govuk-label govuk-checkboxes__label">View team members</label>
-              </div>
-              <div class="govuk-checkboxes__item">
-                <%= check_box_tag :can_manage_team, true, true, class: "govuk-checkboxes__input" %>
-              <label class="govuk-label govuk-checkboxes__label"><%= label_tag :can_manage_team, "Add and remove team members" %></label>
-              </div>
-              <div class="govuk-checkboxes__item">
-                <input type="checkbox" class='govuk-checkboxes__input' checked disabled>
-                <label class="govuk-label govuk-checkboxes__label">View locations and IP addresses</label>
-              </div>
-              <div class="govuk-checkboxes__item">
-                <%= check_box_tag :can_manage_locations, true, true, class: "govuk-checkboxes__input" %>
-                <label class="govuk-label govuk-checkboxes__label"><%= label_tag :can_manage_locations, "Add and remove locations and IP addresses" %></label>
-              </div>
-              <% if super_admin? %>
-                <%= hidden_field_tag :organisation_id, @target_organisation.id %>
-            <% end %>
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset" aria-describedby="sign-in-hint">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+          Permission level
+        </legend>
+        <div class="govuk-radios" data-module="govuk-radios">
+          <div class="govuk-radios__item">
+            <%= radio_button_tag(
+                  :permission_level,
+                  "administrator",
+                  false,
+                  class: "govuk-radios__input",
+                  "aria-described-by" => "permission_level_administrator_hint",
+                ) %>
+            <%= label_tag(
+                  :permission_level_administrator,
+                  "Administrator",
+                  class: "govuk-label govuk-radios__label govuk-!-font-weight-bold",
+                ) %>
+            <div id="permission_level_administrator_hint" class="govuk-hint govuk-radios__hint">
+              View locations and IPs, team members, and logs<br>
+              Manage locations and IPs<br>
+              Add or remove team members
+            </div>
           </div>
-        </fieldset>
-      </div>
+          <div class="govuk-radios__item">
+            <%= radio_button_tag(
+                  :permission_level,
+                  "manage_locations",
+                  false,
+                  class: "govuk-radios__input",
+                  "aria-described-by" => "permission_level_manage_locations_hint",
+                ) %>
+            <%= label_tag(
+                  :permission_level_manage_locations,
+                  "Manage locations",
+                  class: "govuk-label govuk-radios__label govuk-!-font-weight-bold",
+                ) %>
+            <div id="permission_level_manage_locations_hint" class="govuk-hint govuk-radios__hint">
+              View locations and IPs, team members, and logs<br>
+              Manage locations and IPs<br>
+              Cannot add or remove team members
+            </div>
+          </div>
+          <div class="govuk-radios__item">
+            <%= radio_button_tag(
+                  :permission_level,
+                  "view_only",
+                  false,
+                  class: "govuk-radios__input",
+                  "aria-described-by" => "permission_level_view_only_hint",
+                ) %>
+            <%= label_tag(
+                  :permission_level_view_only,
+                  "View only",
+                  class: "govuk-label govuk-radios__label govuk-!-font-weight-bold",
+                ) %>
+            <div id="permission_level_view_only_hint" class="govuk-hint govuk-radios__hint">
+              View locations and IPs, team members, and logs<br>
+              Cannot manage locations and IPs<br>
+              Cannot add or remove team members
+            </div>
+          </div>
+        </div>
+      </fieldset>
     </div>
+
+    <% if super_admin? %>
+      <%= hidden_field_tag :organisation_id, @target_organisation.id %>
+    <% end %>
 
     <%= f.govuk_submit "Send invitation email" %>
   </div>

--- a/spec/features/logout_user_after_inactivity_spec.rb
+++ b/spec/features/logout_user_after_inactivity_spec.rb
@@ -15,7 +15,7 @@ describe "Logout users after period of inactivity", type: :feature do
     it "and they navigate to a page" do
       visit memberships_path
 
-      expect(page).to have_content("Invite team member")
+      expect(page).to have_content("Invite a team member")
     end
   end
 
@@ -34,7 +34,7 @@ describe "Logout users after period of inactivity", type: :feature do
       sign_in_user user
       visit memberships_path
 
-      expect(page).to have_content("Invite team member")
+      expect(page).to have_content("Invite a team member")
     end
   end
 end

--- a/spec/features/pending_user_spec.rb
+++ b/spec/features/pending_user_spec.rb
@@ -20,7 +20,7 @@ describe "Inviting an existing user which belongs to an organisation", type: :fe
     end
 
     it "will show pending users which have been invited to an organisation" do
-      expect(page).to have_content("inviteme@gov.uk (invited)")
+      expect(page).to have_content("#{user_2.name} (invited)")
     end
   end
 end

--- a/spec/features/pending_user_spec.rb
+++ b/spec/features/pending_user_spec.rb
@@ -14,7 +14,7 @@ describe "Inviting an existing user which belongs to an organisation", type: :fe
     before do
       sign_in_user user
       visit memberships_path
-      click_on "Invite team member"
+      click_on "Invite a team member"
       fill_in "Email", with: user_2.email
       click_on "Send invitation email"
     end

--- a/spec/features/super_admin/invite_user_to_organisation_spec.rb
+++ b/spec/features/super_admin/invite_user_to_organisation_spec.rb
@@ -91,7 +91,7 @@ describe "Inviting a team member as a super admin", type: :feature do
     end
 
     it "sets the correct target organisation" do
-      click_on "Invite team member"
+      click_on "Invite a team member"
 
       expect(page).to have_current_path(new_user_invitation_path)
       expect(page).to have_content "Invite a team member to #{other_organisation.name}"

--- a/spec/features/team/edit_permissions_spec.rb
+++ b/spec/features/team/edit_permissions_spec.rb
@@ -33,8 +33,7 @@ describe "Edit user permissions", type: :feature do
       before do
         visit memberships_path
         click_link "Edit permissions"
-        uncheck "Add and remove team members"
-        uncheck "Add and remove locations and IP addresses"
+        choose "View only"
         click_on "Save"
       end
 

--- a/spec/features/team/invite_with_permissions_spec.rb
+++ b/spec/features/team/invite_with_permissions_spec.rb
@@ -16,47 +16,38 @@ describe "Set user permissions on invite", type: :feature do
     fill_in "Email", with: invited_email
   end
 
-  context "when setting all the permissions" do
+  context "for administrators" do
     before do
+      choose "Administrator"
       click_on "Send invitation email"
     end
 
-    it "assigns manage team permission to the user" do
+    it "assigns the correct permissions" do
       expect(invited_user.membership_for(organisation).can_manage_team?).to eq(true)
-    end
-
-    it "assigns manage locations permission to the user" do
       expect(invited_user.membership_for(organisation).can_manage_locations?).to eq(true)
     end
   end
 
-  context "when setting only one permission" do
+  context "for the manage locations permissions level" do
     before do
-      uncheck "Add and remove locations and IP addresses"
+      choose "Manage locations"
       click_on "Send invitation email"
     end
 
-    it "assigns manage team permission to the user" do
-      expect(invited_user.membership_for(organisation).can_manage_team?).to eq(true)
-    end
-
-    it "does not assign manage locations permission to the user" do
-      expect(invited_user.membership_for(organisation).can_manage_locations?).to eq(false)
+    it "assigns the correct permissions" do
+      expect(invited_user.membership_for(organisation).can_manage_team?).to eq(false)
+      expect(invited_user.membership_for(organisation).can_manage_locations?).to eq(true)
     end
   end
 
-  context "when setting no permissions" do
+  context "for the view only permissions level" do
     before do
-      uncheck "Add and remove locations and IP addresses"
-      uncheck "Add and remove team members"
+      choose "View only"
       click_on "Send invitation email"
     end
 
-    it "does not assign manage team permission to the user" do
+    it "assigns the correct permissions" do
       expect(invited_user.membership_for(organisation).can_manage_team?).to eq(false)
-    end
-
-    it "does not assign manage locations permission to the user" do
       expect(invited_user.membership_for(organisation).can_manage_locations?).to eq(false)
     end
   end

--- a/spec/features/team/permissions_spec.rb
+++ b/spec/features/team/permissions_spec.rb
@@ -14,8 +14,8 @@ describe "Invite a team member", type: :feature do
       visit memberships_path
     end
 
-    it "shows the invite team member link" do
-      expect(page).to have_link("Invite team member")
+    it "shows the invite a team member link" do
+      expect(page).to have_link("Invite a team member")
     end
 
     it "allows visiting the invites page directly" do

--- a/spec/features/team/view_team_members_spec.rb
+++ b/spec/features/team/view_team_members_spec.rb
@@ -15,16 +15,6 @@ describe "View team members of my organisation", type: :feature do
     end
 
     context "when there is only one user in an organisation" do
-      let(:correct_permissions) do
-        [
-          "Can View logs",
-          "Can View team members",
-          "Can Add and remove team members",
-          "Can View locations and IP addresses",
-          "Can Add and remove locations and IP addresses",
-        ]
-      end
-
       before do
         sign_in_user user
         visit memberships_path
@@ -33,16 +23,10 @@ describe "View team members of my organisation", type: :feature do
       it "shows the users email" do
         expect(page).to have_content(user.email)
       end
-
-      it "displays all the permissions" do
-        selector = "#member-#{user.id}-permissions"
-        array_of_permissions = find(selector).all("li").collect(&:text)
-        expect(array_of_permissions).to eq(correct_permissions)
-      end
     end
 
     context "when there are many users in my organisation" do
-      let!(:user_1) { create(:user, email: "bill@example.gov.uk", name: nil, organisations: [organisation]) }
+      let!(:user_1) { create(:user, name: "bill", email: "bill@example.gov.uk", organisations: [organisation]) }
       let!(:user_2) { create(:user, name: "amada", organisations: [organisation]) }
       let!(:user_3) { create(:user, name: "zara", organisations: [organisation]) }
 


### PR DESCRIPTION
### What
Change the designs for 3 pages related to team members within an organisation.

### Why
The new design is simpler, which is better for users.

### After screenshots

![image](https://user-images.githubusercontent.com/1130010/158354722-9475d152-f57e-4fe3-9fe0-d0a7c45d1dbe.png)
![image](https://user-images.githubusercontent.com/1130010/158354485-f6e44004-f936-49ac-8581-2c8507e5a8f3.png)
![image](https://user-images.githubusercontent.com/1130010/158354614-0ce99bdd-05a1-4124-865a-23ac1e072053.png)



Link to Trello card: https://trello.com/c/qGBxPnU0/2087-changes-to-invite-team-member-and-edit-team-member-page-2 and https://trello.com/c/Xs1ICSKc/2086-display-admin-users-and-their-roles-in-table-1