### PR TITLE
Use the govuk form builder for organisation#edit view

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2022-01-07T09:25:38Z",
+  "generated_at": "2022-04-22T10:10:52Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -166,7 +166,7 @@
       {
         "hashed_secret": "53f87d0cadd4f96eb250190b62c20381802bd43c",
         "is_verified": false,
-        "line_number": 120,
+        "line_number": 113,
         "type": "Secret Keyword"
       }
     ],

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -7,7 +7,7 @@ class Organisation < ApplicationRecord
   has_many :ips, through: :locations
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
-  validates :service_email, format: { with: Devise.email_regexp, message: "must be in the correct format, like name@example.com" }
+  validates :service_email, format: { with: Devise.email_regexp }
   validate :validate_in_register?, unless: proc { |org| org.name.blank? }
 
   scope :sortable_with_child_counts, lambda { |sort_column, sort_direction|

--- a/app/views/organisations/edit.html.erb
+++ b/app/views/organisations/edit.html.erb
@@ -1,25 +1,15 @@
 <% content_for :page_title, "Edit service email" %>
 
-<%= render "layouts/form_errors", resource: @organisation %>
-
-<%= link_to "Back to settings", settings_path, class: "govuk-back-link" %>
-<h1 class="govuk-heading-l">Edit service email</h1>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_for @organisation do |form| %>
-      <div class="govuk-form-group <%= field_error(@organisation, :service_email) %>">
-        <%= form.label :service_email, "Service email", class: "govuk-label" %>
-        <div class="govuk-hint">A shared and monitored email, so we can contact your organisation</div>
-        <% if @organisation.errors.attribute_names.include?(:service_email) %>
-          <span class="govuk-error-message" id="email_error">
-            <span class="govuk-visually-hidden">Error:</span><%= @organisation.errors.full_messages_for(:service_email).first %>
-          </span>
-          <%= form.text_field :service_email, class: "govuk-input govuk-input--error" %>
-        <% else %>
-          <%= form.text_field :service_email, class: "govuk-input" %>
-        <% end %>
-      </div>
-      <%= form.submit "Save", class: "govuk-button" %>
-    <% end %>
+<%= form_with model: @organisation, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+  <%= form.govuk_error_summary %>
+  <%= link_to "Back to settings", settings_path, class: "govuk-back-link" %>
+  <h1 class="govuk-heading-l">Edit service email</h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= form.govuk_text_field :service_email,
+                                label: { text: "Service email" },
+                                hint: { text: "A shared and monitored email, so we can contact your organisation" } %>
+      <%= form.govuk_submit "Save" %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,5 +44,8 @@ module GovwifiAdmin
 
     # Disable IP spoofing check as we get too many false positives due to proxies
     config.action_dispatch.ip_spoofing_check = false
+
+    # enable customising the full_message method.
+    config.active_model.i18n_customize_full_message = true
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,10 @@ en:
   activerecord:
     errors:
       models:
+        user/organisations:
+          attributes:
+            service_email:
+              format: "%{message}"
         user:
           attributes:
             email:
@@ -17,6 +21,9 @@ en:
               taken: " is already registered. If you wish to administer an \n
               existing GovWifi installation, you must be invited to that \n
               organisation's team."
+            service_email:
+              format: "%{message}"
+              invalid: "Service email must be in the correct format, like name@example.com"
         location:
           attributes:
             address:

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -131,7 +131,7 @@ describe "Sign up as an organisation", type: :feature do
     it_behaves_like "errors in form"
 
     it "tells the user that the service email must be present" do
-      expect(page).to have_content "Organisations service email must be in the correct format, like name@example.com"
+      expect(page).to have_content "Service email must be in the correct format, like name@example.com"
     end
   end
 
@@ -145,7 +145,7 @@ describe "Sign up as an organisation", type: :feature do
     it_behaves_like "errors in form"
 
     it "tells the user that the service email must be a valid email address" do
-      expect(page).to have_content "Organisations service email must be in the correct format, like name@example.com"
+      expect(page).to have_content "Service email must be in the correct format, like name@example.com"
     end
   end
 


### PR DESCRIPTION
### What
Use the govuk form builder for organisation#edit view
### Why
Simplifies the code, benefit from automatic updates

Link to Trello card (if applicable): 
https://trello.com/c/geuWyFBU/614-improve-error-messages-in-govwifi-admin