### PR TITLE
Add search functionality to allow super admins to search for an admin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,7 +49,8 @@ protected
        super_admin_users_path,
        new_super_admin_allowlist_path,
        super_admin_mou_index_path,
-       super_admin_wifi_user_search_path]
+       super_admin_wifi_user_search_path,
+       super_admin_wifi_admin_search_path]
     if sidebar_paths.include?(request.path)
       session[:sidebar_path] = request.path
     end

--- a/app/controllers/super_admin/wifi_admin_searches_controller.rb
+++ b/app/controllers/super_admin/wifi_admin_searches_controller.rb
@@ -1,0 +1,18 @@
+class SuperAdmin::WifiAdminSearchesController < SuperAdminController
+  def show
+    @form = SearchForm.new(search_term_params)
+  end
+
+  def create
+    @form = SearchForm.new(search_term_params)
+    @form_valid = @form.valid?
+    @user = @form_valid ? User.search(@form.search_term) : nil
+    render :show
+  end
+
+private
+
+  def search_term_params
+    params.fetch(:search_form, {}).permit(:search_term)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,4 +95,10 @@ class User < ApplicationRecord
   def send_new_otp_after_login?
     false
   end
+
+  def self.search(search_term)
+    search_attr = search_term =~ Devise.email_regexp ? :email : :name
+
+    find_by(search_attr => search_term)
+  end
 end

--- a/app/views/shared/sidebar/_default.html.erb
+++ b/app/views/shared/sidebar/_default.html.erb
@@ -45,6 +45,9 @@
         <li>
           <%= link_to "User Details", super_admin_wifi_user_search_path, class: active_tab(super_admin_wifi_user_search_path) %>
         </li>
+        <li>
+          <%= link_to "Admin Details", super_admin_wifi_admin_search_path, class: active_tab(super_admin_wifi_admin_search_path) %>
+        </li>
       </ul>
     <% end %>
   </nav>

--- a/app/views/super_admin/wifi_admin_searches/show.html.erb
+++ b/app/views/super_admin/wifi_admin_searches/show.html.erb
@@ -1,0 +1,33 @@
+<% content_for :page_title, "Search logs by admin details" %>
+<%= form_with model: @form, url: super_admin_wifi_admin_search_path do |f| %>
+  <%= f.govuk_error_summary %>
+  <div class='govuk-grid-row'>
+    <h1 class='govuk-heading-l govuk-grid-column-full'>Search for admin details</h1>
+    <div class='govuk-grid-column-two-thirds'>
+      <%= f.govuk_text_field :search_term, width: 20, label: { text: "Admin name or email address" } %>
+      <%= f.govuk_submit "Find admin details" %>
+      <% if @form_valid %>
+        <div class="govuk-body">
+          <% if @user.present? %>
+            <h3 class="govuk-heading-s">User details for '<%= @form.search_term %>'</h3>
+            <p class="govuk-body">
+              Name: <%= @user.name %>
+            </p>
+            <p class="govuk-body">
+              Email: <%= @user.email %>
+            </p>
+            <p class="govuk-body">
+              <ul class="govuk-list"> Organisations:
+                <% @user.organisations.each do |organisation| %>
+                  <li><%= link_to organisation.name, super_admin_organisation_path(organisation), class: "govuk-link filter-by" %></li>
+                <% end %>
+              </ul>
+            </p>
+          <% else %>
+            <h3 class="govuk-heading-s">Nothing found for '<%= @form.search_term %>'</h3>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,7 @@ Rails.application.routes.draw do
     resource :wifi_user_search, only: %i[show create destroy] do
       get "destroy", to: "wifi_user_searches#confirm_destroy", as: :confirm_destroy
     end
+    resource :wifi_admin_search, only: %i[show create]
   end
 
   %w[404 422 500].each do |code|

--- a/spec/features/super_admin/wifi_admin_searches_spec.rb
+++ b/spec/features/super_admin/wifi_admin_searches_spec.rb
@@ -1,0 +1,37 @@
+describe "Wifi Admin Searches", type: :feature do
+  let(:user) { create(:user, :super_admin, name: "super_admin") }
+
+  before do
+    sign_in_user user
+    visit super_admin_wifi_admin_search_path
+  end
+
+  it "Cannot find a user that does not exist" do
+    fill_in "Admin name or email address", with: "bob"
+    click_on "Find admin details"
+
+    expect(page).to have_content("Nothing found for 'bob'")
+  end
+
+  context "With an admin user" do
+    let(:admin_user) { create(:user) }
+    let(:name) { admin_user.name }
+    let(:email) { admin_user.email }
+    before do
+      fill_in "Admin name or email address", with: search_term
+      click_on "Find admin details"
+    end
+    describe "find by name" do
+      let(:search_term) { name }
+      it "Finds an admin user by name" do
+        expect(page).to have_content("User details for '#{name}'")
+      end
+    end
+    describe "find by email" do
+      let(:search_term) { email }
+      it "Finds an admin user by email address" do
+        expect(page).to have_content("User details for '#{email}'")
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -145,4 +145,22 @@ describe User do
       expect(user).not_to be_totp_enabled
     end
   end
+
+  describe "#search" do
+    let(:name) { "bob" }
+    let(:email) { "admin.user@govwifi.org" }
+    before do
+      create(:user, name:, email:)
+    end
+    context "with name as search term" do
+      it "finds an admin user" do
+        expect(User.search("BoB").name).to eq(name)
+      end
+    end
+    context "with email as search term" do
+      it "finds an admin user" do
+        expect(User.search("aDmIn.uSEr@govWIFI.org").email).to eq(email)
+      end
+    end
+  end
 end


### PR DESCRIPTION

### What
Add search functionality to allow super admins to search for an admin and show organisations the admin is a part of

### Why
It is not possible to know which organisation an admin user belongs to without them providing this information up-front via Zendesk


Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-82
<img width="1101" alt="Screenshot 2022-08-18 at 14 54 07" src="https://user-images.githubusercontent.com/34037863/185412584-f50b5935-653a-475e-8be2-69487202662b.png">

