### PR TITLE
Handle invalid IP models when publishing IP allow lists

### DIFF
--- a/lib/use_cases/radius/publish_radius_ip_allowlist.rb
+++ b/lib/use_cases/radius/publish_radius_ip_allowlist.rb
@@ -2,7 +2,7 @@ module UseCases
   module Radius
     class PublishRadiusIpAllowlist
       def execute
-        data = Ip.includes(:location).map do |ip|
+        data = Ip.includes(:location).joins(:location).map do |ip|
           <<~ELEMENT
             client #{ip.address.tr('.', '-')} {
                   ipaddr = #{ip.address}

--- a/spec/use_cases/radius/publish_radius_ip_allowlist_spec.rb
+++ b/spec/use_cases/radius/publish_radius_ip_allowlist_spec.rb
@@ -54,6 +54,13 @@ client 2-2-2-2 {
     end
   end
 
+  context "when an invalid IP has been accidentally saved to the DB" do
+    it "ignores this IP address" do
+      Ip.new(address: "1.2.3.1").save!(validate: false)
+      expect { described_class.new.execute }.to_not raise_error
+    end
+  end
+
   context "when a location has no IPs" do
     let(:correct_configuration) do
       'client 1-2-2-1 {


### PR DESCRIPTION
### What
Handle invalid IP models when publishing IP allow lists

### Why
There are a few IP models in the database that have no corresponding
location. This causes the PublishRadiusIpAllowlist to crash and results
in the user seeing an error when adding an IP address

This commit makes the code a bit more robust and ignores Ip models
without a location
