### PR TITLE
Use GOV.UK form builder for the UI to add IPs to a Location

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -25,19 +25,6 @@ class Location < ApplicationRecord
     ips.sort_by { |ip| ip.address.split(".").map(&:to_i) }
   end
 
-  def add_blank_ips(number_to_add)
-    remaining = number_to_add - blank_ips.length
-    remaining.times { ips.build }
-  end
-
-  def blank_ips
-    ips.reject(&:persisted?)
-  end
-
-  def ips_unable_to_be_persisted
-    blank_ips.select(&:address)
-  end
-
 private
 
   def validate_postcode_format

--- a/app/models/location_ips_form.rb
+++ b/app/models/location_ips_form.rb
@@ -1,0 +1,56 @@
+class LocationIpsForm
+  include ActiveModel::Model
+  validate :ips_must_be_valid, :all_empty
+  delegate :postcode, :address, :full_address, to: :location
+
+  IP_NUM = 5
+  IP_FIELDS = (1..IP_NUM).map { |num| "ip_#{num}".to_sym }
+
+  IP_FIELDS.each do |field|
+    attr_accessor field
+  end
+
+  attr_accessor :location_id
+
+  def updated_length
+    @updated_length ||= ip_data.count(&:present?)
+  end
+
+  def update
+    return false unless valid?
+
+    Facades::Ips::Publish.new.execute
+    ip_data.compact.map { |ip| ip[:model].save }
+  end
+
+private
+
+  def location
+    @location ||= Location.find(location_id)
+  end
+
+  def ips_must_be_valid
+    ip_data.compact.each do |ip|
+      ip[:model].validate
+      ip[:model].errors.each do |error|
+        errors.add(ip[:ip_field], error.message)
+      end
+    end
+  end
+
+  def all_empty
+    errors.add(:location, "Enter at least one IP address") if ip_data.none?
+  end
+
+  def ip_data
+    @ip_data ||= IP_FIELDS.map do |ip_field|
+      ip_address = send(ip_field)
+      next if ip_address.blank?
+
+      {
+        ip_field:,
+        model: Ip.new(location:, address: ip_address),
+      }
+    end
+  end
+end

--- a/app/views/locations/add_ips.html.erb
+++ b/app/views/locations/add_ips.html.erb
@@ -1,38 +1,10 @@
-<% content_for :page_title, if action_name == "update_ips"
-                              "Error: Add IP addresses"
-                            else
-                              "Add IP addresses"
-                            end %>
-
-<% if action_name == 'update_ips' %>
-  <div class="govuk-error-summary" role="alert" tabindex="-1" autofocus>
-    <h2 class="govuk-error-summary__title">There is a problem</h2>
-    <div class="govuk-error-summary__body">
-      <ul class="govuk-list govuk-error-summary__list">
-        <% if @location.ips_unable_to_be_persisted.empty? %>
-          <li>Enter at least one IP address</li>
-        <% else %>
-          <%= form_for @location, url: location_update_ips_path(location_id: @location.id) do |form| %>
-            <%= form.fields_for(:ips, @location.blank_ips) do |ip| %>
-              <% if ip.object.errors.key?(:address) %>
-                <li><a href="#ip_<%= ip.index + 1 %>">
-                  <span class="govuk-visually-hidden">Error:</span> <%= ip.object.errors.full_messages_for(:address).first %>
-                </a></li>
-              <% end %>
-            <% end %>
-          <% end %>
-        <% end %>
-      </ul>
-    </div>
-  </div>
-<% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
     <%= link_to "Back to locations", ips_path, class: "govuk-back-link" %>
-
+    <%= form_for @ips_form, url: location_update_ips_path(location_id: @ips_form.location_id), method: :patch, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form.govuk_error_summary %>
     <span class="govuk-caption-xl govuk-!-font-weight-bold">
-      <%= @location.address %>, <%= @location.postcode %>
+      <%= @ips_form.address %>, <%= @ips_form.postcode %>
     </span>
     <h1 class="govuk-heading-l">
       Add IP addresses
@@ -48,24 +20,10 @@
       </p>
     </div>
 
-    <%= form_for @location, url: location_update_ips_path(location_id: @location.id) do |form| %>
-      <%= form.fields_for(:ips, @location.blank_ips) do |ip| %>
-        <div class='govuk-!-margin-bottom-3' id="ip_<%= ip.index + 1 %>">
-          <% style = "govuk-input govuk-input--width-10#{ip.object.errors.key?(:address) ? ' govuk-input--error' : ''}" %>
-          <% if ip.object.errors.key?(:address) %>
-            <span class="govuk-error-message" id="ip_<%= ip.index + 1 %>_error">
-              <span class="govuk-visually-hidden">Error:</span> <%= ip.object.errors.full_messages_for(:address).first %>
-            </span>
-          <% end %>
-          <%= ip.label :address, "IP address #{ip.index + 1}", class: "govuk-label" %>
-          <%= ip.text_field :address, class: style, "aria-described-by" => ip.object.errors.key?(:address) && "ip_#{ip.index + 1}_error" %>
-        </div>
+      <% LocationIpsForm::IP_FIELDS.each.with_index(1) do |field, index| %>
+          <%= form.govuk_text_field field, label: -> { "IP address #{index}" } %>
       <% end %>
-
-      <div class="govuk-!-margin-top-6">
-        <%= form.submit "Add IP addresses", class: "govuk-button" %>
-      </div>
-
+      <%= form.govuk_submit "Add IP addresses" %>
     <% end %>
   </div>
 </div>

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -22,11 +22,9 @@ RSpec.describe LocationsController, type: :controller do
   describe "POST /update_ips" do
     let(:params) do
       {
-        location: {
-          ips_attributes: {
-            "0": { address: Faker::Internet.ip_v4_address },
-            "1": { address: Faker::Internet.ip_v4_address },
-          },
+        location_ips_form: {
+          ip_1: Faker::Internet.ip_v4_address,
+          ip_2: Faker::Internet.ip_v4_address,
         },
         location_id: location.id,
       }

--- a/spec/features/ips/add_ip_to_existing_location_spec.rb
+++ b/spec/features/ips/add_ip_to_existing_location_spec.rb
@@ -24,7 +24,7 @@ describe "Adding an IP to an existing location", type: :feature do
       allow(Facades::Ips::Publish).to receive(:new).and_return(publish_ip)
       sign_in_user user
       visit location_add_ips_path(location_id: location.id)
-      fill_in "location[ips_attributes][0][address]", with: ip_address
+      fill_in "location_ips_form[ip_1]", with: ip_address
       click_on "Add IP addresses"
     end
 
@@ -111,7 +111,7 @@ describe "Adding an IP to an existing location", type: :feature do
     before do
       sign_in_user user
       visit location_add_ips_path(location_id: other_location.id)
-      fill_in "location[ips_attributes][0][address]", with: "141.0.149.130"
+      fill_in "location_ips_form[ip_1]", with: "141.0.149.130"
       click_on "Add IP addresses"
     end
 
@@ -134,8 +134,8 @@ describe "Adding an IP to an existing location", type: :feature do
     before do
       sign_in_user user
       visit location_add_ips_path(location_id: location.id)
-      ip_addresses.each_with_index do |ip, index|
-        fill_in "location[ips_attributes][#{index}][address]", with: ip
+      ip_addresses.each.with_index(1) do |ip, index|
+        fill_in "location_ips_form[ip_#{index}]", with: ip
       end
       click_on "Add IP addresses"
     end

--- a/spec/features/ips/view_ip_address_readiness_spec.rb
+++ b/spec/features/ips/view_ip_address_readiness_spec.rb
@@ -8,7 +8,7 @@ describe "Wiew whether IPs are ready", type: :feature do
     before do
       sign_in_user user
       visit location_add_ips_path(location_id: location.id)
-      fill_in "location[ips_attributes][0][address]", with: "141.0.149.130"
+      fill_in "location_ips_form[ip_1]", with: "141.0.149.130"
       click_on "Add IP addresses"
     end
 

--- a/spec/features/track_new_organisations_spec.rb
+++ b/spec/features/track_new_organisations_spec.rb
@@ -26,7 +26,7 @@ describe "Tracking new organisations", type: :feature do
 
     before do
       visit location_add_ips_path(location_id: location.id)
-      fill_in "location[ips_attributes][0][address]", with: ip_address
+      fill_in "location_ips_form[ip_1]", with: ip_address
       click_on "Add IP addresses"
       click_on "Settings"
     end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -80,20 +80,4 @@ describe Location do
       expect(location.save).to be_falsey
     end
   end
-
-  describe "#blank_ips" do
-    subject(:location) { described_class.new }
-
-    before do
-      location.add_blank_ips(1)
-    end
-
-    it "creates the right number of blank ip addresses" do
-      expect(location.blank_ips.count).to eq(1)
-    end
-
-    it "doesn’t persist the the blank ip addresses" do
-      expect(location.blank_ips[0]).not_to be_persisted
-    end
-  end
 end


### PR DESCRIPTION
### What
Use GOV.UK form builder for the UI to add IPs to a Location

### Why
The GOV.UK form builder provides simpler view code. The previous approach
of using 'field_for' has been replaced by a form model which is more
straight-forward, and requires less code in the controller, view and model
 and is compatible with the form builder.
