### PR TITLE
Make settings page consistent with new design

### DIFF
--- a/app/views/settings/_account.html.erb
+++ b/app/views/settings/_account.html.erb
@@ -1,22 +1,33 @@
 <h2 class="govuk-heading-m">Your account</h2>
 
-<table class="govuk-table">
+<table class="govuk-table govuk-!-margin-bottom-9">
   <caption class="govuk-visually-hidden">Settings</caption>
   <thead class="govuk-table__head govuk-visually-hidden">
     <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Setting</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Setting</th>
       <th scope="col" class="govuk-table__header">Value</th>
       <th scope="col" class="govuk-table__header">Action</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__cell govuk-!-width-one-half govuk-!-font-weight-regular">
+      <th scope="row" class="govuk-table__cell govuk-!-width-one-third">
+        Email Address
+      </th>
+      <td class="govuk-table__cell">
+        <%= current_user.email %>
+      </td>
+      <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__cell govuk-!-width-one-third">
         Password
       </th>
       <td class="govuk-table__cell"></td>
       <td class="govuk-table__cell govuk-table__cell--numeric">
-        <%= link_to "Change your password", edit_user_registration_path, class: "govuk-link govuk-link--no-visited-state" %>
+        <%= link_to edit_user_registration_path, class: "govuk-link govuk-link--no-visited-state" do %>
+          Change <span class='govuk-visually-hidden'>your password</span>
+        <% end %>
       </td>
     </tr>
   </tbody>

--- a/app/views/settings/_organisation.html.erb
+++ b/app/views/settings/_organisation.html.erb
@@ -1,17 +1,17 @@
 <h2 class="govuk-heading-m">Organisation</h2>
 
-<table class="govuk-table">
+<table class="govuk-table govuk-!-margin-bottom-9">
   <caption class="govuk-visually-hidden">Settings</caption>
   <thead class="govuk-table__head govuk-visually-hidden">
     <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Setting</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Setting</th>
       <th scope="col" class="govuk-table__header">Value</th>
       <th scope="col" class="govuk-table__header">Action</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__cell govuk-!-width-one-half govuk-!-font-weight-regular">
+      <th scope="row" class="govuk-table__cell govuk-!-width-one-third">
         Service email
       </th>
       <td class="govuk-table__cell">
@@ -24,8 +24,8 @@
       </td>
     </tr>
     <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__cell govuk-!-width-one-half govuk-!-font-weight-regular">
-        Memorandum of understanding
+      <th scope="row" class="govuk-table__cell govuk-!-width-one-third">
+        Memorandum of understanding (MOU)
       </th>
       <% if @current_org_signed_mou %>
         <td class="govuk-table__cell">
@@ -37,11 +37,14 @@
           <% end %>
         </td>
       <% else %>
-        <td class="govuk-table__cell" colspan="2">
+        <td class="govuk-table__cell">
           Not signed
           <p class="govuk-hint govuk-!-margin-top-1 govuk-!-margin-bottom-0">
-            You must <%= link_to "sign the memorandum of understanding", mou_index_path, class: "govuk-link govuk-link--no-visited-state" %> to use GovWifi
+            You must sign the MOU to use GovWifi
           </p>
+        </td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">
+          <%= link_to "Sign MOU", mou_index_path, class: "govuk-link govuk-link--no-visited-state" %>
         </td>
       <% end %>
     </tr>

--- a/app/views/settings/_servers.html.erb
+++ b/app/views/settings/_servers.html.erb
@@ -1,17 +1,25 @@
 <h2 class="govuk-heading-m">GovWifi servers</h2>
 
-<table class="govuk-table govuk-!-margin-bottom-3">
+<p class="govuk-hint govuk-!-margin-top-0 govuk-!-margin-bottom-0">
+  The
+  <%= link_to "offer GovWifi documentation",
+              "https://docs.wifi.service.gov.uk/set_up/#step-3-create-a-new-wifi-installation",
+              class: "govuk-link govuk-link--no-visited-state" %>
+  explains how to connect your authenticators to these servers
+</p>
+
+<table class="govuk-table govuk-!-margin-bottom-9">
   <caption class="govuk-visually-hidden">Settings</caption>
   <thead class="govuk-table__head govuk-visually-hidden">
     <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Setting</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-third">Setting</th>
       <th scope="col" class="govuk-table__header">Value</th>
       <th scope="col" class="govuk-table__header">Action</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__cell govuk-!-width-one-half govuk-!-font-weight-regular">
+      <th scope="row" class="govuk-table__cell govuk-!-width-one-third">
         London
       </th>
       <td class="govuk-table__cell">
@@ -25,7 +33,7 @@
       </td>
     </tr>
     <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__cell govuk-!-width-one-half govuk-!-font-weight-regular">
+      <th scope="row" class="govuk-table__cell govuk-!-width-one-third">
         Dublin
       </th>
       <td class="govuk-table__cell">
@@ -34,19 +42,6 @@
             <li><%= render partial: "shared/ip_address", locals: { ip: } %></li>
           <% end %>
         </ul>
-      </td>
-      <td class="govuk-table__cell">
-      </td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__cell govuk-!-width-one-half govuk-!-font-weight-regular">
-        <span class="govuk-visually-hidden">Documentation</span>
-      </th>
-      <td class="govuk-table__cell">
-        <p class="govuk-hint govuk-!-margin-top-0 govuk-!-margin-bottom-0">
-          The
-          <%= link_to "offer GovWifi documentation", "https://docs.wifi.service.gov.uk/set_up/#step-3-create-a-new-wifi-installation", class: "govuk-link govuk-link--no-visited-state" %> explains how to connect your authenticators to these servers
-        </p>
       </td>
       <td class="govuk-table__cell">
       </td>

--- a/spec/features/authentication/edit_password_spec.rb
+++ b/spec/features/authentication/edit_password_spec.rb
@@ -18,7 +18,7 @@ describe "Editing password", type: :feature do
 
     click_on "Settings"
 
-    expect(page).to have_content "Change your password"
+    expect(page).to have_link("Change", href: edit_user_registration_path)
   end
 
   it "successfully updates the current user's password" do


### PR DESCRIPTION
### What
Make settings page consistent with new design

### Why
Change the layout of the page. Retains the basic page structure (tables)
rather than using divs/dls as per the prototype.


Link to Trello card (if applicable): 
https://trello.com/c/dQVU1o17/2118-changes-to-the-setting-page-1