### PR TITLE
Gw 290 blank error location uploads

### DIFF
--- a/app/assets/stylesheets/components/locations.scss
+++ b/app/assets/stylesheets/components/locations.scss
@@ -1,0 +1,3 @@
+.ip-container {
+  margin-left: 40px;
+}

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -86,8 +86,10 @@ class LocationsController < ApplicationController
 
     @parent_organisation = current_organisation
     BulkUpload::BulkUpload.add_location_data(data, @parent_organisation)
+    @locations = @parent_organisation.locations.select(&:new_record?)
+    @ips_count = @locations.flat_map(&:ips).count
     @parent_organisation.save!
-    redirect_to(ips_path, notice: "Successfully uploaded locations")
+    redirect_to(ips_path, notice: "Upload complete. You have saved #{@locations.count} new locations and #{@ips_count} new IP addresses")
   rescue ActiveRecord::RecordInvalid
     redirect_to(ips_path, flash: { error: "Uploading data failed. Please try again." })
   rescue StandardError => e

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -59,6 +59,10 @@ class LocationsController < ApplicationController
     end
   end
 
+  def download_locations_upload_template
+    send_file "public/locations_upload_template.csv", disposition: "inline"
+  end
+
   def bulk_upload
     @upload_form = UploadForm.new
   end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -74,6 +74,8 @@ class LocationsController < ApplicationController
     else
       @parent_organisation = current_organisation
       BulkUpload::BulkUpload.add_location_data(@upload_form.data, @parent_organisation)
+      @new_locations = @parent_organisation.locations.select(&:new_record?)
+      @new_ips_total = @new_locations.flat_map(&:ips).count
       @parent_organisation.validate
     end
   end

--- a/app/models/upload_form.rb
+++ b/app/models/upload_form.rb
@@ -1,29 +1,59 @@
 class UploadForm
   include ActiveModel::Model
   include ActiveModel::Validations
+  include BulkUpload::AddressHeaders
 
   validate :validate_reading_csv
   validate :validate_csv
+  validate :validate_data_present
+  validate :validate_header
 
   def validate_reading_csv
-    @data ||= CSV.read(upload_file, col_sep: "\t")
+    result = CSV.read(upload_file, headers: true)
+    @data ||= result.to_a[1..]
+    @headers ||= result.headers
   rescue TypeError
     errors.add(:upload_file, :csv_error, message: "Choose a file before uploading")
   rescue CSV::MalformedCSVError, CSV::Parser::InvalidEncoding
-    errors.add(:upload_file, :csv_error, message: "Invalid file type")
+    errors.add(:upload_file, :csv_error, message: "File must be csv format")
   end
 
   def validate_csv
     errors.add(:upload_file, :csv_error, message: "Invalid data structure") unless csv_valid?
   end
 
+  def validate_data_present
+    errors.add(:upload_file, :csv_error, message: "File has no data") if first_row_empty?
+  end
+
+  def validate_header
+    errors.add(:upload_file, :csv_error, message: "File must use correct header names") if headers_match?
+  end
+
   attr_accessor :upload_file, :data
 
 private
 
+  def headers_match?
+    return false if @data.nil?
+
+    headers_in_csv = @headers[0..HEADER_COLS.length - 1].map(&:strip).map(&:downcase)
+
+    headers_in_csv != HEADER_COLS.map(&:downcase)
+  end
+
   def csv_valid?
+    return false if @data.nil?
+
     @data.is_a?(Array) &&
       @data.all? { |row| row.is_a? Array } &&
       @data.all? { |row| row.length >= 2 }
+  end
+
+  def first_row_empty?
+    return false if @data.nil?
+    return true if @data[1].nil?
+
+    @data[1].all?(&:blank?)
   end
 end

--- a/app/models/upload_form.rb
+++ b/app/models/upload_form.rb
@@ -30,6 +30,14 @@ class UploadForm
     errors.add(:upload_file, :csv_error, message: "File must use correct header names") if headers_match?
   end
 
+  def self.build_address(row)
+    "#{row[ADDRESS_LINE_1]}
+    #{row[ADDRESS_LINE_2]}
+    #{row[ADDRESS_LINE_3]}
+    #{row[CITY]}
+    #{row[COUNTY]}".squish
+  end
+
   attr_accessor :upload_file, :data
 
 private

--- a/app/views/locations/bulk_upload.html.erb
+++ b/app/views/locations/bulk_upload.html.erb
@@ -1,14 +1,26 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-three-quarters">
+  <div class="govuk-grid-column-two-quarters">
     <%= form_with url: upload_locations_csv_path, model: @upload_form, multipart: true  do |form| %>
       <%= form.govuk_error_summary %>
-      <h1 class="govuk-heading-l">Bulk Upload Locations and IPs</h1>
-      <p class="govuk-body">Upload a CSV file containing locations and Ips</p>
-      <%= form.govuk_file_field :upload_file, label: { text: "File to Upload" } %>
+      <h1 class="govuk-heading-l">Upload multiple locations and</h1>
+      <p class="govuk-body">Follow these steps to upload multiple addresses and IPs:</p>
+
+      <ol class="govuk-list govuk-list--number">
+        <li>
+          <%= link_to "Download the bulk upload template", download_locations_upload_template_path, class: "govuk-link--no-visited-state" %>
+        </li>
+        <li>
+          Enter the addresses and IP details in the template. Save the file as a csv.
+        </li>
+        <li>
+          Upload your completed csv file.
+        </li>
+      </ol>
+
+      <br>
+
+      <%= form.govuk_file_field :upload_file, label: { text: "Upload completed template" } %>
       <%= form.govuk_submit "Upload" %>
     <% end %>
   </div>
 </div>
-
-<p class="govuk-body"><%= link_to "Cancel", :back, class: "govuk-link--no-visited-state" %></p>
-<p class="govuk-body"><%= link_to "Contact GovWifi support", help_index_path, class: "govuk-link--no-visited-state" %></p>

--- a/app/views/locations/upload_locations_csv.html.erb
+++ b/app/views/locations/upload_locations_csv.html.erb
@@ -1,4 +1,8 @@
-<h1 class="govuk-heading-l">Upload Summary</h1>
+<h1 class="govuk-heading-l">Summary of upload</h1>
+
+<p class="govuk-body-m">You have submitted <strong><%= @new_locations.size %></strong> addresses and <strong><%= @new_ips_total %></strong> IPs. You can review your uploaded locations before saving.</p>
+
+<br>
 
 <% if @parent_organisation.errors.present? %>
   <div class="govuk-error-summary" role="alert" data-module="govuk-error-summary" aria-labelledby="error-summary-title">
@@ -7,7 +11,7 @@
     </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
-        <% @parent_organisation.locations.select(&:new_record?).each_with_index do |location, i| %>
+        <% @new_locations.each_with_index do |location, i| %>
           <% (location.errors.where(:address) + location.errors.where(:postcode)).first&.tap do |error| %>
             <li>
               <a href='#<%= upload_error_id_helper(i, location.address) %>'><%= error.full_message %></a>
@@ -29,45 +33,54 @@
   </div>
 <% end %>
 
-<% @parent_organisation.locations.select(&:new_record?).each_with_index do |location, i| %>
+<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+  <% @new_locations.each_with_index do |location, i| %>
+    <div class="govuk-accordion__section ">
+      <div class="govuk-accordion__section-header">
+        <h2 class="govuk-accordion__section-heading">
+          <span class="govuk-accordion__section-button" id="accordion-default-heading-4">
+              <% location_errors = (location.errors.where(:address) + location.errors.where(:postcode)) %>
+              <div class="govuk-form-group <% if location_errors.any? %>govuk-form-group--error<% end %>">
+                <% location_errors.first&.tap do |error| %>
+                  <p class="govuk-error-message" id='<%= upload_error_id_helper(i, location.address) %>'>
+                      <span class="govuk-visually-hidden">
+                        Error:
+                      </span>
+                    <%= error.full_message %>
+                  </p>
+                <% end %>
 
-  <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-      <% location_errors = (location.errors.where(:address) + location.errors.where(:postcode)) %>
-        <div class="govuk-form-group <% if location_errors.any? %>govuk-form-group--error<% end %>">
-          <% location_errors.first&.tap do |error| %>
-            <p class="govuk-error-message" id='<%= upload_error_id_helper(i, location.address) %>'>
-                <span class="govuk-visually-hidden">
-                  Error:
-                </span>
-              <%= error.full_message %>
-            </p>
-          <% end %>
-          <h1 class="govuk-fieldset__heading">
-            <%= location.address %>, <%= location.postcode %>
-          </h1>
-        </div>
-    </legend>
-
-    <% location.ips.each do |ip| %>
-      <div class="govuk-form-group <% if ip.errors.any? %>govuk-form-group--error<% end %>">
-        <% ip.errors.first&.tap do |error| %>
-          <p class="govuk-error-message" id='<%= upload_error_id_helper(i, location.address, ip.address) %>'>
-            <span class="govuk-visually-hidden">
-              Error:
-            </span>
-            <%= error.full_message %>
-          </p>
-        <% end %>
-        <label class="govuk-label">
-          <%= ip.address %>
-        </label>
+                <h1 class="govuk-fieldset__heading">
+                  <%= location.address %>, <%= location.postcode %>
+                </h1>
+              </div>
+          </span>
+        </h2>
       </div>
-    <% end %>
+      <div id="accordion-default-content-4" class="govuk-accordion__section-content ip-container" aria-labelledby="accordion-default-heading-4">
 
-  </fieldset>
+        <% location.ips.each do |ip| %>
+          <div class='govuk-body'>
+            <div class="govuk-form-group <% if ip.errors.any? %>govuk-form-group--error<% end %>">
+              <% ip.errors.first&.tap do |error| %>
+                <p class="govuk-error-message" id='<%= upload_error_id_helper(i, location.address, ip.address) %>'>
+                  <span class="govuk-visually-hidden">
+                    Error:
+                  </span>
+                  <%= error.full_message %>
+                </p>
+              <% end %>
+              <label class="govuk-label">
+                <%= ip.address %>
+              </label>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
 
-<% end %>
+  <% end %>
+</div>
 
 <% if @parent_organisation.errors.empty? %>
   <%= form_with url: confirm_upload_url do |form| %>
@@ -80,4 +93,4 @@
   <% end %>
 <% end %>
 
-<p class="govuk-body"><%= link_to "Cancel", :back, class: "govuk-link--no-visited-state" %></p>
+<p class="govuk-body"><%= link_to "Cancel", bulk_upload_path, class: "govuk-link--no-visited-state" %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
     get "user_support", on: :new
   end
   get "bulk_upload", to: "locations#bulk_upload"
+  get "download_locations_upload_template", to: "locations#download_locations_upload_template"
   get "download_keys", to: "locations#download_keys"
   post "confirm_upload", to: "locations#confirm_upload"
   post "upload_locations_csv", to: "locations#upload_locations_csv"

--- a/lib/bulk_upload/address_headers.rb
+++ b/lib/bulk_upload/address_headers.rb
@@ -1,0 +1,12 @@
+module BulkUpload
+  module AddressHeaders
+    HEADER_COLS = ["Address line 1", "Address line 2", "Address line 3", "City", "County", "Postcode", "IP address"].freeze
+    ADDRESS_LINE_1 = 0
+    ADDRESS_LINE_2 = 1
+    ADDRESS_LINE_3 = 2
+    CITY = 3
+    COUNTY = 4
+    POSTCODE = 5
+    IP_ADDRESS = 6
+  end
+end

--- a/lib/bulk_upload/bulk_upload.rb
+++ b/lib/bulk_upload/bulk_upload.rb
@@ -2,11 +2,13 @@ require "csv"
 
 module BulkUpload
   module BulkUpload
+    include AddressHeaders
+
     def self.add_location_data(data, organisation)
       data.each do |row|
-        location = organisation.locations.new(address: row[0], postcode: row[1])
-        row.slice(2..).each do |ip_address|
-          location.ips.new(address: ip_address)
+        location = organisation.locations.new(address: UploadForm.build_address(row), postcode: row[POSTCODE]&.strip)
+        row.slice(IP_ADDRESS..).reject(&:blank?).each do |ip_address|
+          location.ips.new(address: ip_address.strip)
         end
       end
     end

--- a/public/locations_upload_template.csv
+++ b/public/locations_upload_template.csv
@@ -1,0 +1,4 @@
+Address line 1,Address line 2,Address line 3,City,County,Postcode,IP address,IP address,IP address,IP address,IP address
+122,London road,,London,Greater London,LE2 0EN,192.1.2.3,192.1.2.33,,,
+101,Avenue  street,,Leicester,Leicestershire,SE2 9TT,192.1.2.32, ,,,
+Lint House,Burton road,,Birmingham,West Midlands,B1 9HH,192.1.2.36,192.1.2.37,192.1.2.38,192.1.2.39,

--- a/spec/features/locations/bulk_upload_spec.rb
+++ b/spec/features/locations/bulk_upload_spec.rb
@@ -10,11 +10,7 @@ describe "Bulk upload locations and IPs", type: :feature do
 
   context "when uploading a locations CSV file" do
     it "displays the bulk upload page" do
-      expect(page).to have_content("Upload a CSV file containing locations and Ips")
-    end
-
-    it "displays a link to the support page" do
-      expect(page).to have_link("Contact GovWifi support", href: "/help")
+      expect(page).to have_content("Follow these steps to upload multiple addresses and IPs:")
     end
 
     context "when no file is chosen to upload" do
@@ -29,18 +25,18 @@ describe "Bulk upload locations and IPs", type: :feature do
 
     context "when a PDF file is uploaded" do
       before do
-        attach_file("File to Upload", Rails.root.join("spec/fixtures/mou.pdf"))
+        attach_file("Upload completed template", Rails.root.join("spec/fixtures/mou.pdf"))
         click_on "Upload"
       end
 
       it "displays the appropriate error" do
-        expect(page).to have_content("Invalid file type").twice
+        expect(page).to have_content("File must be csv format").twice
       end
     end
 
-    context "when a CSV with commas as delimiter is uploaded" do
+    context "when a CSV with tabs as delimiter is uploaded" do
       before do
-        attach_file("File to Upload", Rails.root.join("spec/fixtures/csv/locations_upload_no_dupes_commas.csv"))
+        attach_file("Upload completed template", Rails.root.join("spec/fixtures/csv/locations_upload_no_dupes_tabs.csv"))
         click_on "Upload"
       end
 
@@ -49,17 +45,50 @@ describe "Bulk upload locations and IPs", type: :feature do
       end
     end
 
+    context "when a CSV has contains incorrect OR missing headers" do
+      before do
+        attach_file("Upload completed template", Rails.root.join("spec/fixtures/csv/locations_upload_invalid_headers.csv"))
+        click_on "Upload"
+      end
+
+      it "displays the appropriate error" do
+        expect(page).to have_content("File must use correct header names").twice
+      end
+    end
+
+    context "when a CSV has only header but no data" do
+      before do
+        attach_file("Upload completed template", Rails.root.join("spec/fixtures/csv/locations_upload_only_headers_no_data.csv"))
+        click_on "Upload"
+      end
+
+      it "displays the appropriate error" do
+        expect(page).to have_content("File has no data").twice
+      end
+    end
+
+    context "when a CSV has no header AND no data" do
+      before do
+        attach_file("Upload completed template", Rails.root.join("spec/fixtures/csv/locations_upload_blank.csv"))
+        click_on "Upload"
+      end
+
+      it "displays the appropriate error" do
+        expect(page).to have_content("File has no data").twice
+      end
+    end
+
     context "when a CSV with locations but no IPs is uploaded the summary page" do
       before do
-        attach_file("File to Upload", Rails.root.join("spec/fixtures/csv/locations_upload_no_ips.csv"))
+        attach_file("Upload completed template", Rails.root.join("spec/fixtures/csv/locations_upload_no_ips.csv"))
         click_on "Upload"
       end
 
       it "displays the uploaded locations" do
-        expect(page).to have_content("Some Address")
-        expect(page).to have_content("AL2 2LU")
-        expect(page).to have_content("Another Address")
-        expect(page).to have_content("E1 2QE")
+        expect(page).to have_content("122 London road London Greater London")
+        expect(page).to have_content("LE2 0EN")
+        expect(page).to have_content("101 Avenue street Leicester Leicestershire")
+        expect(page).to have_content("SE2 9TT")
       end
 
       it "has a save button" do
@@ -70,26 +99,31 @@ describe "Bulk upload locations and IPs", type: :feature do
     context "when a CSV with locations and IPs is uploaded the summary page" do
       before do
         organisation.locations << build(:location, address: "Existing Address", organisation:)
-        attach_file("File to Upload", Rails.root.join("spec/fixtures/csv/locations_upload_no_dupes.csv"))
+        attach_file("Upload completed template", Rails.root.join("spec/fixtures/csv/locations_upload_no_dupes.csv"))
         click_on "Upload"
       end
 
+      it "displays total number of Locations and IP addresses uploaded in csv" do
+        summary = "You have submitted 2 addresses and 3 IPs. You can review your uploaded locations before saving."
+
+        expect(page).to have_content(summary)
+      end
+
       it "does not display already existing locations" do
-        expect(page).to_not have_content("Existing Address")
+        expect(page).to_not have_content("Location address already exists for this organisation")
       end
 
       it "displays the uploaded locations" do
-        expect(page).to have_content("Some Address")
-        expect(page).to have_content("AL2 2LU")
-        expect(page).to have_content("Another Address")
-        expect(page).to have_content("E1 2QE")
+        expect(page).to have_content("122 London road London Greater London")
+        expect(page).to have_content("LE2 0EN")
+        expect(page).to have_content("101 Avenue street Leicester Leicestershire")
+        expect(page).to have_content("SE2 9TT")
       end
 
       it "displays the uploaded IP addresses" do
-        expect(page).to have_content("81.1.1.1")
-        expect(page).to have_content("81.2.2.2")
-        expect(page).to have_content("82.1.1.1")
-        expect(page).to have_content("82.2.2.2")
+        expect(page).to have_content("192.1.2.3")
+        expect(page).to have_content("192.1.2.4")
+        expect(page).to have_content("192.1.2.5")
       end
 
       it "has a save button" do
@@ -97,9 +131,23 @@ describe "Bulk upload locations and IPs", type: :feature do
       end
     end
 
+    context "when a CSV has extra spaces in the data" do
+      before do
+        attach_file("Upload completed template", Rails.root.join("spec/fixtures/csv/locations_upload_extra_spaces.csv"))
+        click_on "Upload"
+      end
+
+      it "displays data without the extra spaces" do
+        expect(page).to have_content("122 London road London Greater London")
+        expect(page).to have_content("LE2 0EN")
+        expect(page).to have_content("101 Avenue street Leicester Leicestershire")
+        expect(page).to have_content("SE2 9TT")
+      end
+    end
+
     context "when a CSV with an invalid postcode is uploaded the summary page" do
       before do
-        attach_file("File to Upload", Rails.root.join("spec/fixtures/csv/locations_upload_no_dupes_invalid_postcode.csv"))
+        attach_file("Upload completed template", Rails.root.join("spec/fixtures/csv/locations_upload_no_dupes_invalid_postcode.csv"))
         click_on "Upload"
       end
 
@@ -114,13 +162,11 @@ describe "Bulk upload locations and IPs", type: :feature do
 
     context "when a CSV with existing locations is uploaded the summary page" do
       before do
-        l = create(:location, address: "Some Address", postcode: "AL2 2LU", organisation:)
-        create(:location, address: "Another Address", postcode: "E1 2QE", organisation:)
-        create(:ip, address: "81.1.1.1", location: l)
-        create(:ip, address: "81.2.2.2", location: l)
-        create(:ip, address: "82.1.1.1", location: l)
-        create(:ip, address: "82.2.2.2", location: l)
-        attach_file("File to Upload", Rails.root.join("spec/fixtures/csv/locations_upload_no_dupes.csv"))
+        l = create(:location, address: "122 London road London Greater London", postcode: "LE2 0EN", organisation:)
+        create(:location, address: "101 Avenue street Leicester Leicestershire", postcode: "SE2 9TT", organisation:)
+        create(:ip, address: "192.1.2.3", location: l)
+        create(:ip, address: "192.1.2.4", location: l)
+        attach_file("Upload completed template", Rails.root.join("spec/fixtures/csv/locations_upload_no_dupes.csv"))
         click_on "Upload"
       end
 
@@ -129,7 +175,7 @@ describe "Bulk upload locations and IPs", type: :feature do
       end
 
       it "displays the IP address error messages" do
-        expect(page).to have_content("IP address is already in use", count: 8)
+        expect(page).to have_content("IP address is already in use", count: 4)
       end
 
       it "does not have a save button" do
@@ -139,16 +185,17 @@ describe "Bulk upload locations and IPs", type: :feature do
 
     context "when a CSV with duplicate locations is uploaded the summary page" do
       before do
-        attach_file("File to Upload", Rails.root.join("spec/fixtures/csv/locations_upload_with_dupes.csv"))
+        attach_file("Upload completed template", Rails.root.join("spec/fixtures/csv/locations_upload_with_dupes.csv"))
         click_on "Upload"
       end
 
       it "displays the location address error messages" do
-        expect(page).to have_content("Address Third Address is a duplicate", count: 4)
+        expect(page).to have_content("Address 122 London road London Greater London", count: 4)
       end
 
       it "displays the IP address error messages" do
-        expect(page).to have_content("Ip address 84.1.1.1 is a duplicate", count: 4)
+        expect(page).to have_content("Ip address 192.1.2.3 is a duplicate", count: 4)
+        expect(page).to have_content("Ip address 192.1.2.4 is a duplicate", count: 4)
       end
 
       it "does not have a save button" do
@@ -158,45 +205,43 @@ describe "Bulk upload locations and IPs", type: :feature do
 
     context "when confirming an upload" do
       before do
-        attach_file("File to Upload", Rails.root.join("spec/fixtures/csv/locations_upload_no_dupes.csv"))
+        attach_file("Upload completed template", Rails.root.join("spec/fixtures/csv/locations_upload_no_dupes.csv"))
         click_on "Upload"
         click_on "Save"
       end
 
       it "returns to the locations page and displays an alert" do
-        expect(page).to have_content("Successfully uploaded locations")
+        expect(page).to have_content("Upload complete. You have saved 2 new locations and 3 new IP addresses")
       end
 
       it "displays the new locations" do
-        expect(page).to have_content("Some Address, AL2 2LU")
-        expect(page).to have_content("Another Address, E1 2QE")
+        expect(page).to have_content("122 London road London Greater London")
+        expect(page).to have_content("101 Avenue street Leicester Leicestershire")
       end
 
       it "displays the new IP addresses" do
-        expect(page).to have_content("81.1.1.1")
-        expect(page).to have_content("81.2.2.2")
-        expect(page).to have_content("82.1.1.1")
-        expect(page).to have_content("82.2.2.2")
+        expect(page).to have_content("192.1.2.3")
+        expect(page).to have_content("192.1.2.4")
+        expect(page).to have_content("192.1.2.5")
       end
     end
 
     context "when not confirming an upload" do
       before do
-        attach_file("File to Upload", Rails.root.join("spec/fixtures/csv/locations_upload_no_dupes.csv"))
+        attach_file("Upload completed template", Rails.root.join("spec/fixtures/csv/locations_upload_no_dupes.csv"))
         click_on "Upload"
         click_on "Locations"
       end
 
-      it "does not displau the new locations" do
-        expect(page).not_to have_content("Some Address, AL2 2LU")
-        expect(page).not_to have_content("Another Address, E1 2QE")
+      it "does not display the new locations" do
+        expect(page).not_to have_content("122 London road London Greater London")
+        expect(page).not_to have_content("101 Avenue street Leicester Leicestershire")
       end
 
       it "does not display the new IP addresses" do
-        expect(page).not_to have_content("81.1.1.1")
-        expect(page).not_to have_content("81.2.2.2")
-        expect(page).not_to have_content("82.1.1.1")
-        expect(page).not_to have_content("82.2.2.2")
+        expect(page).not_to have_content("192.1.2.3")
+        expect(page).not_to have_content("192.1.2.4")
+        expect(page).not_to have_content("192.1.2.5")
       end
     end
   end

--- a/spec/fixtures/csv/locations_upload_extra_spaces.csv
+++ b/spec/fixtures/csv/locations_upload_extra_spaces.csv
@@ -1,0 +1,3 @@
+Address line 1   ,Address line 2   ,Address line 3,City,County,Postcode,IP address, IP address,IP address, IP address, IP address
+122   ,London road   ,,London,Greater London   ,LE2 0EN    ,   192.1.2.3,192.1.2.4
+101,Avenue    street   ,,Leicester,Leicestershire   ,    SE2 9TT   ,192.1.2.5

--- a/spec/fixtures/csv/locations_upload_invalid_headers.csv
+++ b/spec/fixtures/csv/locations_upload_invalid_headers.csv
@@ -1,0 +1,3 @@
+Invalid,Address line 2,Address line 3,City,County,Postcode,IP address,IP address,IP address,IP address,IP address
+122,London road,,London,Greater London,LE2 0EN
+101,Avenue  street,,Leicester,Leicestershire,SE2 9TT

--- a/spec/fixtures/csv/locations_upload_no_dupes.csv
+++ b/spec/fixtures/csv/locations_upload_no_dupes.csv
@@ -1,2 +1,3 @@
-Some Address	AL2 2LU	81.1.1.1	81.2.2.2
-Another Address	E1 2QE	82.1.1.1	82.2.2.2
+Address line 1,Address line 2,Address line 3,City,County,Postcode,IP address, IP address,IP address, IP address, IP address
+122,London road,,London,Greater London,LE2 0EN,192.1.2.3,192.1.2.4
+101,Avenue street,,Leicester,Leicestershire,SE2 9TT,192.1.2.5

--- a/spec/fixtures/csv/locations_upload_no_dupes_commas.csv
+++ b/spec/fixtures/csv/locations_upload_no_dupes_commas.csv
@@ -1,2 +1,0 @@
-Some Address,AL2 2LU,81.1.1.1,81.2.2.2
-Another Address,E1 2QE,82.1.1.1,82.2.2.2

--- a/spec/fixtures/csv/locations_upload_no_dupes_invalid_postcode.csv
+++ b/spec/fixtures/csv/locations_upload_no_dupes_invalid_postcode.csv
@@ -1,2 +1,3 @@
-Some Address	not-a-postcode	81.1.1.1	81.2.2.2
-Another Address	E1 2QE	82.1.1.1	82.2.2.2
+Address line 1,Address line 2,Address line 3,City,County,Postcode,IP address, IP address,IP address, IP address, IP address
+122,London road,,London,Greater London,not-a-postcode,192.1.2.3,192.1.2.4
+101,Avenue  street,,Leicester,Leicestershire,SE2 9TT,192.1.2.5

--- a/spec/fixtures/csv/locations_upload_no_dupes_tabs.csv
+++ b/spec/fixtures/csv/locations_upload_no_dupes_tabs.csv
@@ -1,0 +1,3 @@
+Address line 1	Address line 2	Address line 3	City	County	 Postcode	 IP address	 IP address	 IP address	 IP address	 IP address
+122	London road		London	Greater London	LE2 0EN	192.1.2.3	192.1.2.3
+101	Avenue street		Leicester	Leicestershire	SE2 9TT	192.1.2.3

--- a/spec/fixtures/csv/locations_upload_only_headers_no_data.csv
+++ b/spec/fixtures/csv/locations_upload_only_headers_no_data.csv
@@ -1,3 +1,1 @@
 Address line 1,Address line 2,Address line 3,City,County,Postcode,IP address,IP address,IP address,IP address,IP address
-122,London road,,London,Greater London,LE2 0EN
-101,Avenue  street,,Leicester,Leicestershire,SE2 9TT

--- a/spec/fixtures/csv/locations_upload_with_dupes.csv
+++ b/spec/fixtures/csv/locations_upload_with_dupes.csv
@@ -1,4 +1,4 @@
-Some Address	AL2 2LU	83.1.1.1	83.2.2.2
-Third Address	AL2 2LU	84.1.1.1	81.1.1.1
-Third Address	TN13 1EG	85.1.1.1	84.1.1.1
-Fourth Address	E1 2QE	86.1.1.1	85.2.2.2
+Address line 1,Address line 2,Address line 3,City,County,Postcode,IP address, IP address,IP address, IP address, IP address
+122,London road,,London,Greater London,LE2 0EN,192.1.2.3,192.1.2.4
+122,London road,,London,Greater London,LE2 0EN,192.1.2.3,192.1.2.4
+101,Avenue street,,Leicester,Leicestershire,SE2 9TT,192.1.2.5

--- a/spec/requests/locations/confirm_upload_spec.rb
+++ b/spec/requests/locations/confirm_upload_spec.rb
@@ -12,10 +12,30 @@ describe "DELETE /locations/:id", type: :request do
     context "With valid parameters" do
       let(:params) do
         { "csv" =>
-            {
-              "0" => { "0" => "Address 1", "1" => "AA111AA", "2" => "1.1.1.1" },
-              "1" => { "0" => "Address 2", "1" => "BB111BB", "2" => "2.2.2.2" },
-            } }
+          {
+            "0" => { "0" => "122",
+                     "1" => "London road",
+                     "2" => nil,
+                     "3" => "London",
+                     "4" => "Greater London",
+                     "5" => "LE2 0EN",
+                     "6" => "192.12.2.3",
+                     "7" => "192.15.2.33",
+                     "8" => nil,
+                     "9" => nil,
+                     "10" => nil },
+            "1" => { "0" => "101",
+                     "1" => "Burton road",
+                     "2" => nil,
+                     "3" => "Birmingham",
+                     "4" => "West Midlands",
+                     "5" => "B1 9HH",
+                     "6" => "192.14.2.36",
+                     "7" => "192.17.2.37",
+                     "8" => "192.16.2.38",
+                     "9" => nil,
+                     "10" => nil },
+          } }
       end
       it "Adds two locations" do
         expect {
@@ -25,7 +45,7 @@ describe "DELETE /locations/:id", type: :request do
       it "Adds two Ip addresses" do
         expect {
           post confirm_upload_path, params:
-        }.to change(Ip, :count).by(2)
+        }.to change(Ip, :count).by(5)
       end
       it "redirects with a success message" do
         expect(
@@ -34,7 +54,7 @@ describe "DELETE /locations/:id", type: :request do
       end
       it "sets a success flash message" do
         post confirm_upload_path, params: params
-        expect(flash[:notice]).to eq("Successfully uploaded locations")
+        expect(flash[:notice]).to eq("Upload complete. You have saved 2 new locations and 5 new IP addresses")
       end
     end
     describe "empty input" do
@@ -58,11 +78,31 @@ describe "DELETE /locations/:id", type: :request do
     end
     context "params that causes a validation error" do
       let(:params) do
-        {
-          "csv" => {
-            "0" => { "0" => "Address 1", "1" => "INVALID" },
-          },
-        }
+        { "csv" =>
+          {
+            "0" => { "0" => "Address line 1",
+                     "1" => "Address line 2",
+                     "2" => "Address line 3",
+                     "3" => "City",
+                     "4" => "County",
+                     "5" => "Postcode",
+                     "6" => "IP address",
+                     "7" => "IP address",
+                     "8" => "IP address",
+                     "9" => "IP address",
+                     "10" => "IP address" },
+            "1" => { "0" => "Invalid",
+                     "1" => nil,
+                     "2" => nil,
+                     "3" => nil,
+                     "4" => nil,
+                     "5" => nil,
+                     "6" => nil,
+                     "7" => nil,
+                     "8" => nil,
+                     "9" => nil,
+                     "10" => nil },
+          } }
       end
       it "redirects with an error message" do
         expect(


### PR DESCRIPTION
### What
Describe the change
I changed few things in Location upload feature.
* I added a downloadable Template
* The upload now processes using Commas instead of Tabs.
* I have added extra columns in the upload to handle Address.
* Fix issue with Blank values for IP addresses.

### Why
Describe why the change was necessary
Blank error messages showing for IP addresses.

Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-290