### PR TITLE
Add left-side border to active menu item in navigation side-bar

### DIFF
--- a/app/assets/stylesheets/components/left_nav.scss
+++ b/app/assets/stylesheets/components/left_nav.scss
@@ -14,5 +14,8 @@
   .active {
     font-weight: bold;
     text-decoration: none;
+    margin-left: -14px;
+    padding-left: 10px;
+    border-left: 4px solid #1d70b8;
   }
 }


### PR DESCRIPTION


### What
Add left-side border to active menu item in navigation side-bar

### Why
Make it clearer which page the user is currently on and make
compliant with design system


Link to Trello card (if applicable): 

https://trello.com/c/gm1r5gXK/1948-update-admin-side-navigation
