### PR TITLE
Implement several small fixes for the recent logging changes.

### DIFF
--- a/app/views/help/signed_in.html.erb
+++ b/app/views/help/signed_in.html.erb
@@ -15,7 +15,7 @@
       </li>
       <% unless current_organisation&.locations&.empty? %>
         <li>
-          <%= link_to "Search our logs", username_new_logs_search_path, class: "govuk-link" %> to confirm they are reaching our service
+          <%= link_to "Search our logs", new_logs_search_path, class: "govuk-link" %> to confirm they are reaching our service
         </li>
       <% end %>
       <li>
@@ -36,7 +36,7 @@
       </li>
       <% unless current_organisation&.locations&.empty? %>
         <li>
-          <%= link_to "Search our logs", location_new_logs_search_path, class: "govuk-link" %> to confirm traffic from you is reaching our service
+          <%= link_to "Search our logs", new_logs_search_path, class: "govuk-link" %> to confirm traffic from you is reaching our service
         </li>
       <% end %>
       <li>

--- a/app/views/super_admin/wifi_user_searches/show.html.erb
+++ b/app/views/super_admin/wifi_user_searches/show.html.erb
@@ -22,7 +22,8 @@
         <h3>User details for '<%= params[:search_term] %>'</h3>
         <p>
           Username: <%= link_to @wifi_user.username,
-                                logs_path(username: @wifi_user.username),
+                                logs_path(log_search_form: { username: @wifi_user.username,
+                                                             filter_option: LogSearchForm::USERNAME_FILTER_OPTION }),
                                 title: "Search logs for '#{@wifi_user.username}'" %>
         </p>
         <p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,12 +43,7 @@ Rails.application.routes.draw do
   resources :memberships, only: %i[edit update index destroy]
   resources :mou, only: %i[index create]
   resources :logs, only: %i[index]
-  resources :logs_searches, path: "logs/search", only: %i[new index create] do
-    post "choose_option", on: :new
-    get "ip", on: :new
-    get "username", on: :new
-    get "location", on: :new
-  end
+  resources :logs_searches, path: "logs/search", only: %i[new index create]
   resources :organisations, only: %i[new create edit update]
   resources :settings, only: %i[index] do
     collection do

--- a/spec/features/super_admin/lookup_wifi_user_contact_details_spec.rb
+++ b/spec/features/super_admin/lookup_wifi_user_contact_details_spec.rb
@@ -27,8 +27,11 @@ describe "Lookup wifi user contact details", type: :feature do
       expect(page).to have_content("wifi.user@govwifi.org")
     end
 
-    it "provides a link to search logs by username" do
-      expect(page).to have_link("zZyYxX", href: logs_path(username: "zZyYxX"))
+    describe "click on the username link" do
+      it "shows a page with logs for the user" do
+        click_on "zZyYxX"
+        expect(page).to have_content("The username \"zZyYxX\" is not reaching the GovWifi service")
+      end
     end
   end
 


### PR DESCRIPTION
1. There are a number of superfluous routes that can now be removed
2. The username link in the userdetails view now point to the right page
3. A link in the help page now points correctly to the logging page
