### PR TITLE
GW-102-Change-a-registered-location-address-(Q2)

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,6 +1,6 @@
 class LocationsController < ApplicationController
   before_action :authorise_manage_locations
-  before_action :authorise_manage_current_location, only: %i[add_ips update_ips update]
+  before_action :authorise_manage_current_location, only: %i[add_ips update_ips update edit]
 
   def new
     @location = Location.new
@@ -20,10 +20,27 @@ class LocationsController < ApplicationController
     end
   end
 
+  def edit
+    @location = Location.find(params[:id])
+  end
+
   def update
     location = Location.find(params[:id])
     location.update!(radius_secret_key: rotate_radius_secret_key)
     redirect_to(ips_path, notice: "RADIUS secret key has been successfully rotated")
+  end
+
+  def update_location
+    @location = Location.find(params[:location_id])
+    if @location.update(
+      address: params.dig(:location, :address),
+      postcode: params.dig(:location, :postcode),
+      organisation_id: current_organisation.id,
+    )
+      redirect_to(ips_path, notice: "Location updated")
+    else
+      render :edit
+    end
   end
 
   def add_ips

--- a/app/views/locations/edit.erb
+++ b/app/views/locations/edit.erb
@@ -1,0 +1,17 @@
+<% content_for :page_title, "Update location" %>
+
+<%= form_with model: @location, url: location_update_location_path(@location), method: :patch do |f| %>
+  <%= f.govuk_error_summary %>
+  <div class='govuk-grid-row'>
+    <div class='govuk-grid-column-full'>
+      <h1 class='govuk-heading-l'>Update location</h1>
+    </div>
+    <div class='govuk-grid-column-full'>
+      <%= f.govuk_text_field :address,
+                             hint: { text: "For example, 10 High Street, London" } %>
+      <%= f.govuk_text_field :postcode %>
+      <%= f.govuk_submit "Update" %>
+      <p><%= link_to "Cancel", ips_path, class: "govuk-link--no-visited-state govuk-body" %></p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/_manage_ips.html.erb
+++ b/app/views/shared/_manage_ips.html.erb
@@ -18,6 +18,11 @@
                     role: "button", draggable: "false", "data-module" => "govuk-button" do %>
           Rotate secret key <span class='govuk-visually-hidden'>for <%= location.full_address %></span>
         <% end %>
+        <%= link_to edit_location_path(location),
+                    class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-5",
+                    role: "button", draggable: "false", "data-module" => "govuk-button" do %>
+          Update this location <span class='govuk-visually-hidden'>for <%= location.full_address %></span>
+        <% end %>
         <% if location.ips.empty? %>
           <%= link_to ips_path(location_id: location.id, confirm_remove: true),
                       class: "govuk-button govuk-button--warning govuk-!-margin-bottom-5",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,9 +36,10 @@ Rails.application.routes.draw do
     get "technical_support", on: :new
     get "user_support", on: :new
   end
-  resources :locations, only: %i[new create destroy update] do
+  resources :locations, only: %i[new create destroy update edit] do
     get "add_ips", to: "add_ips"
     patch "update_ips", to: "update_ips"
+    patch "update_location", to: "update_location"
   end
   resources :memberships, only: %i[edit update index destroy]
   resources :mou, only: %i[index create]

--- a/spec/features/locations/update_location_spec.rb
+++ b/spec/features/locations/update_location_spec.rb
@@ -1,0 +1,32 @@
+describe "Update location", type: :feature do
+  let(:organisation) { create(:organisation) }
+  let(:user) { create(:user, organisations: [organisation]) }
+  let!(:location) { create(:location, organisation:) }
+
+  before do
+    sign_in_user user
+    visit ips_path
+    click_on "Update this location"
+  end
+
+  it "displays an instruction to update a location" do
+    expect(page).to have_content("Update location")
+  end
+
+  it "displays a Cancel link" do
+    expect(page).to have_link("Cancel", href: "/ips")
+  end
+
+  context "update current location details" do
+    let(:new_address) { "new address" }
+    let(:new_postcode) { "E14 4BU" }
+    it "succeeds" do
+      fill_in "Address", with: new_address
+      fill_in "Postcode", with: new_postcode
+      click_on "Update"
+      location.reload
+      expect(location.address).to eq(new_address)
+      expect(location.postcode).to eq(new_postcode)
+    end
+  end
+end


### PR DESCRIPTION
### What
Change a registered location address

### Why
Admin users are unable to amend address from the admin site. This is rarely a problem but on occasion an admin may need to make an amendment to an address and its associated IP. We could do this from the database but that requires scheduling dev time for an arbitrary task that could be performed by the admin as a self serve function.


Link to Jira ticket (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-102

Image attached:
<img width="1333" alt="Screenshot 2022-07-26 at 00 05 25" src="https://user-images.githubusercontent.com/34037863/180889450-f00c0473-7c86-4e87-a9c0-0c94ecf9f0d5.png">
