### PR TITLE
Update confirmations#new and confirmations#show to use GOV.UK form builder

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -25,7 +25,7 @@ class Organisation < ApplicationRecord
 
   def validate_in_register?
     unless Organisation.fetch_organisations_from_register.include?(name)
-      errors.add(:name, "isn't in the organisations allow list")
+      errors.add(:name, "Name isn't in the organisations allow list")
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,10 +33,6 @@ class User < ApplicationRecord
     !password.nil?
   end
 
-  def only_if_unconfirmed(&block)
-    pending_any_confirmation(&block)
-  end
-
   # Must be defined to allow Devise to create users without passwords
   def password_required?
     false

--- a/app/models/user_membership_form.rb
+++ b/app/models/user_membership_form.rb
@@ -1,0 +1,34 @@
+class UserMembershipForm
+  include ActiveModel::Model
+
+  attr_accessor :name, :service_email, :organisation_name, :confirmation_token, :password
+
+  def write_to(user)
+    return false if user.confirmed?
+
+    user.assign_attributes(name:, password:)
+    user.organisations.build(name: organisation_name, service_email:)
+    if user.valid?
+      user.save!
+      user.confirm
+      user.default_membership.confirm!
+      true
+    else
+      copy_errors_from(user)
+      false
+    end
+  end
+
+private
+
+  def copy_errors_from(user)
+    attribute_transform_map = {
+      "organisations.service_email": :service_email,
+      "organisations.name": :organisation_name,
+    }
+    user.errors.each do |error|
+      attribute = attribute_transform_map[error.attribute] || error.attribute
+      errors.add(attribute, error.message)
+    end
+  end
+end

--- a/app/views/shared/_organisation_register_dropdown.html.erb
+++ b/app/views/shared/_organisation_register_dropdown.html.erb
@@ -3,7 +3,7 @@
 
 <script>
   accessibleAutocomplete.enhanceSelectElement({
-    selectElement: document.querySelector('#organisation_name'),
+    selectElement: document.querySelector('.govuk-select'),
     required: false,
     defaultValue: '',
     showNoOptionsFound: true,

--- a/app/views/super_admin/whitelists/organisation_names/index.html.erb
+++ b/app/views/super_admin/whitelists/organisation_names/index.html.erb
@@ -10,7 +10,7 @@
   <div class="govuk-grid-column-three-quarters">
     <h1 class="govuk-heading-l">Allow an organisation access to the admin platform</h1>
       <%= label_tag "search_orgs_label", "Search for existing organisations on GovWifi before adding them", class: "govuk-label" %>
-      <%= select_tag "organisations_register", options_for_select(@fetched_organisations_from_register << "", "") %>
+      <%= select_tag "organisations_register", options_for_select(@fetched_organisations_from_register << "", ""), class: "govuk-select" %>
 
     <%= form_for(:custom_organisations, url: super_admin_whitelist_organisation_names_path, html: { novalidate: "" }) do |f| %>
       <div class="govuk-form-group <%= field_error(@custom_organisation, :name) %>">

--- a/app/views/super_admin/whitelists/steps/_third.html.erb
+++ b/app/views/super_admin/whitelists/steps/_third.html.erb
@@ -1,6 +1,6 @@
 <h1 class="govuk-heading-l">Is the organisation's name on the register?</h1>
 <div class="govuk-form-group">
-  <%= select_tag "organisations_register", options_for_select(@organisation_names << "", "") %>
+  <%= select_tag "organisations_register", options_for_select(@organisation_names << "", ""), class: "govuk-select" %>
 </div>
 <%= link_to "Yes", new_super_admin_whitelist_path(step: "fifth", register: "Yes", organisation_name: "", admin: params[:admin]), class: "govuk-button", role: "button", draggable: "false", "data-module" => "govuk-button" %>
 <%= link_to "No", new_super_admin_whitelist_path(step: "fourth", register: "No", admin: params[:admin]), class: "govuk-button", role: "button", draggable: "false", "data-module" => "govuk-button" %>

--- a/app/views/users/confirmations/new.html.erb
+++ b/app/views/users/confirmations/new.html.erb
@@ -1,24 +1,16 @@
 <% content_for :page_title, "Resend confirmation instructions" %>
 
-<%= render "layouts/form_errors" %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Resend confirmation instructions</h1>
 
     <%= render "users/shared/end_user_warning" %>
 
-    <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, novalidate: "" }) do |f| %>
-      <div class="govuk-form-group <%= field_error(resource, :email) %>">
-        <%= f.label :email, "Enter your email address", class: "govuk-label" %>
-        <%= f.email_field :email,
-                          autocomplete: "email",
-                          class: "govuk-input",
-                          value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
-      </div>
-      <div class="actions">
-        <%= f.submit "Resend confirmation instructions", class: "govuk-button govuk-!-margin-top-2" %>
-      </div>
+    <%= form_with url: confirmation_path(resource_name),
+                  html: { method: :post, novalidate: "" },
+                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_email_field :email, label: { text: "Enter your email address" } %>
+      <%= f.govuk_submit "Resend confirmation instructions" %>
     <% end %>
 
     <%= render "users/shared/links" %>

--- a/app/views/users/confirmations/show.html.erb
+++ b/app/views/users/confirmations/show.html.erb
@@ -1,49 +1,26 @@
-<%= render "layouts/form_errors" %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Create your GovWifi admin account</h1>
+<%= form_for(@form, url: users_confirmations_path, html: { method: :put, novalidate: "" }, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
+  <%= f.govuk_error_summary %>
 
-    <%= render "users/shared/end_user_warning" %>
+  <h1 class="govuk-heading-l">Create your GovWifi admin account</h1>
 
-    <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-      <%= form_for(resource, as: resource_name, url: users_confirmations_path, html: { method: :put, novalidate: "" }) do |f| %>
-        <%= f.hidden_field :confirmation_token, value: params[:confirmation_token] || params[:user][:confirmation_token] %>
+  <%= render "users/shared/end_user_warning" %>
+  <%= f.hidden_field :confirmation_token %>
+  <% organisation_name_hint = capture do %>
+    If your organisation name does not appear below
+    <%= link_to "contact us", technical_support_new_help_path, class: "govuk-link" %>
+  <% end %>
+    <%= f.govuk_select :organisation_name,
+                       options_for_select(@register_organisations << "", @form.organisation_name || ""),
+                       label: { text: "Organisation name" },
+                       hint: -> { organisation_name_hint } %>
+  <%= f.govuk_text_field :service_email,
+                         label: { text: "Service email" },
+                         hint: { text: "A shared and monitored email so we can contact your organisation about GovWifi" } %>
+  <%= f.govuk_text_field :name, label: { text: "Your name" } %>
+  <%= f.govuk_password_field :password, hint: { text: "Must be at least 6 characters long" } %>
+  <%= f.govuk_submit "Create my account" %>
+<% end %>
 
-        <%= f.fields_for :organisations, resource.organisations.build do |organisation_form| %>
-          <div class="govuk-form-group <%= field_error(resource, "organisation.name") %>">
-            <%= label_tag "organisation_name", "Organisation name", class: "govuk-label" %>
-            <div class="govuk-hint">If your organisation name does not appear below <%= link_to "contact us", technical_support_new_help_path, class: "govuk-link" %></div>
-            <%= organisation_form.select :name, options_for_select(@register_organisations << "", ""), {}, class: "govuk-select", id: "organisation_name" %>
-          </div>
-
-          <div class="govuk-form-group <%= field_error(resource, "organisation.service_email") %>">
-            <%= organisation_form.label :service_email, "Service email", class: "govuk-label" %>
-            <div class="govuk-hint">A shared and monitored email so we can contact your organisation about GovWifi</div>
-            <%= organisation_form.text_field :service_email,
-                                             class: "govuk-input",
-                                             value: (params || {}).dig(:user, :organisation_attributes, :service_email) %>
-          </div>
-        <% end %>
-
-        <div class="govuk-form-group">
-          <%= f.label :name, "Your name", class: "govuk-label" %>
-          <%= f.text_field :name, class: "govuk-input", value: (params || {}).dig(:user, :name) %>
-        </div>
-
-        <div class="govuk-form-group <%= field_error(resource, :password) %>">
-          <%= f.label :password, "Password", class: "govuk-label" %>
-          <div class="govuk-hint"> Must be at least 6 characters long</div>
-          <%= f.password_field :password, class: "govuk-input", autocomplete: "off" %>
-        </div>
-
-        <div class="actions">
-          <%= f.submit "Create my account", class: "govuk-button govuk-!-margin-top-2" %>
-        </div>
-      <% end %>
-
-      <%= render "users/shared/links" %>
-    </div>
-  </div>
-</div>
+<%= render "users/shared/links" %>
 
 <%= render "shared/organisation_register_dropdown" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,28 +2,50 @@ en:
   support:
     email: 'govwifi-tech@digital.cabinet-office.gov.uk'
 
+  activemodel:
+    errors:
+      models:
+        user_membership_form:
+          attributes:
+            name:
+              format: "%{message}"
+            password:
+              format: "%{message}"
+            email:
+              format: "%{message}"
+            service_email:
+              format: "%{message}"
+            organisation_name:
+              format: "%{message}"
   activerecord:
     errors:
       models:
-        user/organisations:
-          attributes:
-            service_email:
-              format: "%{message}"
         user:
           attributes:
+            name:
+              format: "%{message}"
+              blank: "Name can't be blank"
+            password:
+              format: "%{message}"
+              blank: "Password can't be blank"
+              too_short: "Password is too short (minimum is 6 characters)"
+              weak_password: "Password is not strong enough (scored %{score}, required at least %{min_password_score}). %{feedback}"
             email:
+              format: "%{message}"
               taken: "This email address is already associated with an account. If you can't sign in, reset your password."
               invalid: "Enter an email address in the correct format, like name@example.com"
               blank: "Email can't be blank"
         organisation:
           attributes:
-            name:
-              taken: " is already registered. If you wish to administer an \n
-              existing GovWifi installation, you must be invited to that \n
-              organisation's team."
             service_email:
               format: "%{message}"
               invalid: "Service email must be in the correct format, like name@example.com"
+            name:
+              format: "%{message}"
+              blank: "Name can't be blank"
+              taken: "Name is already registered. If you wish to administer an \n
+              existing GovWifi installation, you must be invited to that \n
+              organisation's team."
         location:
           attributes:
             address:

--- a/spec/features/registration/resend_confirmation_instructions_spec.rb
+++ b/spec/features/registration/resend_confirmation_instructions_spec.rb
@@ -12,7 +12,7 @@ describe "Resending confirmation instructions", type: :feature do
     before do
       sign_up_for_account(email: unconfirmed_email)
       visit new_user_confirmation_path
-      fill_in "user_email", with: unconfirmed_email
+      fill_in "Enter your email address", with: unconfirmed_email
     end
 
     it "resends the confirmation link" do
@@ -33,7 +33,7 @@ describe "Resending confirmation instructions", type: :feature do
     before do
       sign_up_for_account(email: unconfirmed_email)
       visit new_user_confirmation_path
-      fill_in "user_email", with: unconfirmed_email
+      fill_in "Enter your email address", with: unconfirmed_email
       click_on "Resend confirmation instructions"
     end
 
@@ -47,7 +47,7 @@ describe "Resending confirmation instructions", type: :feature do
 
     before do
       visit new_user_confirmation_path
-      fill_in "user_email", with: new_user_email
+      fill_in "Enter your email address", with: new_user_email
     end
 
     it "displays a generic response to the user" do
@@ -68,7 +68,7 @@ describe "Resending confirmation instructions", type: :feature do
 
     before do
       visit new_user_confirmation_path
-      fill_in "user_email", with: confirmed_email
+      fill_in "Enter your email address", with: confirmed_email
     end
 
     it "displays a generic response to the user" do

--- a/spec/features/registration/sign_up_as_an_organisation_spec.rb
+++ b/spec/features/registration/sign_up_as_an_organisation_spec.rb
@@ -191,8 +191,8 @@ describe "Sign up as an organisation", type: :feature do
     it_behaves_like "errors in form"
 
     it "shows the user an error message" do
-      within("div#error-summary") do
-        expect(page).to have_content("Organisations name is already registered")
+      within("div.govuk-error-summary") do
+        expect(page).to have_content("Name is already registered")
       end
     end
   end
@@ -216,8 +216,8 @@ describe "Sign up as an organisation", type: :feature do
     it "displays one error message that the name cannot be left blank" do
       update_user_details(organisation_name: org_name_left_blank)
       skip_two_factor_authentication
-      within("div#error-summary") do
-        expect(page).to have_selector("li", count: 1, text: "Organisations name can't be blank")
+      within("div.govuk-error-summary") do
+        expect(page).to have_content("Name can't be blank")
       end
     end
   end

--- a/spec/models/user_membership_form_spec.rb
+++ b/spec/models/user_membership_form_spec.rb
@@ -1,0 +1,74 @@
+require "support/notifications_service"
+
+describe UserMembershipForm do
+  let(:name) { "tom" }
+  let(:password) { "S3Cret!123" }
+  let(:service_email) { "tom@gov.uk" }
+  let(:organisation_name) { "Gov Org 1" }
+  let(:user) { FactoryBot.create(:user, :unconfirmed, name: "harry", email: "harry@gov.uk") }
+  let(:form) { UserMembershipForm.new(name:, password:, service_email:, organisation_name:) }
+
+  include_context "when using the notifications service"
+
+  describe "Updating attributes" do
+    it "updates the name" do
+      form.write_to(user)
+      expect(user.name).to eq("tom")
+    end
+    it "updates the password" do
+      form.write_to(user)
+      expect(user.password).to eq("S3Cret!123")
+    end
+    it "updates the users organisation name" do
+      form.write_to(user)
+      expect(user.organisations.first.name).to eq("Gov Org 1")
+    end
+    it "updates the users organisation email address" do
+      form.write_to(user)
+      expect(user.organisations.first.service_email).to eq("tom@gov.uk")
+    end
+    it "confirms the user" do
+      expect { form.write_to(user) }.to change { user.confirmed? }.from(false).to(true)
+    end
+    it "adds an organisation" do
+      expect { form.write_to(user) }.to change { user.organisations.count }.from(0).to(1)
+    end
+    it "confirms the membership" do
+      form.write_to(user)
+      expect(user.default_membership.confirmed?).to be true
+    end
+    it "returns true" do
+      expect(form.write_to(user)).to be true
+    end
+  end
+  describe "failing validations" do
+    describe "user already confirmed" do
+      let(:user) { FactoryBot.create(:user, name: "harry", email: "harry@gov.uk") }
+      it "returns false" do
+        expect(form.write_to(user)).to be false
+      end
+    end
+    describe "blank name and blank password" do
+      let(:name) { "" }
+      let(:password) { "" }
+      it "copies the validations" do
+        form.write_to(user)
+        expect(form.errors.map(&:full_message)).to match_array(["Name can't be blank",
+                                                                "Password can't be blank",
+                                                                "Password is too short (minimum is 6 characters)"])
+      end
+      it "returns false" do
+        expect(form.write_to(user)).to be false
+      end
+    end
+    describe "blank service email and blank organisation" do
+      let(:organisation_name) { "" }
+      let(:service_email) { "" }
+      it "copies the validations" do
+        form.write_to(user)
+        expect(form.errors.map(&:full_message)).to match_array(["Name can't be blank",
+                                                                "Service email must be in the correct format, like name@example.com"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What
Update confirmations#new and confirmations#show to use GOV.UK form builder
### Why
This simplifies code, ensures the frontend and error messages are consistent
 and in line with the design system.

Link to Trello card (if applicable): 
https://trello.com/c/geuWyFBU/614-improve-error-messages-in-govwifi-admin