### PR TITLE
Enable Rails web console in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,10 @@ group :test do
   gem "webmock", "~> 3.14.0"
 end
 
+group :development do
+  gem "web-console"
+end
+
 group :development, :test do
   gem "bullet", "~> 7.0"
   gem "byebug", "~> 11"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       html_tokenizer (~> 0.0.6)
       parser (>= 2.4)
       smart_properties
+    bindex (0.8.1)
     builder (3.2.4)
     bullet (7.0.2)
       activesupport (>= 3.0.0)
@@ -462,6 +463,11 @@ GEM
     uniform_notifier (1.16.0)
     warden (1.2.9)
       rack (>= 2.0.9)
+    web-console (4.2.0)
+      actionview (>= 6.0.0)
+      activemodel (>= 6.0.0)
+      bindex (>= 0.4.0)
+      railties (>= 6.0.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -530,6 +536,7 @@ DEPENDENCIES
   two_factor_authentication
   tzinfo-data
   uk_postcode (~> 2.1)
+  web-console
   webmock (~> 3.14.0)
   zendesk_api
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -146,4 +146,5 @@
     </footer>
     <%= javascript_include_tag "application.js" %>
   </body>
+  <%= console if Rails.env.development? %>
 </html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,6 +6,8 @@ Rails.application.configure do
   Bullet.unused_eager_loading_enable = true
   Bullet.n_plus_one_query_enable     = true
 
+  config.web_console.permissions = %w[172.0.0.0/8 192.168.0.0/16 10.0.0.0/8]
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on


### PR DESCRIPTION
### What
Enable Rails web console in development

### Why
To make debugging easier


Link to Trello card (if applicable): N/A
