### PR TITLE
fix bug for location logs filtering by status type and add tests to c…

### DIFF
--- a/app/views/logs/_filter_logs_select.html.erb
+++ b/app/views/logs/_filter_logs_select.html.erb
@@ -3,7 +3,7 @@
     <%= form.hidden_field :filter_option %>
     <%= form.hidden_field :username %>
     <%= form.hidden_field :ip %>
-    <%= form.hidden_field :location %>
+    <%= form.hidden_field :location_id %>
     <%= form.govuk_select :success,
                           options_for_select([["All", nil], %w[Successful true], %w[Failed false]]),
                           label: { text: "Status type:" } %>

--- a/spec/features/logging/view_auth_requests_for_a_location_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_a_location_spec.rb
@@ -51,8 +51,8 @@ describe "View authentication requests for a location", type: :feature do
     let(:organisation) { create(:organisation, :with_location_and_ip) }
     let(:ip_address) { organisation.locations.first.ips.first.address }
     let!(:sessions) do
-      create(:session, username: "AAAAAA", siteIP: ip_address)
-      create(:session, username: "BBBBBB", siteIP: "6.6.6.6")
+      create(:session, username: "AAAAAA", siteIP: ip_address, success: true)
+      create(:session, username: "BBBBBB", siteIP: "6.6.6.6", success: false)
     end
 
     before do
@@ -76,6 +76,30 @@ describe "View authentication requests for a location", type: :feature do
     it "has hyperlinks for IP address" do
       click_on ip_address
       expect(page).to have_content("for IP: \"#{ip_address}\"")
+    end
+
+    context "when fitering for successful requests" do
+      before do
+        select("Successful", from: "Status type:")
+        click_button("Filter")
+      end
+
+      it "shows only successful requests" do
+        expect(page).to have_content("successful")
+        expect(page).to_not have_content("failed")
+      end
+    end
+
+    context "when filtering for failed requests" do
+      before do
+        select("Failed", from: "Status type:")
+        click_button("Filter")
+      end
+
+      it "shows only failed requests" do
+        expect(page).to_not have_content("successful")
+        expect(page).to have_content("failed")
+      end
     end
 
     context "when going back to search by a different location" do

--- a/spec/features/logging/view_logs_spec.rb
+++ b/spec/features/logging/view_logs_spec.rb
@@ -65,7 +65,7 @@ describe "View authentication requests for an IP", type: :feature do
         click_button("Filter")
       end
 
-      it "shows only successful requests" do
+      it "shows only failed requests" do
         expect(page).to_not have_css("td", text: "successful")
         expect(page).to have_css("td", text: "failed")
       end


### PR DESCRIPTION
…atch bug

### What
Fix bug for location logs filtering by status type and add tests to catch bug

### Why
When viewing logs via the logs page and selecting ‘location’, attempting to filter the logs by success/failure, ‘Page not found’ is displayed.


Link to Jira card (if applicable): 

https://technologyprogramme.atlassian.net/browse/GW-448
