### PR TITLE
Remove Content Security Policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,3 +1,0 @@
-Rails.application.config.content_security_policy do |policy|
-  policy.script_src :self, "https://www.googletagmanager.com", "https://www.google-analytics.com"
-end


### PR DESCRIPTION
### What

Removes the CSP added in 64643534efa6cf329350fc58c50caa22f30785a1
as part of work to re-implement Google Analytics. Adding a CSP will
be split out into another PR.

### Why

To separate this proposed change into another PR, TBC after further
discussion.

Link to Trello card (if applicable): 

https://trello.com/c/wy54K9rM/2263-analytics-on-admin-user-journeys