### PR TITLE
Add model validation and database constraint

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -9,6 +9,7 @@ class Location < ApplicationRecord
   validates_associated :ips
 
   validates :address, :postcode, presence: true
+  validates :address, uniqueness: { scope: :organisation_id }
   validate :validate_postcode_format, if: ->(l) { l.postcode.present? }
 
   before_create :set_radius_secret_key

--- a/db/migrate/20220525140423_add_address_organisation_id_index_to_locations.rb
+++ b/db/migrate/20220525140423_add_address_organisation_id_index_to_locations.rb
@@ -1,0 +1,5 @@
+class AddAddressOrganisationIdIndexToLocations < ActiveRecord::Migration[6.1]
+  def change
+    add_index :locations, %i[address organisation_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_16_112023) do
+ActiveRecord::Schema.define(version: 2022_05_25_140423) do
 
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2022_03_16_112023) do
     t.bigint "organisation_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["address", "organisation_id"], name: "index_locations_on_address_and_organisation_id", unique: true
     t.index ["organisation_id"], name: "index_locations_on_organisation_id"
   end
 

--- a/spec/features/ips/search_locations_spec.rb
+++ b/spec/features/ips/search_locations_spec.rb
@@ -2,10 +2,12 @@ describe "Search Locations", type: :feature do
   let(:user) { create(:user, :with_organisation) }
   let(:organisation) { user.organisations.first }
 
-  context "10 organisations with the same name, 1 different and alphabetically last" do
+  context "10 locations with the same name, 1 different and alphabetically last" do
     before :each do
-      FactoryBot.create_list(:location, 10, address: "BB123BB", postcode: "AA11AA", organisation:)
-      FactoryBot.create(:location, address: "QQQ123QQQ", postcode: "ZZ99ZZ", organisation:)
+      FactoryBot.create_list(:location, 20, postcode: "AA11AA", organisation:) do |location, i|
+        location.address = "Aardvark Place #{i}"
+      end
+      FactoryBot.create(:location, address: "Zebra Place 0", postcode: "ZZ99ZZ", organisation:)
       sign_in_user user
       visit ips_path
     end
@@ -27,7 +29,7 @@ describe "Search Locations", type: :feature do
     end
 
     it "Filters on addresses that are not in the current page" do
-      fill_in "search", with: "Q12"
+      fill_in "search", with: "Zebra"
       expect {
         click_button("Search")
       }.to change {


### PR DESCRIPTION
### What
Add model validation and database constraint

### Why
So that the same location address cannot be entered twice for any given organisation.
A single organisation may still have two different addresses with the same postcode.


Link to Trello card (if applicable): 

https://trello.com/c/YDAI28UQ/2217-upload-a-list-of-locations-and-associated-ip-addresses-to-connect-to-govwifi