### PR TITLE
Tweak the back link on the invite a team member page

### DIFF
--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -8,13 +8,12 @@
 
   <%= f.govuk_error_summary %>
 
-  <% if super_admin? %>
-    <%= link_to "Back to organisation", super_admin_organisation_path(@target_organisation.id), class: "govuk-back-link" %>
-    <h1 class="govuk-heading-l">Invite a team member to <%= @target_organisation.name %> </h1>
-  <% else %>
-    <%= link_to "Back to list", memberships_path, class: "govuk-back-link" %>
-    <h1 class="govuk-heading-l">Invite a team member</h1>
-  <% end %>
+  <h1 class="govuk-heading-l">
+    Invite a team member
+    <% if super_admin? %>
+      to <%= @target_organisation.name %>
+    <% end %>
+  </h1>
 
   <div class="govuk-grid-column-full govuk-!-padding-left-0">
     <%= f.govuk_email_field :email, label: { text: "Email address" } %>
@@ -91,5 +90,13 @@
     <% end %>
 
     <%= f.govuk_submit "Send invitation email" %>
+
+    <p class="govuk-body">
+      <% if super_admin? %>
+        <%= link_to "Cancel", super_admin_organisation_path(@target_organisation.id), class: "govuk-link--no-visited-state" %>
+      <% else %>
+        <%= link_to "Cancel", memberships_path, class: "govuk-link--no-visited-state" %>
+      <% end %>
+    </p>
   </div>
 <% end %>

--- a/spec/features/super_admin/invite_user_to_organisation_spec.rb
+++ b/spec/features/super_admin/invite_user_to_organisation_spec.rb
@@ -16,8 +16,8 @@ describe "Inviting a team member as a super admin", type: :feature do
   include_context "when using the notifications service"
   include_context "when sending an invite email"
 
-  it "will take the user to the organisation when they click 'back to organisation'" do
-    click_on "Back to organisation"
+  it "will take the user to the organisation when they click 'Cancel'" do
+    click_on "Cancel"
     expect(page).to have_current_path(super_admin_organisation_path(organisation))
   end
 


### PR DESCRIPTION
### What
Tweak the back link on the invite a team member page

### Why
So that it's by the button at the bottom. This should be easier for
users to see.

The behaviour here is still not great, since the button does different
things for super admins, but that should be fixable in the future.


Link to Trello card: https://trello.com/c/qGBxPnU0/2087-changes-to-invite-team-member-and-edit-team-member-page-2