### PR TITLE
Allow users to only set up 2FA once.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -534,7 +534,7 @@ DEPENDENCIES
   zendesk_api
 
 RUBY VERSION
-   ruby 3.1.1p18
+   ruby 3.1.2p20
 
 BUNDLED WITH
    2.2.32

--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -1,4 +1,5 @@
 class Users::TwoFactorAuthenticationSetupController < ApplicationController
+  before_action :user_not_2fa_setup
   # Skips 2FA so User can set up the totp via QR code
   skip_before_action :handle_two_factor_authentication
   # Skips 2FA setup confirmation callback in ApplicationController.
@@ -38,6 +39,11 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
   helper_method :twofa_key
 
 private
+
+  def user_not_2fa_setup
+    redirect_to user_two_factor_authentication_path if current_user.reload.totp_enabled?
+    false
+  end
 
   def disable_2fa_checks_for_session
     request.env["warden"].session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false

--- a/spec/features/authentication/set_up_two_factor_authentication_spec.rb
+++ b/spec/features/authentication/set_up_two_factor_authentication_spec.rb
@@ -69,6 +69,17 @@ describe "Set up two factor authentication", type: :feature do
       expect(page).to have_current_path(new_organisation_settings_path)
     end
 
+    describe "A user with 2FA completed tries to access the setup page directly" do
+      before :each do
+        sign_out
+        sign_in_user(user, pass_through_two_factor: false)
+        visit(users_two_factor_authentication_setup_path)
+      end
+      it "redirects to the 2fa authentication path" do
+        expect(page).to have_current_path(user_two_factor_authentication_path)
+      end
+    end
+
     context "with a super admin user without an organisation" do
       let(:user) { create(:user, :super_admin) }
 


### PR DESCRIPTION
### What
Allow users to only set up 2FA once.
### Why
Users were able to overwrite 2FA by manually visiting the 2FA setup page.

Link to Trello card (if applicable): 
https://trello.com/c/9rkusm1t/2214-it-health-check-high-risk-mfa-bypass