### PR TITLE
Update password forms to use GOV.UK form builder

### DIFF
--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,26 +1,21 @@
 <% content_for :page_title, "Change your password" %>
 
-<%= render "layouts/form_errors" %>
+<%= form_with model: resource, as: resource_name,
+              url: password_path(resource_name),
+              html: { method: :put },
+              builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+  <%= f.govuk_error_summary %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Change your password</h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Change your password</h1>
 
-    <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+      <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
         <%= f.hidden_field :reset_password_token %>
-
-        <div class="govuk-form-group <%= field_error(resource, :password) %>">
-          <%= f.label :password, "New password", class: "govuk-label" %>
-          <%= f.password_field :password, class: "govuk-input", autocomplete: "off" %>
-        </div>
-
-        <div class="actions">
-          <%= f.submit "Change my password", class: "govuk-button govuk-!-margin-top-2" %>
-        </div>
-      <% end %>
-
-      <%= render "users/shared/links" %>
+        <%= f.govuk_password_field :password, label: { text: "New password" } %>
+        <%= f.govuk_submit "Change my password" %>
+        <%= render "users/shared/links" %>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,26 +1,19 @@
 <% content_for :page_title, "Reset your password" %>
+<%= form_with model: resource, as: resource_name,
+              url: password_path(resource_name),
+              html: { method: :post, novalidate: "" },
+              builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
 
-<%= render "layouts/form_errors" %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Reset your GovWifi admin account password</h1>
+      <%= render "users/shared/end_user_warning" %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Reset your GovWifi admin account password</h1>
-
-    <%= render "users/shared/end_user_warning" %>
-
-    <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, novalidate: "" }) do |f| %>
-        <div class="govuk-form-group">
-          <%= f.label :email, "Provide your email address", class: "govuk-label" %>
-          <%= f.email_field :email, autocomplete: "email", class: "govuk-input" %>
-        </div>
-
-        <div class="actions">
-          <%= f.submit "Send me reset password instructions", class: "govuk-button govuk-!-margin-top-2" %>
-        </div>
-      <% end %>
-
-      <%= render "users/shared/links" %>
+      <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
+        <%= f.govuk_email_field :email, label: { text: "Provide your email address" } %>
+        <%= f.govuk_submit "Send me reset password instructions" %>
+        <%= render "users/shared/links" %>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/spec/features/authentication/reset_password_spec.rb
+++ b/spec/features/authentication/reset_password_spec.rb
@@ -17,7 +17,7 @@ describe "Resetting a password", type: :feature do
   context "when the user has never signed up" do
     before do
       visit new_user_password_path
-      fill_in "user_email", with: "user@user.com"
+      fill_in "Provide your email address", with: "user@user.com"
       click_on "Send me reset password instructions"
     end
 
@@ -35,7 +35,7 @@ describe "Resetting a password", type: :feature do
 
     before do
       visit new_user_password_path
-      fill_in "user_email", with: user.email
+      fill_in "Provide your email address", with: user.email
       click_on "Send me reset password instructions"
     end
 
@@ -53,7 +53,7 @@ describe "Resetting a password", type: :feature do
 
     before do
       visit new_user_password_path
-      fill_in "user_email", with: user.email
+      fill_in "Provide your email address", with: user.email
       click_on "Send me reset password instructions"
     end
 
@@ -71,7 +71,7 @@ describe "Resetting a password", type: :feature do
 
     before do
       visit new_user_password_path
-      fill_in "user_email", with: user.email
+      fill_in "Provide your email address", with: user.email
       click_on "Send me reset password instructions"
       visit(last_notification_link)
     end
@@ -86,7 +86,7 @@ describe "Resetting a password", type: :feature do
 
     context "when entering a password that is 6 to 80 characters long" do
       before do
-        fill_in "user_password", with: "newBUT str0ng passsssssword"
+        fill_in "New password", with: "newBUT str0ng passsssssword"
         click_on "Change my password"
       end
 
@@ -101,7 +101,7 @@ describe "Resetting a password", type: :feature do
 
     context "when entering a password that is less than 6 characters" do
       before do
-        fill_in "user_password", with: "pass"
+        fill_in "New password", with: "pass"
         click_on "Change my password"
       end
 


### PR DESCRIPTION
### What
Update password forms to use GOV.UK form builder

### Why
It simplifies code, ensures the frontend and error messages are consistent
and in line with the design system.

Link to Trello card (if applicable): 
https://trello.com/c/geuWyFBU/614-improve-error-messages-in-govwifi-admin