### PR TITLE
add hyperlinks for locations to find associated IP addresses

### DIFF
--- a/app/views/shared/_manage_ips.html.erb
+++ b/app/views/shared/_manage_ips.html.erb
@@ -1,5 +1,5 @@
 <div class="result-row">
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1" id="<%= location.id %>">
     <%= location.full_address %>
   </h2>
   <% if show_ip_controls %>

--- a/app/views/super_admin/locations/index.html.erb
+++ b/app/views/super_admin/locations/index.html.erb
@@ -20,7 +20,8 @@
         <% @locations.each do |location| %>
           <tr class="govuk-table__row result-row">
             <td class="govuk-table__cell filter-by">
-              <%= location.full_address %>
+              <%= link_to location.full_address, "#{super_admin_organisation_path(location.organisation.id)}##{location.id}", class: "govuk-link" %>
+
             </td>
             <td class="govuk-table__cell filter-by">
               <%= link_to location.organisation.name, super_admin_organisation_path(location.organisation.id), class: "govuk-link" %>

--- a/spec/features/super_admin/locations/locations_spec.rb
+++ b/spec/features/super_admin/locations/locations_spec.rb
@@ -6,7 +6,7 @@ describe "View and search locations", type: :feature do
     create(:location, address: "69 Garry Street, London", postcode: "HA7 2BL", organisation:)
     sign_in_user user
     visit root_path
-    within(".leftnav") { click_on "Locations" }
+    within(".leftnav") { click_on "All Locations" }
   end
 
   it "takes the user to the locations page" do
@@ -44,6 +44,13 @@ describe "View and search locations", type: :feature do
       within(".pager__controls", match: :first) { click_on "5" }
       expect(page).to_not have_content "Next"
       expect(page).to have_content(/Prev\s*1\s*2\s*3\s*4\s*5/).twice
+    end
+  end
+
+  context "selecting a location" do
+    it "takes the user to the organisation page" do
+      click_on "69 Garry Street, London, HA7 2BL"
+      expect(page).to have_content(organisation.name)
     end
   end
 end


### PR DESCRIPTION
### What
As a super admin, when you’re investigating a thing, you might look for the location. But then you need to click the hyperlink for the organisation and then have to start working through the pages to find that location. It’s a pain when the organisation has lots of different locations - and the big users of GovWifi can often be the ones where tickets come in for.

### Why
Make it easier for super admins to find a location and find the IPs associated with it.


Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-291