### PR TITLE
Search for an ip address on the ips screen and address address to logs

### DIFF
--- a/app/controllers/ips_controller.rb
+++ b/app/controllers/ips_controller.rb
@@ -5,8 +5,17 @@ class IpsController < ApplicationController
     locations_scope = Location.includes(:ips)
       .where(organisation: current_organisation)
     if params[:search].present?
-      locations_scope = locations_scope.where("postcode like ?", "%#{params[:search]}%")
-                                       .or(locations_scope.where("address like ?", "%#{params[:search]}%"))
+      locations_scope = locations_scope.where(
+        "postcode like ?", "%#{params[:search]}%"
+      ).or(
+        locations_scope.where(
+          "locations.address like ?", "%#{params[:search]}%"
+        ),
+      ).or(
+        locations_scope.where(
+          "ips.address like ?", "%#{params[:search]}%"
+        ),
+      ).left_outer_joins(:ips)
     end
     @pagy, @locations = pagy(locations_scope.order(:address))
   end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -18,6 +18,7 @@ class LogsController < ApplicationController
               current_organisation.ip_addresses.intersection([log_search_form.ip])
             end
       logs = Gateways::Sessions.search(ips:, success:)
+      @current_location = Ip.find_by(address: ips).location if logs.present?
       render locals: { log_search_form:, logs: }
     when LogSearchForm::USERNAME_FILTER_OPTION
       ips = super_admin? ? nil : current_organisation.ip_addresses

--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -23,10 +23,10 @@
   <div class="govuk-grid-row">
   <% if current_organisation.locations.length > 1 %>
     <%= form_with url: ips_path, method: "get" do |form| %>
-      <%= form.govuk_fieldset legend: { text: "Search by location or postcode" } do %>
+      <%= form.govuk_fieldset legend: { text: "Search by location, postcode or IP address" } do %>
         <%= form.govuk_text_field :search, value: params.fetch(:search, ""),
-                                           label: { text: "Search by location or postcode", hidden: true },
-                                           hint: { text: "For example, 'SW1A 2AA' or 'High Street'" },
+                                           label: { text: "Search by location, postcode or IP address", hidden: true },
+                                           hint: { text: "For example, 'SW1A 2AA', 'High Street' or '78.22.233.40'" },
                                            width: 20 %>
         <%= form.govuk_submit "Search", class: "text-right" %>
       <% end %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -17,6 +17,12 @@
     "<%= log_search_form.username || log_search_form.ip || location_address %>"
   </h1>
 
+  <p class="govuk-body govuk-!-font-size-24">
+    <% if log_search_form.ip %>
+      IP address <%= log_search_form.ip %> is located at <%= @current_location.full_address %>
+    <% end %>
+  </p>
+
   <%= render "logs/filtered_results_explanation", logs: %>
 
   <%= render "logs/filter_logs_select", log_search_form: %>

--- a/spec/features/ips/search_locations_spec.rb
+++ b/spec/features/ips/search_locations_spec.rb
@@ -6,8 +6,9 @@ describe "Search Locations", type: :feature do
     before :each do
       create_list(:location, 20, postcode: "AA11AA", organisation:) do |location, i|
         location.address = "Aardvark Place #{i}"
+        location.ips.new(address: "89.1.1.#{i}")
       end
-      create(:location, address: "Zebra Place 0", postcode: "ZZ99ZZ", organisation:)
+      create(:location, address: "Zebra Place 0", postcode: "ZZ99ZZ", organisation:, ips: [Ip.new(address: "89.1.1.30")])
       sign_in_user user
       visit ips_path
     end
@@ -35,6 +36,12 @@ describe "Search Locations", type: :feature do
       }.to change {
         page.has_content?("ZZ99ZZ")
       }.from(false).to(true)
+    end
+
+    it "It shows location address when searching by IP" do
+      fill_in "search", with: "89.1.1.30"
+      click_button("Search")
+      expect(page).to have_content("Zebra Place 0")
     end
   end
 end

--- a/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
@@ -1,76 +1,95 @@
 describe "View authentication requests for an IP", type: :feature do
-  let!(:user) { create(:user) }
-  let!(:organisation_one) { create(:organisation, :with_location_and_ip, users: [user]) }
-  let!(:organisation_two) { create(:organisation, :with_location_and_ip, users: [user]) }
-  let(:ip_one) { organisation_one.ip_addresses.first }
-  let(:ip_two) { organisation_two.ip_addresses.first }
+  let(:user) { create(:user) }
 
   before do
-    create(:session, username: "Aaaaaa", siteIP: ip_one)
-    create(:session, username: "Aaaaaa", siteIP: ip_two)
-    create(:session, username: "aaabbb", siteIP: "9.9.9.9")
     sign_in_user user
   end
 
-  context "when using a link" do
+  context "User has an organisation, with a location and an IP" do
+    let(:ip) { location.ips.first.address }
+    let(:location) { user.organisations.first.locations.first }
     before do
-      visit ips_path
-
-      within(:xpath, "//tr[th[normalize-space(text())=\"#{ip_one}\"]]") do
-        click_on "View logs"
+      create(:organisation, :with_location_and_ip, users: [user])
+      create(:session, siteIP: ip, username: "Aaaaaa")
+    end
+    describe "when using a link" do
+      before do
+        visit ips_path
+        within(:xpath, "//tr[th[normalize-space(text())=\"#{ip}\"]]") do
+          click_on "View logs"
+        end
       end
-    end
-
-    it "displays the authentication requests" do
-      expect(page).to have_content("Found 1 result for IP: \"#{ip_one}\"")
-    end
-  end
-
-  context "when searching for an IP address" do
-    before do
-      visit new_logs_search_path
-      choose "IP address"
-      fill_in "Enter IP address", with: search_string
-      click_on "Show logs"
-    end
-
-    context "with a correct IP" do
-      let(:search_string) { ip_one }
 
       it "displays the authentication requests" do
-        expect(page).to have_content("Found 1 result for IP: \"#{ip_one}\"")
+        expect(page).to have_content("Found 1 result for IP: \"#{ip}\"")
+      end
+    end
+
+    context "when searching for an IP address" do
+      before do
+        visit new_logs_search_path
+        choose "IP address"
+        fill_in "Enter IP address", with: search_string
+        click_on "Show logs"
       end
 
-      it "has hyperlinks for username" do
-        click_on "Aaaaaa"
-        expect(page).to have_content("for username: \"Aaaaaa\"")
+      context "with a correct IP" do
+        let(:search_string) { ip }
+
+        it "displays the authentication requests" do
+          expect(page).to have_content("Found 1 result for IP: \"#{ip}\"")
+        end
+
+        it "displays address associated with the IP" do
+          expect(page).to have_content("IP address #{ip} is located at #{location.address}, #{location.postcode}")
+        end
+
+        it "has hyperlinks for username" do
+          click_on "Aaaaaa"
+          expect(page).to have_content("for username: \"Aaaaaa\"")
+        end
       end
     end
 
     context "with an IP that is not part of the current organisation" do
-      let(:search_string) { ip_two }
+      let!(:other_organisation) { create(:organisation, :with_location_and_ip) }
+      let(:search_string) { other_ip }
+      let(:other_ip) { other_organisation.locations.first.ips.first.address }
 
-      it "shows there are no results" do
-        expect(page).to have_content("Traffic from #{ip_two} is not reaching the GovWifi service")
+      before do
+        create(:session, siteIP: other_ip, username: "BBBBBB")
+        visit new_logs_search_path
+        choose "IP address"
+        fill_in "Enter IP address", with: search_string
+        click_on "Show logs"
+      end
+      context "as a regular admin" do
+        it "shows there are no results" do
+          expect(page).to have_content("Traffic from #{other_ip} is not reaching the GovWifi service")
+        end
+      end
+      context "as a super admin" do
+        let(:user) { create(:user, :super_admin) }
+
+        it "finds log entries for ip addresses regardless of the current organisation" do
+          expect(page).to have_content("Found 1 result for IP: \"#{other_ip}\"")
+        end
       end
     end
 
     context "with an incorrect IP" do
       let(:search_string) { "1" }
+      before do
+        visit new_logs_search_path
+        choose "IP address"
+        fill_in "Enter IP address", with: search_string
+        click_on "Show logs"
+      end
 
       it_behaves_like "errors in form"
 
       it "displays an error summary" do
         expect(page).to have_content("Search term must be a valid IP address").twice
-      end
-    end
-
-    context "as a super admin" do
-      let(:user) { create(:user, :super_admin) }
-      let(:search_string) { "9.9.9.9" }
-
-      it "finds log entries for ip addresses regardless of the current organisation" do
-        expect(page).to have_content("Found 1 result for IP: \"9.9.9.9\"")
       end
     end
   end

--- a/spec/features/logging/view_logs_spec.rb
+++ b/spec/features/logging/view_logs_spec.rb
@@ -1,5 +1,6 @@
 describe "View authentication requests for an IP", type: :feature do
-  let(:ip) { "1.2.3.4" }
+  let(:ip_address) { "11.22.33.44" }
+  let(:ip) { create(:ip, address: ip_address) }
   let(:username) { "ABCDEF" }
   let(:ap) { "govwifi-ap" }
   let(:mac) { "govwifi-mac" }
@@ -12,7 +13,7 @@ describe "View authentication requests for an IP", type: :feature do
            mac:,
            start: time,
            username:,
-           siteIP: ip,
+           siteIP: ip.address,
            success: true,
            task_id:)
 
@@ -21,7 +22,7 @@ describe "View authentication requests for an IP", type: :feature do
            mac:,
            start: time,
            username:,
-           siteIP: ip,
+           siteIP: ip.address,
            success: false,
            task_id:)
   end
@@ -30,10 +31,10 @@ describe "View authentication requests for an IP", type: :feature do
     before do
       super_admin_user = create(:user, :super_admin, :with_organisation)
       sign_in_user super_admin_user
-      visit logs_path(log_search_form: { ip:, filter_option: LogSearchForm::IP_FILTER_OPTION })
+      visit logs_path(log_search_form: { ip: ip.address, filter_option: LogSearchForm::IP_FILTER_OPTION })
     end
     it "displays the log" do
-      expect(page).to have_content("Found 2 results for IP: \"#{ip}\"")
+      expect(page).to have_content("Found 2 results for IP: \"#{ip.address}\"")
       expect(page).to have_css("td", text: username)
       expect(page).to have_css("td", text: ap)
       expect(page).to have_css("td", text: mac)
@@ -72,15 +73,16 @@ describe "View authentication requests for an IP", type: :feature do
   end
 
   context "as a regular admin" do
+    let(:ip) { create(:ip, location_id: location.id, address: ip_address, created_at: 5.days.ago) }
+    let(:admin_user) { create(:user, :with_organisation) }
+    let(:location) { create(:location, organisation: admin_user.organisations.first) }
+
     before do
-      admin_user = create(:user, :with_organisation)
-      location = create(:location, organisation: admin_user.organisations.first)
-      create(:ip, location_id: location.id, address: ip, created_at: 5.days.ago)
       sign_in_user admin_user
-      visit logs_path(log_search_form: { ip:, filter_option: LogSearchForm::IP_FILTER_OPTION })
+      visit logs_path(log_search_form: { ip: ip.address, filter_option: LogSearchForm::IP_FILTER_OPTION })
     end
     it "does not display the radius server" do
-      expect(page).to have_content("Found 2 results for IP: \"#{ip}\"")
+      expect(page).to have_content("Found 2 results for IP: \"#{ip.address}\"")
       expect(page).to_not have_css("td", text: task_id)
       expect(page).to_not have_css("th", text: "Radius Server")
     end


### PR DESCRIPTION
### What
Describe the change
Extend search functionality to allow searches using the IP address and to add address information to the IP logs

### Why
Describe why the change was necessary
The first page of the admin tool (/IPS) allows users to search by location and postcode but not by IP address.

If admins search for a user who is having problems, they will see the IP address they are connecting to but won't know what location the IP address is attributed to.

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-270
![Screenshot 2022-08-10 at 10 03 19](https://user-images.githubusercontent.com/34037863/184185784-762e1221-8600-4ccc-ba47-bbc6d512e119.png)
![Screenshot 2022-08-10 at 10 01 41](https://user-images.githubusercontent.com/34037863/184185805-bc5e13ca-50bf-4272-9905-95794b74218f.png)

