### PR TITLE
Six digit code error message

### DIFF
--- a/app/controllers/users/two_factor_authentication_setup_controller.rb
+++ b/app/controllers/users/two_factor_authentication_setup_controller.rb
@@ -17,7 +17,7 @@ class Users::TwoFactorAuthenticationSetupController < ApplicationController
       flash[:notice] = "Two factor authentication setup successful"
       disable_2fa_checks_for_session
     else
-      flash[:alert] = "Six digit code is not valid"
+      flash[:alert] = "The 6 digit code entered is not valid.<br />  Check the code sent in the email or request a new email.".html_safe
       render "show"
     end
   end

--- a/app/views/layouts/_flash_notices.html.erb
+++ b/app/views/layouts/_flash_notices.html.erb
@@ -13,7 +13,11 @@
         There is a problem
       </h2>
       <div class="govuk-error-summary__body">
-        <p><%= msg %></p>
+        <ul class="govuk-list govuk-error-summary__list">
+          <li>
+            <%= msg %>
+          </li>
+        </ul>
       </div>
     </div>
   <% end %>

--- a/spec/features/authentication/set_up_two_factor_authentication_spec.rb
+++ b/spec/features/authentication/set_up_two_factor_authentication_spec.rb
@@ -104,7 +104,7 @@ describe "Set up two factor authentication", type: :feature do
     end
 
     it "returns an error" do
-      expect(page).to have_content("Six digit code is not valid")
+      expect(page).to have_content("The 6 digit code entered is not valid. Check the code sent in the email or request a new email.")
     end
 
     it "returns to the 2FA screen" do


### PR DESCRIPTION
### What
Change wording and styling for 2FA error message

### Why
Current wording for 2FA error message is inaccurate


Link to Trello card (if applicable): https://trello.com/c/Cb2s7VqC/2444-wording-for-2fa-error-message-and-help-text

<img width="840" alt="Screenshot error message" src="https://user-images.githubusercontent.com/34037863/179460982-97dc2285-54f8-440c-a69a-0807fa949079.png">

