### PR TITLE
Update no organisation redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   include Pagy::Backend
   include GovWifiAuthenticatable
 
+  before_action :redirect_user_without_organisation, unless: :current_action_is_valid?
   helper_method :current_organisation, :super_admin?
   helper_method :sidebar
   helper_method :subnav
@@ -20,6 +21,13 @@ class ApplicationController < ActionController::Base
     current_user&.is_super_admin?
   end
 
+  def redirect_user_with_no_organisation
+    if !current_user&.is_super_admin? && current_user&.organisations&.empty?
+      msg = "You do not belong to an organisation. Please mention this in your support request."
+      redirect_to signed_in_new_help_path, notice: msg
+    end
+  end
+
 protected
 
   def subnav
@@ -32,6 +40,10 @@ protected
 
   def authorise_manage_locations
     redirect_to(root_path) unless current_user.can_manage_locations?(current_organisation)
+  end
+
+  def current_action_is_valid?
+    devise_controller? || (controller_name == "help" && valid_help_actions.include?(action_name))
   end
 
   def valid_help_actions

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   include Pagy::Backend
   include GovWifiAuthenticatable
 
-  before_action :redirect_user_without_organisation, unless: :current_action_is_valid?
+  before_action :redirect_user_with_no_organisation, unless: :devise_controller?
   helper_method :current_organisation, :super_admin?
   helper_method :sidebar
   helper_method :subnav
@@ -40,13 +40,5 @@ protected
 
   def authorise_manage_locations
     redirect_to(root_path) unless current_user.can_manage_locations?(current_organisation)
-  end
-
-  def current_action_is_valid?
-    devise_controller? || (controller_name == "help" && valid_help_actions.include?(action_name))
-  end
-
-  def valid_help_actions
-    @valid_help_actions ||= %w[signed_in create].freeze
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   def current_organisation
     if session[:organisation_id] && current_user.organisations.pluck(:id).include?(session[:organisation_id].to_i)
       Organisation.find(session[:organisation_id])
-    elsif !current_user.is_super_admin?
+    else
       current_user.organisations.first
     end
   end
@@ -22,9 +22,14 @@ class ApplicationController < ActionController::Base
   end
 
   def redirect_user_with_no_organisation
-    if !current_user&.is_super_admin? && current_user&.organisations&.empty?
-      msg = "You do not belong to an organisation. Please mention this in your support request."
-      redirect_to signed_in_new_help_path, notice: msg
+    if current_user&.organisations&.empty?
+      redirection_url, message = if current_user&.is_super_admin?
+                                   [super_admin_organisations_path, "You do not belong to an organisation."]
+                                 else
+                                   [signed_in_new_help_path,
+                                    "You do not belong to an organisation. Please mention this in your support request."]
+                                 end
+      redirect_to redirection_url, notice: message
     end
   end
 

--- a/app/controllers/concerns/gov_wifi_authenticatable.rb
+++ b/app/controllers/concerns/gov_wifi_authenticatable.rb
@@ -3,9 +3,7 @@ module GovWifiAuthenticatable
   included do
     before_action :authenticate_user!, except: :error
     before_action :confirm_two_factor_setup
-
     before_action :configure_devise_permitted_parameters, if: :devise_controller?
-    before_action :redirect_user_with_no_organisation, unless: :current_action_is_valid?
   end
 
   def error
@@ -22,16 +20,5 @@ module GovWifiAuthenticatable
 
   def configure_devise_permitted_parameters
     devise_parameter_sanitizer.permit(:accept_invitation, keys: [:name])
-  end
-
-  def redirect_user_with_no_organisation
-    if !current_user&.is_super_admin? && current_user&.organisations&.empty?
-      msg = "You do not belong to an organisation. Please mention this in your support request."
-      redirect_to signed_in_new_help_path, notice: msg
-    end
-  end
-
-  def current_action_is_valid?
-    devise_controller? || (controller_name == "help" && valid_help_actions.include?(action_name))
   end
 end

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,6 +1,7 @@
 class HelpController < ApplicationController
   skip_before_action :authenticate_user!
   before_action :redirect_signed_in_user, only: :new
+  skip_before_action :redirect_user_with_no_organisation, only: %i[signed_in create]
 
   def new
     case params[:choice]

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,6 @@
 class HomeController < ApplicationController
+  skip_before_action :redirect_user_with_no_organisation, if: :super_admin?
+
   def index
     destination =
       if !current_organisation && current_user.is_super_admin?

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,4 +1,6 @@
 class LogsController < ApplicationController
+  skip_before_action :redirect_user_with_no_organisation
+
   def index
     if valid_search_params.blank?
       redirect_to(new_logs_search_path) && return

--- a/app/controllers/logs_searches_controller.rb
+++ b/app/controllers/logs_searches_controller.rb
@@ -1,4 +1,5 @@
 class LogsSearchesController < ApplicationController
+  skip_before_action :redirect_user_with_no_organisation
   def create
     @search = LogsSearch.new(search_params)
     @locations = ordered_locations
@@ -45,6 +46,6 @@ private
   end
 
   def ordered_locations
-    current_organisation.locations.order([:address])
+    current_organisation.nil? ? [] : current_organisation.locations.order([:address])
   end
 end

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -1,6 +1,7 @@
 class MembershipsController < ApplicationController
   before_action :set_membership, only: %i[edit update destroy]
   before_action :validate_can_manage_team, only: %i[edit update destroy]
+  skip_before_action :redirect_user_with_no_organisation, only: %i[destroy edit update]
 
   def edit; end
 

--- a/app/controllers/super_admin_controller.rb
+++ b/app/controllers/super_admin_controller.rb
@@ -1,4 +1,5 @@
 class SuperAdminController < ApplicationController
+  skip_before_action :redirect_user_with_no_organisation
   before_action :authorise_admin
 
   def authorise_admin

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -3,5 +3,11 @@ FactoryBot.define do
     address { Faker::Address.street_address }
     postcode { Faker::Address.postcode }
     association :organisation
+
+    trait :with_organisation do
+      after(:create) do |location|
+        create(:organisation, locations: [location])
+      end
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,8 +8,6 @@ FactoryBot.define do
     confirmed_at { Time.zone.now }
 
     trait :super_admin do
-      otp_secret_key { "ABCDEFGHIJKLMNOPQRSTUVWXYZ" } # 2FA is set up
-
       is_super_admin { true }
     end
 

--- a/spec/features/authentication/reset_password_spec.rb
+++ b/spec/features/authentication/reset_password_spec.rb
@@ -67,7 +67,7 @@ describe "Resetting a password", type: :feature do
   end
 
   context "when clicking on the reset link" do
-    let(:user) { create(:user, :with_organisation) }
+    let(:user) { create(:user) }
 
     before do
       visit new_user_password_path

--- a/spec/features/authentication/set_up_two_factor_authentication_spec.rb
+++ b/spec/features/authentication/set_up_two_factor_authentication_spec.rb
@@ -1,8 +1,7 @@
 require "support/notifications_service"
 
 describe "Set up two factor authentication", type: :feature do
-  let(:organisation) { create(:organisation) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :with_organisation) }
 
   include_context "when using the notifications service"
 
@@ -70,11 +69,19 @@ describe "Set up two factor authentication", type: :feature do
       expect(page).to have_current_path(new_organisation_settings_path)
     end
 
-    context "with a super admin user" do
-      let(:user) { create(:user, :super_admin, otp_secret_key: nil) }
+    context "with a super admin user without an organisation" do
+      let(:user) { create(:user, :super_admin) }
 
       it "redirects the user to the super admin organisations page" do
         expect(page).to have_current_path(super_admin_organisations_path)
+      end
+    end
+
+    context "with a super admin user with an organisation" do
+      let(:user) { create(:user, :with_organisation, :super_admin) }
+
+      it "redirects the user to the organisation setttings page" do
+        expect(page).to have_current_path(new_organisation_settings_path)
       end
     end
   end

--- a/spec/features/logging/view_logs_spec.rb
+++ b/spec/features/logging/view_logs_spec.rb
@@ -28,7 +28,7 @@ describe "View authentication requests for an IP", type: :feature do
 
   context "as a super admin" do
     before do
-      super_admin_user = create(:user, :with_organisation, :super_admin)
+      super_admin_user = create(:user, :super_admin)
       sign_in_user super_admin_user
       visit logs_path(ip:)
     end

--- a/spec/features/super_admin/logging/view_logs_for_ip_spec.rb
+++ b/spec/features/super_admin/logging/view_logs_for_ip_spec.rb
@@ -1,6 +1,6 @@
 describe "View authentication requests for an IP", type: :feature do
-  let(:user) { create(:user, :super_admin, :with_organisation) }
-  let(:user_location) { create(:location, organisation: user.organisations.first) }
+  let(:user) { create(:user, :super_admin) }
+  let(:user_location) { create(:location, :with_organisation) }
   let(:ip_1) { create(:ip, location: user_location, address: "1.2.3.4") }
 
   let(:user_2) { create(:user, :with_organisation) }
@@ -16,9 +16,6 @@ describe "View authentication requests for an IP", type: :feature do
     sign_in_user user
 
     visit root_path
-
-    click_on "Switch organisation"
-    click_on user.organisations.first.name
 
     visit ip_new_logs_search_path
   end

--- a/spec/features/super_admin/logging/view_logs_for_username_spec.rb
+++ b/spec/features/super_admin/logging/view_logs_for_username_spec.rb
@@ -1,24 +1,15 @@
 describe "View authentication requests for a username", type: :feature do
   let(:username) { "Larry" }
 
-  let(:super_admin) { create(:user, :with_organisation, :super_admin) }
-  let(:super_admin_location) { create(:location, organisation: super_admin.organisations.first) }
-  let(:super_admin_ip) { create(:ip, location: super_admin_location) }
+  let(:super_admin) { create(:user, :super_admin) }
 
-  let(:organisation) { create(:organisation) }
-  let(:location) { create(:location, organisation:) }
-  let(:ip) { create(:ip, location:) }
-
-  let(:organisation_2) { create(:organisation) }
-  let(:location_2) { create(:location, organisation: organisation_2) }
-  let(:ip_2) { create(:ip, location: location_2) }
+  let(:organisations) { create_list(:organisation, 3) }
+  let(:locations) { organisations.map { |organisation| create(:location, organisation:) } }
+  let(:ip) { locations.map { |location| create(:ip, location:) } }
 
   before do
     sign_in_user super_admin
     visit root_path
-
-    click_on "Switch organisation"
-    click_on super_admin.organisations.first.name
 
     visit new_logs_search_path
     choose "Username"
@@ -27,10 +18,10 @@ describe "View authentication requests for a username", type: :feature do
 
   context "when there are results from multiple organisations and users" do
     before do
-      create(:session, start: 3.days.ago, username:, siteIP: super_admin_ip.address, success: true)
-      create(:session, start: 3.days.ago, username:, siteIP: ip.address, success: true)
-      create(:session, start: 3.days.ago, username:, siteIP: ip_2.address, success: true)
-      create(:session, start: 3.days.ago, username: "user2", siteIP: ip_2.address, success: true)
+      create(:session, start: 3.days.ago, username:, siteIP: ip[0].address, success: true)
+      create(:session, start: 3.days.ago, username:, siteIP: ip[1].address, success: true)
+      create(:session, start: 3.days.ago, username:, siteIP: ip[2].address, success: true)
+      create(:session, start: 3.days.ago, username: "user2", siteIP: ip[2].address, success: true)
 
       fill_in "Username", with: username
       click_on "Show logs"

--- a/spec/features/super_admin/lookup_wifi_user_contact_details_spec.rb
+++ b/spec/features/super_admin/lookup_wifi_user_contact_details_spec.rb
@@ -1,5 +1,5 @@
 describe "Lookup wifi user contact details", type: :feature do
-  let(:user) { create(:user, :with_organisation, :super_admin) }
+  let(:user) { create(:user, :super_admin) }
   let(:search_term) { "" }
   let(:contact) { "wifi.user@govwifi.org" }
 
@@ -9,9 +9,6 @@ describe "Lookup wifi user contact details", type: :feature do
     sign_in_user user
 
     visit root_path
-
-    click_on "Switch organisation"
-    click_on user.organisations.first.name
 
     visit new_logs_search_path
 

--- a/spec/features/super_admin/organisations/sort_organisation_list_spec.rb
+++ b/spec/features/super_admin/organisations/sort_organisation_list_spec.rb
@@ -1,13 +1,14 @@
 describe "Sorting the organisations list", type: :feature do
   context "when super admin views the list" do
-    let!(:super_admin) { create(:user, :with_organisation, :super_admin) }
+    let!(:super_admin) { create(:user, :super_admin) }
 
     before do
+      create(:organisation, name: "Gov Org 1", created_at: "10 Dec 2015")
       create(:organisation, name: "Gov Org 2", created_at: "10 Dec 2013")
       create(:organisation, name: "Gov Org 3", created_at: "10 Feb 2014")
 
       sign_in_user super_admin
-      visit root_path
+      visit super_admin_organisations_path
     end
 
     context "when sorting by account creation date" do

--- a/spec/features/super_admin/organisations/view_organisation_list_spec.rb
+++ b/spec/features/super_admin/organisations/view_organisation_list_spec.rb
@@ -19,7 +19,7 @@ describe "View a list of signed up organisations", type: :feature do
   end
 
   context "when logged in as an admin" do
-    let(:user) { create(:user, :with_organisation, :super_admin) }
+    let(:user) { create(:user, :super_admin) }
 
     before do
       sign_in_user user
@@ -89,7 +89,7 @@ describe "View a list of signed up organisations", type: :feature do
 
       it "summarises the totals" do
         expect(page).to have_content(
-          "GovWifi is in 6 locations across 3 organisations.",
+          "GovWifi is in 6 locations across 2 organisations.",
         )
       end
 

--- a/spec/features/super_admin/upload_download_mou_spec.rb
+++ b/spec/features/super_admin/upload_download_mou_spec.rb
@@ -1,7 +1,8 @@
 describe "Upload and download the MOU template", type: :feature do
-  let(:super_admin) { create(:user, :with_organisation, :super_admin) }
+  let(:super_admin) { create(:user, :super_admin) }
 
   before do
+    create(:organisation)
     sign_in_user super_admin
     visit super_admin_mou_index_path
   end

--- a/spec/features/team/reset_2fa_spec.rb
+++ b/spec/features/team/reset_2fa_spec.rb
@@ -5,7 +5,7 @@ describe "Reset two factor authentication", type: :feature do
   let(:org_admin_user_2) { create(:user, :with_2fa, organisations: [organisation]) }
   let(:org_admin_user_3) { create(:user, organisations: [organisation]) } # no 2fa
 
-  let(:super_admin_user) { create(:user, :super_admin, :with_organisation) }
+  let(:super_admin_user) { create(:user, :super_admin, :with_2fa) }
 
   context "when logged in as a super admin user" do
     before do
@@ -48,14 +48,6 @@ describe "Reset two factor authentication", type: :feature do
       click_on "Yes, reset two factor authentication"
 
       expect(page).to have_content("Two factor authentication has been reset")
-    end
-
-    context "when visiting the superadmin team" do
-      it "shows a link to reset their own 2FA" do
-        visit super_admin_organisation_path(super_admin_user.organisations.first)
-
-        expect(page).to have_content("Reset 2FA", count: 1)
-      end
     end
   end
 

--- a/spec/features/user_with_no_organisation_memberships_spec.rb
+++ b/spec/features/user_with_no_organisation_memberships_spec.rb
@@ -1,39 +1,67 @@
 describe "A confirmed user with no organisation memberships logs in", type: :feature do
-  let(:user) { create(:user, organisations: []) }
+  context "a regular user" do
+    let(:user) { create(:user, organisations: []) }
 
-  context "with an existing confirmed user" do
+    context "with an existing confirmed user" do
+      before do
+        sign_in_user user
+        visit root_path
+      end
+
+      it "redirects to the help path" do
+        expect(page).to have_current_path(signed_in_new_help_path)
+      end
+
+      it "prints an instruction" do
+        expect(page).to have_content("You do not belong to an organisation")
+      end
+
+      context "when the user selects a specific type of support" do
+        let(:zendesk_client) { instance_double(Gateways::ZendeskSupportTickets) }
+
+        before do
+          allow(Gateways::ZendeskSupportTickets).to receive(:new)
+            .and_return(zendesk_client)
+          allow(zendesk_client).to receive(:create!)
+        end
+
+        it "presents the user with a support request form" do
+          expect(page).to have_content("Support")
+        end
+
+        it "allows the user to submit a support request" do
+          fill_in "Tell us about your issue", with: "Help!"
+          click_on "Send support request"
+
+          expect(page).to have_http_status(200)
+        end
+      end
+    end
+  end
+  context "a super admin" do
+    let(:user) { create(:user, :super_admin) }
     before do
       sign_in_user user
+    end
+    it "redirects to the super admin organisations page when visiting the root" do
       visit root_path
+      expect(page).to have_current_path(super_admin_organisations_path)
     end
-
-    it "redirects to the help path" do
-      expect(page).to have_current_path(signed_in_new_help_path)
+    it "redirects to the super admin organisations page when visiting the current organisations locations page" do
+      visit ips_path
+      expect(page).to have_current_path(super_admin_organisations_path)
     end
-
-    it "prints an instruction" do
-      expect(page).to have_content("You do not belong to an organisation")
+    it "redirects to the super admin organisations page when visiting the current organisations team members page" do
+      visit memberships_path
+      expect(page).to have_current_path(super_admin_organisations_path)
     end
-
-    context "when the user selects a specific type of support" do
-      let(:zendesk_client) { instance_double(Gateways::ZendeskSupportTickets) }
-
-      before do
-        allow(Gateways::ZendeskSupportTickets).to receive(:new)
-          .and_return(zendesk_client)
-        allow(zendesk_client).to receive(:create!)
-      end
-
-      it "presents the user with a support request form" do
-        expect(page).to have_content("Support")
-      end
-
-      it "allows the user to submit a support request" do
-        fill_in "Tell us about your issue", with: "Help!"
-        click_on "Send support request"
-
-        expect(page).to have_http_status(200)
-      end
+    it "redirects to the super admin organisations page when visiting the current organisations settings page" do
+      visit settings_path
+      expect(page).to have_current_path(super_admin_organisations_path)
+    end
+    it "can render the log page" do
+      visit new_logs_search_path
+      expect(page).to have_content("How do you want to filter these logs?")
     end
   end
 end


### PR DESCRIPTION
### What
The logic redirecting users when they are not part of an organisation needs to be improved. Currently, some useful pages, such as logging, cannot be accessed by a super admin that is not part of an organisations. 

### Why
We want to remove the requirement that a super admin has to be a member of an organisation. Only those pages that are specifically scoped to an org should disallow users without organisations.

Link to Trello card (if applicable): 
To be created