### PR TITLE
update pagination for the admin site

### DIFF
--- a/app/helpers/pagy_helper.rb
+++ b/app/helpers/pagy_helper.rb
@@ -4,28 +4,40 @@ module PagyHelper
   def pagy_nav_govuk(pagy)
     return "" if pagy.pages == 1
 
-    link   = pagy_link_proc(pagy, link_extra: "class='govuk-link'")
+    link   = pagy_link_proc(pagy, link_extra: "class='govuk-link govuk-pagination__link'")
     p_prev = pagy.prev
     p_next = pagy.next
 
     html = +%(<nav class="pager__govwifi govuk-body" role="navigation" aria-label="Pagination">)
     html << %(<div class="pager__summary">Showing #{pagy.from}-#{pagy.to} of #{pagy.count} items</div>)
     html << %(<div class="pager__controls">)
+    html << %(<nav class="govuk-pagination" role="navigation" aria-label="results">)
     if p_prev
-      html << (link_to "Prev", pagy_url_for(pagy, p_prev), class: "pager__prev govuk-link", rel: "prev")
+      html << %(<div class="govuk-pagination__prev">)
+      html << %(<a class="govuk-link govuk-pagination__link" href="#{pagy_url_for(pagy, p_prev)}" rel="prev">)
+      html << %(<svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">)
+      html << %(<path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>)
+      html << %(</svg>)
+      html << %(<span class="govuk-pagination__link-title">Previous</span></a>)
+      html << %(</div>)
     end
-    html << %(<ul class="pager__items">)
+    html << %(<ul class="govuk-pagination__list">)
     pagy.series.each do |item|  # series example: [1, :gap, 7, 8, "9", 10, 11, :gap, 36]
       html << case item
-              when Integer then %(<li>#{link.call item}</li>) # page link
-              when String  then %(<li>#{item}</li>) # current page
-              when :gap    then %(<li">#{pagy_t('pagy.nav.gap')}</li>)   # page gap
+              when Integer then %(<li class="govuk-pagination__item"><a>#{link.call item}</a></li>) # page link
+              when String  then %(<li class="govuk-pagination__item govuk-pagination__item--current"><a>#{item}</a></li>) # current page
               end
     end
     html << %(</ul>)
     if p_next
-      html << (link_to "Next", pagy_url_for(pagy, p_next), class: "pager__next govuk-link", rel: "next")
+      html << %(<div class="govuk-pagination__next">)
+      html << %(<a class="govuk-link govuk-pagination__link" href="#{pagy_url_for(pagy, p_next)}" rel="next">)
+      html << %(<span class="govuk-pagination__link-title">Next</span>)
+      html << %(<svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">)
+      html << %(<path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path></svg></a>)
+      html << %(</div>)
     end
+    html << %(</nav>)
     html << %(</div>)
     html << %(</nav>)
   end

--- a/spec/features/super_admin/locations/locations_spec.rb
+++ b/spec/features/super_admin/locations/locations_spec.rb
@@ -32,18 +32,18 @@ describe "View and search locations", type: :feature do
       FactoryBot.create_list(:location, 40, organisation:)
       click_on organisation.name
     end
-    it "shows 5 pages, a 'Next' link but not a 'Prev' link" do
-      expect(page).to_not have_content "Prev"
+    it "shows 5 pages, a 'Next' link but not a 'Previous' link" do
+      expect(page).to_not have_content "Previous"
       expect(page).to have_content(/1\s*2\s*3\s*4\s*5\s*Next/).twice
     end
-    it "shows 5 pages, a 'Next' link and a 'Prev' link" do
+    it "shows 5 pages, a 'Next' link and a 'Previous' link" do
       within(".pager__controls", match: :first) { click_on "3" }
-      expect(page).to have_content(/Prev\s*1\s*2\s*3\s*4\s*5\s*Next/).twice
+      expect(page).to have_content(/Previous\s*1\s*2\s*3\s*4\s*5\s*Next/).twice
     end
-    it "shows 5 pages, a 'Prev' link but not a 'Next' link" do
+    it "shows 5 pages, a 'Previous' link but not a 'Next' link" do
       within(".pager__controls", match: :first) { click_on "5" }
       expect(page).to_not have_content "Next"
-      expect(page).to have_content(/Prev\s*1\s*2\s*3\s*4\s*5/).twice
+      expect(page).to have_content(/Previous\s*1\s*2\s*3\s*4\s*5/).twice
     end
   end
 


### PR DESCRIPTION
### What
Implement Design System Pagination component from the GovWifi admin tool.

### Why
To ensure that our admin tool follows the best practice with the Government Design System.


Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-279
<img width="1489" alt="Screenshot 2022-11-02 at 23 48 05" src="https://user-images.githubusercontent.com/34037863/199627266-9b07fd39-e996-4076-806d-db32c56aa9d6.png">
<img width="1512" alt="Screenshot 2022-11-02 at 23 48 08" src="https://user-images.githubusercontent.com/34037863/199627270-3cea22f1-ba56-4455-8292-b7511ecc1e39.png">
<img width="1512" alt="Screenshot 2022-11-02 at 23 48 40" src="https://user-images.githubusercontent.com/34037863/199627276-243eb6e3-89da-411f-ba93-7e01f7deec8f.png">
<img width="1512" alt="Screenshot 2022-11-02 at 23 48 46" src="https://user-images.githubusercontent.com/34037863/199627281-79e525a3-042b-4a0c-8bd7-7ea1eab8597d.png">
