### PR TITLE
Remove the super_admin field from organisations

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -18,7 +18,6 @@ class Organisation < ApplicationRecord
     .group("organisations.id, active_storage_attachments.created_at")
     .order("#{sort_column} #{sort_direction}")
   }
-  scope :super_admins, -> { where(super_admin: true) }
 
   def validate_in_register?
     unless Organisation.fetch_organisations_from_register.include?(name)

--- a/db/migrate/20220310094230_remove_super_admin_from_organisation.rb
+++ b/db/migrate/20220310094230_remove_super_admin_from_organisation.rb
@@ -1,0 +1,5 @@
+class RemoveSuperAdminFromOrganisation < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :organisations, :super_admin, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_16_134317) do
+ActiveRecord::Schema.define(version: 2022_03_10_094230) do
 
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -96,7 +96,6 @@ ActiveRecord::Schema.define(version: 2022_02_16_134317) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "service_email"
-    t.boolean "super_admin", default: false
     t.index ["name"], name: "index_organisations_on_name", unique: true
   end
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -186,19 +186,6 @@ describe Organisation do
     end
   end
 
-  describe "super_admins scope" do
-    let(:organisation) { create(:organisation) }
-    let(:super_admin_organisation) { create(:organisation, super_admin: true) }
-
-    it "finds the super admin organisation" do
-      expect(described_class.super_admins).to include(super_admin_organisation)
-    end
-
-    it "excludes other organisations" do
-      expect(described_class.super_admins).not_to include(organisation)
-    end
-  end
-
   describe ".all_as_csv" do
     subject(:csv) { CSV.parse(described_class.all_as_csv, headers: true) }
 


### PR DESCRIPTION
### What
Remove the super_admin field from organisations

### Why
This is now managed at the user level, rather than through association
with a super_admin organisation.


Link to Trello card: https://trello.com/c/08QFeITR/2093-admin-site-migrate-from-super-admin-organisations-to-individual-super-admins-5