### PR TITLE
Support deleting wifi users

### DIFF
--- a/app/controllers/super_admin/wifi_user_searches_controller.rb
+++ b/app/controllers/super_admin/wifi_user_searches_controller.rb
@@ -10,6 +10,24 @@ class SuperAdmin::WifiUserSearchesController < SuperAdminController
     render :show
   end
 
+  def confirm_destroy
+    @form = SearchForm.new(search_term_params)
+    @form_valid = @form.valid?
+    @wifi_user = @form_valid ? WifiUser.search(@form.search_term) : nil
+  end
+
+  def destroy
+    @form = SearchForm.new(search_term_params)
+    @form_valid = @form.valid?
+    @wifi_user = @form_valid ? WifiUser.search(@form.search_term) : nil
+
+    flash[:notice] = "#{@wifi_user.username} (#{@wifi_user.contact}) has been removed"
+
+    @wifi_user.destroy!
+
+    redirect_to super_admin_wifi_user_search_path
+  end
+
 private
 
   def search_term_params

--- a/app/views/super_admin/wifi_user_searches/confirm_destroy.html.erb
+++ b/app/views/super_admin/wifi_user_searches/confirm_destroy.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title, "Confirm removing #{@wifi_user.contact}" %>
+
+<div class='govuk-grid-row'>
+  <h1 class='govuk-heading-l govuk-grid-column-full'>Confirm removing <%= @wifi_user.contact %></h1>
+  <div class='govuk-grid-column-two-thirds'>
+    <p class="govuk-body">
+      This will remove the users credentials from the database. Once
+      this has happened, they will be able to sign up again and get
+      new credentials.
+    </p>
+
+    <%= button_to(
+          "Remove user",
+          super_admin_wifi_user_search_path(search_form: { search_term: @form.search_term }),
+          method: :delete,
+          class: "govuk-button govuk-button--warning",
+          "data-module": "govuk-button",
+        ) %>
+
+    <p class="govuk-body"><%= link_to "Cancel", :back, class: "govuk-link--no-visited-state" %></p>
+  </div>
+</div>

--- a/app/views/super_admin/wifi_user_searches/show.html.erb
+++ b/app/views/super_admin/wifi_user_searches/show.html.erb
@@ -19,6 +19,11 @@
             <p class="govuk-body">
               Contact: <%= @wifi_user.contact %>
             </p>
+
+            <%= link_to confirm_destroy_super_admin_wifi_user_search_path(search_form: { search_term: @form.search_term }),
+                        class: "govuk-button red-button" do %>
+              Remove user <span class='govuk-visually-hidden'>- <%= @wifi_user.contact %></span>
+            <% end %>
           <% else %>
             <h3 class="govuk-heading-s">Nothing found for '<%= @form.search_term %>'</h3>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,7 +75,9 @@ Rails.application.routes.draw do
         resources :organisation_names, only: %i[index create destroy]
       end
     end
-    resource :wifi_user_search, only: %i[show create]
+    resource :wifi_user_search, only: %i[show create destroy] do
+      get "destroy", to: "wifi_user_searches#confirm_destroy", as: :confirm_destroy
+    end
   end
 
   %w[404 422 500].each do |code|

--- a/spec/features/super_admin/lookup_wifi_user_contact_details_spec.rb
+++ b/spec/features/super_admin/lookup_wifi_user_contact_details_spec.rb
@@ -59,4 +59,20 @@ describe "Lookup wifi user contact details", type: :feature do
       expect(page).to have_content("zZyYxX")
     end
   end
+
+  context "when deleting a user" do
+    let(:search_term) { "zZyYxX" }
+
+    it "successfully deletes the user" do
+      click_on "Remove user"
+
+      expect(page).to have_content("Confirm removing #{contact}")
+
+      click_on "Remove user"
+
+      expect(page).to have_content("#{search_term} (#{contact}) has been removed")
+
+      expect(WifiUser.search(search_term)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
### What
Support deleting wifi users.

### Why
So this task can be done by clicking in the admin app, rather than manually running queries against the database.

![image](https://user-images.githubusercontent.com/1130010/171378776-917db825-9d6f-4793-b89c-f2b94ed46ff5.png)

![image](https://user-images.githubusercontent.com/1130010/171378831-ef1a42fc-6a1d-4156-ba7e-92087704b364.png)

![image](https://user-images.githubusercontent.com/1130010/171378885-6ee43e9b-3736-47ae-a903-5007f365f3f6.png)


Link to Trello card: https://trello.com/c/yw5VYGdD/2265-a-super-admin-can-delete-user-credentials