### PR TITLE
Wording for password not strong enough error message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,7 +55,7 @@ en:
               invalid: "Password is invalid"
               blank: "Password can't be blank"
               too_short: "Password is too short (minimum is 6 characters)"
-              weak_password: "Password is not strong enough (scored %{score}, required at least %{min_password_score}). %{feedback}"
+              weak_password: "Password is not strong enough. Choose a different password."
             email:
               format: "%{message}"
               taken: "This email address is already associated with an account. If you can't sign in, reset your password."

--- a/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
+++ b/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
@@ -32,7 +32,7 @@ describe "Sign up from invitation", type: :feature do
         end
 
         it "rejects a weak password like #{weak_pass}" do
-          expect(page).to have_content "Password is not strong enough"
+          expect(page).to have_content "Password is not strong enough. Choose a different password."
         end
 
         it "does not confirm the user" do


### PR DESCRIPTION
### What
Re-word error message for password not strong enough.

### Why
Current wording for password not strong enough is confusing.


Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-298
<img width="1214" alt="Screenshot 2022-08-23 at 10 26 05" src="https://user-images.githubusercontent.com/34037863/186125179-05e9c547-bc7e-42f8-a4cc-2473eddc11bd.png">



