### PR TITLE
Remove superfluous ips#index routes

### DIFF
--- a/app/controllers/ips_controller.rb
+++ b/app/controllers/ips_controller.rb
@@ -17,7 +17,7 @@ class IpsController < ApplicationController
 
     ip.destroy!
     Facades::Ips::Publish.new.execute
-    redirect_to removed_ips_path, notice: "Successfully removed IP address #{ip.address}"
+    redirect_to ips_path, notice: "Successfully removed IP address #{ip.address}"
   end
 
 private
@@ -41,14 +41,14 @@ private
   end
 
   def ip_removal_requested?
-    params[:ip_id].present?
+    params[:ip_id].present? && params[:confirm_remove].present?
   end
 
   def key_rotation_requested?
-    params[:location_id].present? && params[:rotate].present?
+    params[:location_id].present? && params[:confirm_rotate].present?
   end
 
   def location_removal_requested?
-    params[:location_id].present? && params[:remove].present?
+    params[:location_id].present? && params[:confirm_remove].present?
   end
 end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -14,10 +14,7 @@ class LocationsController < ApplicationController
     )
 
     if @location.save
-      redirect_to(
-        @location.ips.any? ? created_location_with_ip_ips_path : created_location_ips_path,
-        notice: "Added #{@location.full_address}",
-      )
+      redirect_to(ips_path, notice: "Added #{@location.full_address}")
     else
       render :new
     end
@@ -42,7 +39,7 @@ class LocationsController < ApplicationController
       Facades::Ips::Publish.new.execute
       length_of_ips_added = @location.ips.length - length_of_ips_before
       redirect_to(
-        created_ips_path,
+        ips_path,
         notice: "Added #{length_of_ips_added} #{'IP address'.pluralize(length_of_ips_added)} to #{@location.full_address}",
       )
     else
@@ -56,7 +53,7 @@ class LocationsController < ApplicationController
     redirect_to ips_path && return unless location && location.ips.empty?
 
     location.destroy!
-    redirect_to removed_location_ips_path, notice: "Successfully removed location #{location.address}"
+    redirect_to ips_path, notice: "Successfully removed location #{location.address}"
   end
 
 private

--- a/app/views/shared/_manage_ips.html.erb
+++ b/app/views/shared/_manage_ips.html.erb
@@ -13,13 +13,13 @@
                     role: "button", draggable: "false", "data-module" => "govuk-button" do %>
           Add IP addresses <span class='govuk-visually-hidden'>for <%= location.full_address %></span>
         <% end %>
-        <%= link_to location_rotate_key_path(location, rotate: true),
+        <%= link_to ips_path(location_id: location.id, confirm_rotate: true),
                     class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-5",
                     role: "button", draggable: "false", "data-module" => "govuk-button" do %>
           Rotate secret key <span class='govuk-visually-hidden'>for <%= location.full_address %></span>
         <% end %>
         <% if location.ips.empty? %>
-          <%= link_to location_remove_path(location, remove: true),
+          <%= link_to ips_path(location_id: location.id, confirm_remove: true),
                       class: "govuk-button govuk-button--warning govuk-!-margin-bottom-5",
                       role: "button", draggable: "false", "data-module" => "govuk-button" do %>
             Remove this location <span class='govuk-visually-hidden'>- <%= location.full_address %></span>
@@ -73,7 +73,7 @@
               <% end %>
               <% if show_ip_controls && current_user.can_manage_locations?(current_organisation) %>
                 <li>
-                  <%= link_to ip_remove_path(ip), class: "govuk-link govuk-link--no-visited-state" do %>
+                  <%= link_to ips_path(ip_id: ip.id, confirm_remove: true), class: "govuk-link govuk-link--no-visited-state" do %>
                     Remove <span class='govuk-visually-hidden'><%= ip.address %> from <%= location.full_address %></span>
                   <% end %>
                 </li>

--- a/app/views/super_admin/organisations/_ips.html.erb
+++ b/app/views/super_admin/organisations/_ips.html.erb
@@ -22,7 +22,7 @@
       <% end %>
       <td class="govuk-table__cell text-right">
         <% if current_user.can_manage_locations?(current_organisation) %>
-          <%= link_to "Remove", ip_remove_path(ip), class: "govuk-link govuk-link--no-visited-state" %>
+          <%= link_to "Remove", ips_path(ip_id: ip.id, confirm_remove: true), class: "govuk-link govuk-link--no-visited-state" %>
         <% end %>
       </td>
     </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,13 +27,7 @@ Rails.application.routes.draw do
   patch "change_organisation", to: "current_organisation#update"
 
   resources :status, only: %i[index]
-  resources :ips, only: %i[index new create destroy] do
-    get "remove", to: "ips#index"
-    get "created", to: "ips#index", on: :collection
-    get "created/location", to: "ips#index", on: :collection
-    get "removed", to: "ips#index", on: :collection
-    get "removed/location", to: "ips#index", on: :collection
-  end
+  resources :ips, only: %i[index new create destroy]
 
   resources :help, only: %i[create new] do
     get "/", on: :collection, to: "help#new"
@@ -43,8 +37,6 @@ Rails.application.routes.draw do
     get "user_support", on: :new
   end
   resources :locations, only: %i[new create destroy update] do
-    get "remove", to: "ips#index"
-    get "rotate_key", to: "ips#index"
     get "add_ips", to: "add_ips"
     patch "update_ips", to: "update_ips"
   end

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe LocationsController, type: :controller do
       end
 
       it "redirects to the created ips path" do
-        expect(@response).to redirect_to(created_ips_path)
+        expect(@response).to redirect_to(ips_path)
       end
     end
 

--- a/spec/features/ips/add_ip_to_existing_location_spec.rb
+++ b/spec/features/ips/add_ip_to_existing_location_spec.rb
@@ -42,7 +42,7 @@ describe "Adding an IP to an existing location", type: :feature do
       end
 
       it 'redirects to the "after IP created" path for Analytics' do
-        expect(page).to have_current_path("/ips/created")
+        expect(page).to have_current_path("/ips")
       end
 
       it "triggers the publishing of the config file" do
@@ -126,7 +126,7 @@ describe "Adding an IP to an existing location", type: :feature do
     end
 
     it 'redirects to the "after IP created" path for Analytics' do
-      expect(page).to have_current_path("/ips/created")
+      expect(page).to have_current_path("/ips")
     end
   end
 

--- a/spec/features/ips/remove_an_ip_spec.rb
+++ b/spec/features/ips/remove_an_ip_spec.rb
@@ -45,7 +45,7 @@ describe "Removing an IP", type: :feature do
         click_on "Remove"
       end
 
-      expect(page).to have_current_path("/ips/removed")
+      expect(page).to have_current_path("/ips")
     end
   end
 
@@ -63,7 +63,7 @@ describe "Removing an IP", type: :feature do
 
     context "when visiting the remove IP page directly" do
       before do
-        visit ip_remove_path(ip)
+        visit ips_path(ip_id: ip.id, confirm_remove: true)
       end
 
       it "does not show the partial" do
@@ -76,7 +76,7 @@ describe "Removing an IP", type: :feature do
     let(:other_ip) { create(:ip, location: create(:location)) }
 
     before do
-      visit ip_remove_path(other_ip)
+      visit ips_path(ip: ip.id, confirm_remove: true)
     end
 
     it "does not show the partial" do

--- a/spec/features/locations/add_new_location_spec.rb
+++ b/spec/features/locations/add_new_location_spec.rb
@@ -35,7 +35,7 @@ describe "Add location", type: :feature do
 
       it 'redirects to "After location created" path' do
         click_on "Add location"
-        expect(page).to have_current_path("/ips/created/location")
+        expect(page).to have_current_path("/ips")
       end
     end
 

--- a/spec/features/locations/remove_a_location_spec.rb
+++ b/spec/features/locations/remove_a_location_spec.rb
@@ -34,7 +34,7 @@ describe "Remove a location", type: :feature do
 
       it 'redirects to the "after location removed" path for analytics' do
         click_on "Yes, remove this location"
-        expect(page).to have_current_path("/ips/removed/location")
+        expect(page).to have_current_path("/ips")
       end
     end
 
@@ -59,28 +59,6 @@ describe "Remove a location", type: :feature do
       within("table") do
         expect(page).not_to have_content("Remove location")
       end
-    end
-
-    context "when visiting the remove location page directly" do
-      before do
-        visit location_remove_path(location)
-      end
-
-      it "does not show the partial" do
-        expect(page).not_to have_content("Are you sure you want to remove this location")
-      end
-    end
-  end
-
-  context "when you do not own the location" do
-    let(:other_location) { create(:location, organisation: create(:organisation)) }
-
-    before do
-      visit location_remove_path(other_location)
-    end
-
-    it "does not show the partial" do
-      expect(page).not_to have_content("Are you sure you want to remove this location")
     end
   end
 end


### PR DESCRIPTION
### What
There were a lot of routes that all point to the same ips#index action. This
is confusing because the associated paths imply different actions exist whereas
in fact they are all synonyms.

### Why
Removing these makes the flow within the application clearer and shortens
the route table
