### PR TITLE
Update invitations#edit and contact details forms to use GOV.UK builder

### DIFF
--- a/app/controllers/super_admin/wifi_user_searches_controller.rb
+++ b/app/controllers/super_admin/wifi_user_searches_controller.rb
@@ -1,18 +1,18 @@
 class SuperAdmin::WifiUserSearchesController < SuperAdminController
-  def show; end
+  def show
+    @form = SearchForm.new(search_term_params)
+  end
 
   def create
-    if search_term.blank?
-      flash.now[:alert] = "Search term can't be blank"
-    else
-      @wifi_user = WifiUser.search(search_term.gsub(" ", ""))
-    end
+    @form = SearchForm.new(search_term_params)
+    @form_valid = @form.valid?
+    @wifi_user = @form_valid ? WifiUser.search(@form.search_term) : nil
     render :show
   end
 
 private
 
-  def search_term
-    params[:search_term]
+  def search_term_params
+    params.fetch(:search_form, {}).permit(:search_term)
   end
 end

--- a/app/models/search_form.rb
+++ b/app/models/search_form.rb
@@ -1,0 +1,11 @@
+class SearchForm
+  include ActiveModel::Model
+
+  attr_writer :search_term
+
+  validates :search_term, presence: true
+
+  def search_term
+    @search_term&.delete(" ")
+  end
+end

--- a/app/views/super_admin/wifi_user_searches/show.html.erb
+++ b/app/views/super_admin/wifi_user_searches/show.html.erb
@@ -1,37 +1,30 @@
 <% content_for :page_title, "Search logs by user details" %>
-
-<%= render "layouts/form_errors", resource: @search %>
-
-<div class='govuk-grid-row'>
-
-  <h1 class='govuk-heading-l govuk-grid-column-full'>Search for user details</h1>
-
-  <div class='govuk-grid-column-two-thirds'>
-    <%= form_with url: super_admin_wifi_user_search_path,
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <p>
-        <%= f.govuk_text_field :search_term, width: 20, label: { text: "Username, email address or phone number" } %>
-      </p>
-      <p>
-        <%= f.govuk_submit "Find user details" %>
-      </p>
-    <% end %>
-
-    <div class="govuk-body">
-      <% if @wifi_user %>
-        <h3>User details for '<%= params[:search_term] %>'</h3>
-        <p>
-          Username: <%= link_to @wifi_user.username,
-                                logs_path(log_search_form: { username: @wifi_user.username,
-                                                             filter_option: LogSearchForm::USERNAME_FILTER_OPTION }),
-                                title: "Search logs for '#{@wifi_user.username}'" %>
-        </p>
-        <p>
-          Contact: <%= @wifi_user.contact %>
-        </p>
-      <% elsif !params[:search_term].blank? %>
-        <h3>Nothing found for '<%= params[:search_term] %>'</h3>
+<%= form_with model: @form, url: super_admin_wifi_user_search_path,
+              builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+  <%= f.govuk_error_summary %>
+  <div class='govuk-grid-row'>
+    <h1 class='govuk-heading-l govuk-grid-column-full'>Search for user details</h1>
+    <div class='govuk-grid-column-two-thirds'>
+      <%= f.govuk_text_field :search_term, width: 20, label: { text: "Username, email address or phone number" } %>
+      <%= f.govuk_submit "Find user details" %>
+      <% if @form_valid %>
+        <div class="govuk-body">
+          <% if @wifi_user.present? %>
+            <h3 class="govuk-heading-s">User details for '<%= params[:search_term] %>'</h3>
+            <p class="govuk-body">
+              Username: <%= link_to @wifi_user.username,
+                                    logs_path(log_search_form: { username: @wifi_user.username,
+                                                                 filter_option: LogSearchForm::USERNAME_FILTER_OPTION }),
+                                    title: "Search logs for '#{@wifi_user.username}'" %>
+            </p>
+            <p class="govuk-body">
+              Contact: <%= @wifi_user.contact %>
+            </p>
+          <% else %>
+            <h3 class="govuk-heading-s">Nothing found for '<%= @form.search_term %>'</h3>
+          <% end %>
+        </div>
       <% end %>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/users/invitations/edit.html.erb
+++ b/app/views/users/invitations/edit.html.erb
@@ -1,30 +1,24 @@
 <% content_for :page_title, "Create your account" %>
 
-<%= render "layouts/form_errors" %>
+<%= form_for resource,
+             as: resource_name,
+             url: invitation_path(resource_name),
+             html: { method: :put, novalidate: "" },
+             builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+  <%= f.govuk_error_summary %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Create your account</h1>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Create your account</h1>
+      <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
 
-    <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-      <%= form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put, novalidate: "" } do |f| %>
         <%= f.hidden_field :invitation_token, readonly: true %>
-
-        <div class="govuk-form-group <%= field_error(resource, :name) %>">
-          <%= f.label :name, "Your name", class: "govuk-label" %>
-          <%= f.text_field :name, class: "govuk-input" %>
-        </div>
-
-        <div class="govuk-form-group <%= field_error(resource, :password) %>">
-          <%= f.label :password, "Password", class: "govuk-label" %>
-          <div class="govuk-hint"> Must be at least 6 characters long</div>
-          <%= f.password_field :password, class: "govuk-input", autocomplete: "off" %>
-        </div>
-
-        <div class="actions">
-          <%= f.submit "Create my account", class: "govuk-button govuk-!-margin-top-2" %>
-        </div>
-      <% end %>
+        <%= f.govuk_text_field :name, label: { text: "Your name" } %>
+        <%= f.govuk_password_field :password,
+                                   label: { text: "Password" },
+                                   hint: { text: "Must be at least 6 characters long" } %>
+        <%= f.govuk_submit "Create my account" %>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,10 @@ en:
   activemodel:
     errors:
       models:
+        search_form:
+          attributes:
+            search_term:
+              blank: "Search term can't be blank"
         user_membership_form:
           attributes:
             name:

--- a/spec/features/super_admin/lookup_wifi_user_contact_details_spec.rb
+++ b/spec/features/super_admin/lookup_wifi_user_contact_details_spec.rb
@@ -10,13 +10,13 @@ describe "Lookup wifi user contact details", type: :feature do
     visit root_path
     click_on "User Details"
 
-    fill_in "search_term", with: search_term
+    fill_in "Username, email address or phone number", with: search_term
     click_on "Find user details"
   end
 
   context "with no search term" do
     it "presents an error message" do
-      expect(page).to have_content("Search term can't be blank")
+      expect(page).to have_content("Search term can't be blank").twice
     end
   end
 


### PR DESCRIPTION
### What

Update invitations#edit and contact details forms to use GOV.UK form builder

### Why

It simplifies code, ensures the frontend and error messages are consistent
and in line with the design system.

Introduced a form model to handle the 'search_term' parameter for the
contact details form.


Link to Trello card (if applicable): 
https://trello.com/c/geuWyFBU/614-improve-error-messages-in-govwifi-admin