### PR TITLE
Ensure the /update_ips feature test passes reliably.

### DIFF
--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe LocationsController, type: :controller do
     let(:params) do
       {
         location_ips_form: {
-          ip_1: Faker::Internet.ip_v4_address,
-          ip_2: Faker::Internet.ip_v4_address,
+          ip_1: Faker::Internet.public_ip_v4_address,
+          ip_2: Faker::Internet.public_ip_v4_address,
         },
         location_id: location.id,
       }


### PR DESCRIPTION
Ip addresses can't be private for the form to add IP addresses to
be valid. Once in a while, the method Faker:Internet#public_ip_v4_address
would produce a private IP address causing the form to be invalid and
the test to fail.

This change ensure that only public IP addresses are chosen for the
test
