### PR TITLE
Do no show subnav and sidebar for 2FA views.

### DIFF
--- a/app/controllers/users/two_factor_authentication_controller.rb
+++ b/app/controllers/users/two_factor_authentication_controller.rb
@@ -25,4 +25,12 @@ class Users::TwoFactorAuthenticationController < Devise::TwoFactorAuthentication
 
     redirect_to root_path unless current_user.can_manage_other_user_for_org?(user, current_organisation)
   end
+
+  def sidebar
+    :empty
+  end
+
+  def subnav
+    :empty
+  end
 end

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -43,4 +43,12 @@ private
     request.env["warden"].session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
     redirect_to stored_location_for(:user) || root_path
   end
+
+  def sidebar
+    :empty
+  end
+
+  def subnav
+    :empty
+  end
 end


### PR DESCRIPTION
### What
Do no show subnav and sidebar for 2FA views.
### Why
None of the links in the subnav or sidebar work until 2FA authentication is completed and so showing them introduces unnecessary clutter and can confuse users

berfore:
<img width="999" alt="image" src="https://user-images.githubusercontent.com/6050162/162768751-b0b3badb-c295-4a1e-9382-923305ad40db.png">

after:
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/6050162/162768914-5c368bf8-a74c-442e-8e1c-3d1171ba4a38.png">


Link to Trello card (if applicable): 
https://trello.com/c/xzsViBpP/1394-do-not-show-links-during-2fa