### PR TITLE
Update organisations#new views to use GOV.UK form builder

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -7,9 +7,8 @@ class OrganisationsController < ApplicationController
 
   def new
     @organisation = Organisation.new
-    @register_organisations = Organisation.fetch_organisations_from_register
-
     @hide_sidebar = true
+    render :new, locals: { organisation_options: }
   end
 
   def create
@@ -21,10 +20,8 @@ class OrganisationsController < ApplicationController
 
       redirect_to root_path, notice: "#{@organisation.name} created"
     else
-      @register_organisations = Organisation.fetch_organisations_from_register
-
       @hide_sidebar = true
-      render :new
+      render :new, locals: { organisation_options: }
     end
   end
 
@@ -39,6 +36,10 @@ class OrganisationsController < ApplicationController
   end
 
 private
+
+  def organisation_options
+    Organisation.fetch_organisations_from_register.prepend("").map { |org| OpenStruct.new(name: org) }
+  end
 
   def sidebar
     @hide_sidebar ? :empty : super

--- a/app/views/organisations/new.html.erb
+++ b/app/views/organisations/new.html.erb
@@ -1,47 +1,22 @@
-<% content_for :page_title, "Add an organisation" %>
+<% content_for :page_title, "Register an organisation" %>
 
-<%= render "layouts/form_errors", resource: @organisation %>
-
-<h1 class="govuk-heading-l">Add an organisation to GovWifi</h1>
-<%= form_for @organisation, url: organisations_path do |form| %>
-  <div class="govuk-form-group <%= field_error(@organisation, "name") %>">
-    <%= form.label :name, "Organisation name", class: "govuk-label" %>
-    <div class="govuk-hint">If your organisation name does not appear below
-      <%= link_to "contact us", technical_support_new_help_path, class: "govuk-link" %>
-    </div>
-    <% if @organisation.errors.attribute_names.include?(:name) %>
-      <span class="govuk-error-message" id="organisation_name_error">
-        <span class="govuk-visually-hidden">Error:</span>
-        <%= @organisation.errors.full_messages_for(:name).first %>
-      </span>
-      <%= form.select :name, options_for_select(@register_organisations << "", @organisation.name || ""),
-                      {}, class: "govuk-select govuk-input--error" %>
-    <% else %>
-      <%= form.select :name, options_for_select(@register_organisations << "", @organisation.name || ""), {}, class: "govuk-select" %>
-    <% end %>
-  </div>
-
-  <div class="govuk-form-group <%= field_error(@organisation, "service_email") %>">
-    <%= form.label :service_email, "Service email", class: "govuk-label" %>
-    <div class="govuk-hint">A shared and monitored email so we can contact your organisation about GovWifi</div>
-    <% if @organisation.errors.attribute_names.include?(:service_email) %>
-      <span class="govuk-error-message" id="email_error">
-        <span class="govuk-visually-hidden">Error:</span>
-        <%= @organisation.errors.full_messages_for(:service_email).first %>
-      </span>
-      <%= form.text_field :service_email,
-                          class: "govuk-input govuk-input--error",
-                          value: @organisation.service_email || "" %>
-    <% else %>
-      <%= form.text_field :service_email,
-                          class: "govuk-input",
-                          value: @organisation.service_email || "" %>
-    <% end %>
-  </div>
-  <div class="actions">
-    <%= form.submit "Add organisation", class: "govuk-button govuk-!-margin-top-2" %>
-
-  </div>
+<%= form_with model: @organisation,
+              url: organisations_path,
+              builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+  <%= form.govuk_error_summary %>
+  <h1 class="govuk-heading-l">Add an organisation to GovWifi</h1>
+  <% select_hint = capture do %>
+    If your organisation name does not appear below
+    <%= link_to "contact us", technical_support_new_help_path, class: "govuk-link" %>
+  <% end %>
+  <%= form.govuk_collection_select :name,
+                                   organisation_options, :name, :name,
+                                   hint: { text: select_hint },
+                                   label: { text: "Organisation name" } %>
+  <%= form.govuk_text_field :service_email,
+                            label: { text: "Service email" },
+                            hint: { text: "A shared and monitored email so we can contact your organisation about GovWifi" } %>
+  <%= form.govuk_submit "Add organisation" %>
   <p class="govuk-body"><%= link_to "Cancel", :back, class: "govuk-link--no-visited-state" %></p>
 <% end %>
 


### PR DESCRIPTION
### What
Update organisations#new views to use GOV.UK form builder
### Why
It simplifies code, ensures the frontend and error messages are consistent
and in line with the design system.

Link to Trello card (if applicable): 
https://trello.com/c/geuWyFBU/614-improve-error-messages-in-govwifi-admin