### PR TITLE
Replace 'back to list' breadcrumb with 'Cancel' link

### DIFF
--- a/app/views/locations/new.erb
+++ b/app/views/locations/new.erb
@@ -6,7 +6,6 @@
   <%= f.govuk_error_summary %>
   <div class='govuk-grid-row'>
     <div class='govuk-grid-column-full'>
-      <%= link_to 'Back to list', ips_path, class: 'govuk-back-link' %>
       <h1 class='govuk-heading-l'>Add a location</h1>
     </div>
     <div class='govuk-grid-column-full'>
@@ -14,6 +13,7 @@
                               hint: { text: "For example, 10 High Street, London" } %>
       <%= f.govuk_text_field :postcode %>
       <%= f.govuk_submit "Add location" %>
+      <p><%= link_to 'Cancel', ips_path, class: 'govuk-link--no-visited-state govuk-body' %></p>
     </div>
   </div>
 <% end %>

--- a/spec/features/locations/add_new_location_spec.rb
+++ b/spec/features/locations/add_new_location_spec.rb
@@ -13,6 +13,10 @@ describe "Add location", type: :feature do
     expect(page).to have_content("Add a location")
   end
 
+  it "displays a Cancel link" do
+    expect(page).to have_link("Cancel", href: "/ips")
+  end
+
   context "when adding the first location" do
     context "with valid IP data" do
       before do


### PR DESCRIPTION
### What
Replace 'back to list' breadcrumb with 'Cancel' link

### Why
More clearly represents the navigation which takes place
when clicking on the link, and generally easier to see.


Link to Trello card (if applicable): 

https://trello.com/c/1DbWYmzf/2085-improve-the-ui-of-the-add-location-page-through-rewording-buttons-1