### PR TITLE
Remove superfluous memberships#index and mou#index routes

### DIFF
--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -12,7 +12,7 @@ class MembershipsController < ApplicationController
       can_manage_locations: %w[administrator manage_locations].include?(permission_level),
     )
     flash[:notice] = "Permissions updated"
-    redirect_to updated_permissions_memberships_path
+    redirect_to memberships_path
   end
 
   def index
@@ -47,7 +47,7 @@ class MembershipsController < ApplicationController
     redirect_path = if current_user.is_super_admin? && @membership.organisation_id != current_organisation&.id
                       super_admin_organisation_path(@membership.organisation)
                     else
-                      removed_memberships_path
+                      memberships_path
                     end
 
     redirect_to redirect_path, notice: "Team member has been removed"

--- a/app/controllers/mou_controller.rb
+++ b/app/controllers/mou_controller.rb
@@ -5,7 +5,6 @@ class MouController < ApplicationController
   end
 
   def create
-    redirect_path = replacing? ? replaced_mou_index_path : created_mou_index_path
     if params[:signed_mou]
       mime_type = Marcel::MimeType.for(params[:signed_mou])
       if mime_type.to_s == "application/pdf"
@@ -13,13 +12,11 @@ class MouController < ApplicationController
         flash[:notice] = "MOU uploaded successfully."
       else
         flash[:alert] = "Unsupported file type. Signed MOU should be a PDF."
-        redirect_path = mou_index_path
       end
     else
       flash[:alert] = "Choose a file before uploading "
-      redirect_path = mou_index_path
     end
-    redirect_to redirect_path
+    redirect_to mou_index_path
   end
 
 private

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -48,7 +48,7 @@ private
   end
 
   def after_path(organisation)
-    super_admin? ? super_admin_organisation_path(organisation) : created_invite_memberships_path
+    super_admin? ? super_admin_organisation_path(organisation) : memberships_path
   end
 
   def user_belongs_to_current_organisation?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,19 +40,8 @@ Rails.application.routes.draw do
     get "add_ips", to: "add_ips"
     patch "update_ips", to: "update_ips"
   end
-  resources :memberships, only: %i[edit update index destroy] do
-    collection do
-      get "created/invite", to: "memberships#index"
-      get "updated/permissions", to: "memberships#index"
-      get "removed", to: "memberships#index"
-    end
-  end
-  resources :mou, only: %i[index create] do
-    collection do
-      get "created", to: "mou#index"
-      get "replaced", to: "mou#index"
-    end
-  end
+  resources :memberships, only: %i[edit update index destroy]
+  resources :mou, only: %i[index create]
   resources :logs, only: %i[index]
   resources :logs_searches, path: "logs/search", only: %i[new index create] do
     post "choose_option", on: :new

--- a/spec/features/team/edit_permissions_spec.rb
+++ b/spec/features/team/edit_permissions_spec.rb
@@ -50,7 +50,7 @@ describe "Edit user permissions", type: :feature do
       end
 
       it 'redirects to "after permission updated" team members page for analytics' do
-        expect(page).to have_current_path("/memberships/updated/permissions")
+        expect(page).to have_current_path("/memberships")
       end
     end
 

--- a/spec/features/team/invite_a_team_member_spec.rb
+++ b/spec/features/team/invite_a_team_member_spec.rb
@@ -46,7 +46,7 @@ describe "Inviting a team member", type: :feature do
       end
 
       it 'redirects to the "after user invited" path for analytics' do
-        expect(page).to have_current_path("/memberships/created/invite")
+        expect(page).to have_current_path("/memberships")
       end
     end
 
@@ -71,7 +71,7 @@ describe "Inviting a team member", type: :feature do
       end
 
       it 'redirects to the "after user invited" path for analytics' do
-        expect(page).to have_current_path("/memberships/created/invite")
+        expect(page).to have_current_path("/memberships")
       end
     end
 
@@ -118,7 +118,7 @@ describe "Inviting a team member", type: :feature do
       end
 
       it 'redirects to the "after user invited" path for analytics' do
-        expect(page).to have_current_path("/memberships/created/invite")
+        expect(page).to have_current_path("/memberships")
       end
     end
 

--- a/spec/features/team/remove_a_team_member_spec.rb
+++ b/spec/features/team/remove_a_team_member_spec.rb
@@ -27,7 +27,7 @@ describe "Remove a team member", type: :feature do
 
     it 'redirects to "after user removed" team members page for analytics' do
       click_on "Yes, remove this team member"
-      expect(page).to have_current_path("/memberships/removed")
+      expect(page).to have_current_path("/memberships")
     end
   end
 

--- a/spec/features/upload_download_mous_spec.rb
+++ b/spec/features/upload_download_mous_spec.rb
@@ -56,7 +56,7 @@ describe "Uploading and downloading an MOU", type: :feature do
       end
 
       it 'redirects to "after MOU uploaded" path for analytics' do
-        expect(page).to have_current_path("/mou/created")
+        expect(page).to have_current_path("/mou")
       end
 
       describe "access control" do
@@ -130,7 +130,7 @@ describe "Uploading and downloading an MOU", type: :feature do
       end
 
       it 'redirects to "after MOU uploaded" path for analytics' do
-        expect(page).to have_current_path("/mou/replaced")
+        expect(page).to have_current_path("/mou")
       end
     end
 


### PR DESCRIPTION
There were a lot of routes that all point to the the same action. This
is confusing because the associated paths imply different actions exist whereas
in fact they are all synonyms.

Removing these makes the flow within the application clearer and shortens
the route table