### PR TITLE
Rename the 2fA button from Submit to Continue

### DIFF
--- a/app/views/users/two_factor_authentication/show.html.erb
+++ b/app/views/users/two_factor_authentication/show.html.erb
@@ -13,7 +13,7 @@
                                autocomplete: "off",
                                "aria-describedby" => "code-hint",
                                label: nil %>
-      <%= f.govuk_submit "Submit" %>
+      <%= f.govuk_submit "Continue" %>
     <% end %>
 
     <details class="govuk-details" data-module="govuk-details">


### PR DESCRIPTION
### What
Rename the 2fA button from Submit to Continue
### Why
It was changed by accident when converting the form to using the
GOV.UK form builder. This changes it back. 
