### PR TITLE
Change valid CSV delimiter from semi-colon to tab

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -89,7 +89,7 @@ class LocationsController < ApplicationController
   end
 
   def download_keys
-    keys_csv = CSV.generate(headers: true, col_sep: ";") do |csv|
+    keys_csv = CSV.generate(headers: true, col_sep: "\t") do |csv|
       current_organisation.locations.each do |location|
         csv << [location[:address], location[:postcode], location[:radius_secret_key]]
       end

--- a/app/models/upload_form.rb
+++ b/app/models/upload_form.rb
@@ -6,7 +6,7 @@ class UploadForm
   validate :validate_csv
 
   def validate_reading_csv
-    @data ||= CSV.read(upload_file, col_sep: ";")
+    @data ||= CSV.read(upload_file, col_sep: "\t")
   rescue TypeError
     errors.add(:upload_file, :csv_error, message: "Choose a file before uploading")
   rescue CSV::MalformedCSVError, CSV::Parser::InvalidEncoding

--- a/spec/fixtures/csv/locations_upload_no_dupes.csv
+++ b/spec/fixtures/csv/locations_upload_no_dupes.csv
@@ -1,2 +1,2 @@
-Some Address;AL2 2LU;81.1.1.1;81.2.2.2
-Another Address;E1 2QE;82.1.1.1;82.2.2.2
+Some Address	AL2 2LU	81.1.1.1	81.2.2.2
+Another Address	E1 2QE	82.1.1.1	82.2.2.2

--- a/spec/fixtures/csv/locations_upload_no_dupes_invalid_postcode.csv
+++ b/spec/fixtures/csv/locations_upload_no_dupes_invalid_postcode.csv
@@ -1,2 +1,2 @@
-Some Address;not-a-postcode;81.1.1.1;81.2.2.2
-Another Address;E1 2QE;82.1.1.1;82.2.2.2
+Some Address	not-a-postcode	81.1.1.1	81.2.2.2
+Another Address	E1 2QE	82.1.1.1	82.2.2.2

--- a/spec/fixtures/csv/locations_upload_no_ips.csv
+++ b/spec/fixtures/csv/locations_upload_no_ips.csv
@@ -1,2 +1,2 @@
-Some Address;AL2 2LU
-Another Address;E1 2QE
+Some Address	AL2 2LU
+Another Address	E1 2QE

--- a/spec/fixtures/csv/locations_upload_with_dupes.csv
+++ b/spec/fixtures/csv/locations_upload_with_dupes.csv
@@ -1,4 +1,4 @@
-Some Address;AL2 2LU;83.1.1.1;83.2.2.2
-Third Address;AL2 2LU;84.1.1.1;81.1.1.1
-Third Address;TN13 1EG;85.1.1.1;84.1.1.1
-Fourth Address;E1 2QE;86.1.1.1;85.2.2.2
+Some Address	AL2 2LU	83.1.1.1	83.2.2.2
+Third Address	AL2 2LU	84.1.1.1	81.1.1.1
+Third Address	TN13 1EG	85.1.1.1	84.1.1.1
+Fourth Address	E1 2QE	86.1.1.1	85.2.2.2


### PR DESCRIPTION
### What

Changes the delimiter expected by the bulk upload function from semi-colons to tabs.

Makes the same change for the RADIUS keys download for consitency.

### Why

MS Excel only permits saving CSVs with either commas or tabs as the delimiter. We can't
use commas as they typically occur in street addresses.


Link to Trello card (if applicable): https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-290
