### PR TITLE
Improve membership permissions

### DIFF
--- a/db/migrate/20220316111522_change_membership_permissions_to_not_null.rb
+++ b/db/migrate/20220316111522_change_membership_permissions_to_not_null.rb
@@ -1,0 +1,6 @@
+class ChangeMembershipPermissionsToNotNull < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :memberships, :can_manage_team, false, false
+    change_column_null :memberships, :can_manage_locations, false, false
+  end
+end

--- a/db/migrate/20220316112023_change_membership_can_manage_locations.rb
+++ b/db/migrate/20220316112023_change_membership_can_manage_locations.rb
@@ -1,0 +1,7 @@
+class ChangeMembershipCanManageLocations < ActiveRecord::Migration[6.1]
+  def up
+    execute "UPDATE memberships SET can_manage_locations = 1 WHERE can_manage_team = 1 AND can_manage_locations = 0"
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_16_111522) do
+ActiveRecord::Schema.define(version: 2022_03_16_112023) do
 
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_10_094230) do
+ActiveRecord::Schema.define(version: 2022_03_16_111522) do
 
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -80,8 +80,8 @@ ActiveRecord::Schema.define(version: 2022_03_10_094230) do
     t.bigint "user_id", null: false
     t.integer "invited_by_id"
     t.datetime "confirmed_at"
-    t.boolean "can_manage_team", default: true
-    t.boolean "can_manage_locations", default: true
+    t.boolean "can_manage_team", default: true, null: false
+    t.boolean "can_manage_locations", default: true, null: false
     t.index ["organisation_id"], name: "index_memberships_on_organisation_id"
     t.index ["user_id"], name: "index_memberships_on_user_id"
   end


### PR DESCRIPTION
### What
Remove the NULLs from the membership permissions and set `can_manage_locations` to true where `can_manage_team` is true. 

### Why
So that the NULLs aren't confusing, and the values for these two fields match up with the 3 permission levels.


Link to Trello card: https://trello.com/c/qGBxPnU0/2087-changes-to-invite-team-member-and-edit-team-member-page-2