### PR TITLE
Restore Google Tag Manager to Admin Site

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -1,7 +1,13 @@
 //= require all.js
 //= require govwifi-shared-frontend.js
 
+const GA_ID = "<%= SITE_CONFIG["google_analytics_script_id"] %>";
+
 window.addEventListener("DOMContentLoaded", () => {
   window.GOVUKFrontend.initAll();
   window.GovWifi.cookies.checkCookiePolicy();
+
+  if (!!GA_ID && !GovWifi.cookies.isCategoryAllowed("tracking")) {
+    window['ga-disable-' + GA_ID] = true;
+  }
 });

--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -1,0 +1,31 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= SITE_CONFIG["google_analytics_script_id"] %>"></script>
+
+<script>
+ window.dataLayer = [{
+     'signedIn': '<%= user_signed_in?.to_json %>',
+     'hasIPs': '<%= (current_user && current_organisation&.ips&.any?).to_json %>'
+ }];
+</script>
+
+<!-- Google Tag Manager -->
+<script>
+ window.dataLayer = window.dataLayer || [];
+ function gtag(){dataLayer.push(arguments);}
+ gtag('js', new Date());
+ gtag('config', '<%= SITE_CONFIG["google_analytics_script_id"] %>');
+
+ (function(w, d, s, l, i) {
+     w[l] = w[l] || [];
+     w[l].push({
+         "gtm.start": new Date().getTime(),
+         event: "gtm.js"
+     });
+     var f = d.getElementsByTagName(s)[0],
+         j = d.createElement(s),
+         dl = l != "dataLayer" ? "&l=" + l : "";
+     j.async = true;
+     j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+     f.parentNode.insertBefore(j, f);
+ })(window, document, "script", "dataLayer", "GTM-WX4MM64");
+</script>

--- a/app/views/layouts/_google_tag_manager_no_script.html.erb
+++ b/app/views/layouts/_google_tag_manager_no_script.html.erb
@@ -1,0 +1,4 @@
+<noscript>
+  <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WX4MM64"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe>
+</noscript>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,8 @@
   <head>
     <!-- test post please ignore -->
 
+    <%= render "layouts/google_analytics" %>
+
     <title><%= infer_page_title %></title>
 
     <meta charset="utf-8" />
@@ -34,6 +36,8 @@
   </head>
 
   <body class="govuk-template__body app-body-class">
+    <%= render "layouts/google_tag_manager_no_script" %>
+
     <script>
         document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,0 +1,3 @@
+Rails.application.config.content_security_policy do |policy|
+  policy.script_src :self, "https://www.googletagmanager.com", "https://www.google-analytics.com"
+end

--- a/config/site.yml
+++ b/config/site.yml
@@ -17,7 +17,10 @@ test:
   <<: *default
 
 staging:
+  google_analytics_script_id: 'UA-127779891-2'
+
   <<: *default
 
 production:
+  google_analytics_script_id: 'UA-127779891-1'
   <<: *default


### PR DESCRIPTION
### What

This reverts commit 9fc5a48edab7ae7769e4bc23ff247530608a50d3.

Revert "Remove google tag manager" and add CSRF protection

### Why

So we can record and access analytics data on the admin site.


Link to Trello card (if applicable): 

https://trello.com/c/wy54K9rM/2263-analytics-on-admin-user-journeys
