### PR TITLE
Update password edit form to use GOV.UK form builder

### DIFF
--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,60 +1,14 @@
 <% content_for :page_title, "Change your password" %>
 
-<%= render "layouts/form_errors", resource: %>
-
-<fieldset class="govuk-fieldset">
-  <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-    <h1 class="govuk-fieldset__heading">
-      Change your password
-    </h1>
-  </legend>
-
-<%= form_for(current_user, url: user_registration_path, method: :put) do |f| %>
-  <div class="govuk-form-group <%= field_error(resource, :current_password) %>">
-    <%= f.label :current_password, class: "govuk-label" %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-three-quarters">
-        <% if resource.errors.attribute_names.include?(:current_password) %>
-          <span class="govuk-error-message" id="current_password_error">
-            <span class="govuk-visually-hidden">Error:</span>
-            <%= resource.errors.full_messages_for(:current_password).first %>
-          </span>
-        <% end %>
-
-        <%= f.password_field :current_password, class: "govuk-input #{input_error(resource, :current_password)}" %>
-      </div>
-    </div>
-  </div>
-  <div id="password" class="govuk-form-group <%= field_error(resource, :password) %>">
-    <%= f.label :password, class: "govuk-label" %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-three-quarters">
-        <% if resource.errors.attribute_names.include?(:password) %>
-          <span class="govuk-error-message" id="password_error">
-            <span class="govuk-visually-hidden">Error:</span>
-            <%= resource.errors.full_messages_for(:password).first %>
-          </span>
-        <% end %>
-
-        <%= f.password_field :password, class: "govuk-input #{input_error(resource, :password)}" %>
-      </div>
-    </div>
-  </div>
-  <div class="govuk-form-group <%= field_error(resource, :password_confirmation) %>">
-    <%= f.label :password_confirmation, class: "govuk-label" %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-three-quarters">
-        <% if resource.errors.attribute_names.include?(:password_confirmation) %>
-          <span class="govuk-error-message" id="password_confirmation_error">
-            <span class="govuk-visually-hidden">Error:</span>
-            <%= resource.errors.full_messages_for(:password_confirmation).first %>
-          </span>
-        <% end %>
-
-        <%= f.password_field :password_confirmation, class: "govuk-input #{input_error(resource, :password_confirmation)}" %>
-      </div>
-    </div>
-  </div>
-  <%= f.submit "Submit", class: "govuk-button" %>
+<%= form_with model: resource,
+              url: user_registration_path,
+              method: :put,
+              builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+  <%= f.govuk_error_summary %>
+  <%= f.govuk_fieldset legend: { text: "Change your password", size: "xl" } do %>
+    <%= f.govuk_password_field :current_password, label: { text: "Current password" } %>
+    <%= f.govuk_password_field :password, label: { text: "Password" } %>
+    <%= f.govuk_password_field :password_confirmation, label: { text: "Password confirmation" } %>
+    <%= f.govuk_submit "Submit" %>
+  <% end %>
 <% end %>
-</fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,7 @@ en:
               blank: "Name can't be blank"
             password:
               format: "%{message}"
+              invalid: "Password is invalid"
               blank: "Password can't be blank"
               too_short: "Password is too short (minimum is 6 characters)"
               weak_password: "Password is not strong enough (scored %{score}, required at least %{min_password_score}). %{feedback}"
@@ -35,6 +36,10 @@ en:
               taken: "This email address is already associated with an account. If you can't sign in, reset your password."
               invalid: "Enter an email address in the correct format, like name@example.com"
               blank: "Email can't be blank"
+            current_password:
+              invalid: "Current password is invalid"
+            password_confirmation:
+              confirmation: "Password confirmation doesn't match Password"
         organisation:
           attributes:
             service_email:

--- a/spec/features/authentication/edit_password_spec.rb
+++ b/spec/features/authentication/edit_password_spec.rb
@@ -52,8 +52,6 @@ describe "Editing password", type: :feature do
     click_on "Submit"
 
     expect(page).to have_content "Current password is invalid"
-    expect(page).to have_css "#user_current_password.govuk-input--error"
-    expect(page).to have_css ".govuk-form-group.govuk-form-group--error"
   end
 
   it "stays on the same page and does not change the password, if the new password is too short" do
@@ -66,8 +64,6 @@ describe "Editing password", type: :feature do
     click_on "Submit"
 
     expect(page).to have_content "Password is too short"
-    expect(page).to have_css "#user_password.govuk-input--error"
-    expect(page).to have_css ".govuk-form-group.govuk-form-group--error"
   end
 
   it "stays on the same page and does not change the password, if the confirmation does not match" do
@@ -80,7 +76,5 @@ describe "Editing password", type: :feature do
     click_on "Submit"
 
     expect(page).to have_content "Password confirmation doesn't match Password"
-    expect(page).to have_css "#user_password_confirmation.govuk-input--error"
-    expect(page).to have_css ".govuk-form-group.govuk-form-group--error"
   end
 end


### PR DESCRIPTION
### What
Update password edit form to use GOV.UK form builder
### Why
This simplifies code, ensures the frontend and error messages are consistent
and in line with the design system.

Link to Trello card (if applicable): 
https://trello.com/c/geuWyFBU/614-improve-error-messages-in-govwifi-admin