### PR TITLE
Add former flexibility in JS execution defaulted-out by new CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,3 +1,3 @@
 Rails.application.config.content_security_policy do |policy|
-  policy.script_src :self, "https://www.googletagmanager.com", "https://www.google-analytics.com"
+  policy.script_src :self, "https://www.googletagmanager.com", "https://www.google-analytics.com", :unsafe_eval, :unsafe_inline
 end


### PR DESCRIPTION
### What

The addition of a Content Security Policy prevents, by default,
the execution of inline scripts from other domains and the
evalution of strings as JS. The intention of the CSP (for now)
was simply to restrict which domains scripts could be downloaded
and executed from.

This commit re-introduces the ability to do both.

### Why
To enable execution of Google Analytics scripts.


Link to Trello card (if applicable): 

https://trello.com/c/wy54K9rM/2263-analytics-on-admin-user-journeys
