### PR TITLE
Change download keys CSV delimiter to ;

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -89,7 +89,7 @@ class LocationsController < ApplicationController
   end
 
   def download_keys
-    keys_csv = CSV.generate(headers: true) do |csv|
+    keys_csv = CSV.generate(headers: true, col_sep: ";") do |csv|
       current_organisation.locations.each do |location|
         csv << [location[:address], location[:postcode], location[:radius_secret_key]]
       end


### PR DESCRIPTION
### What
Change download keys CSV delimiter to ;

### Why
Because postal addresses may contain commas, meaning
applications can't correctly interpret the downloaded CSV.


Link to Trello card (if applicable): None
