### PR TITLE
Revert "update pagination for the admin site (#1773)"

### DIFF
--- a/app/helpers/pagy_helper.rb
+++ b/app/helpers/pagy_helper.rb
@@ -4,40 +4,28 @@ module PagyHelper
   def pagy_nav_govuk(pagy)
     return "" if pagy.pages == 1
 
-    link   = pagy_link_proc(pagy, link_extra: "class='govuk-link govuk-pagination__link'")
+    link   = pagy_link_proc(pagy, link_extra: "class='govuk-link'")
     p_prev = pagy.prev
     p_next = pagy.next
 
     html = +%(<nav class="pager__govwifi govuk-body" role="navigation" aria-label="Pagination">)
     html << %(<div class="pager__summary">Showing #{pagy.from}-#{pagy.to} of #{pagy.count} items</div>)
     html << %(<div class="pager__controls">)
-    html << %(<nav class="govuk-pagination" role="navigation" aria-label="results">)
     if p_prev
-      html << %(<div class="govuk-pagination__prev">)
-      html << %(<a class="govuk-link govuk-pagination__link" href="#{pagy_url_for(pagy, p_prev)}" rel="prev">)
-      html << %(<svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">)
-      html << %(<path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>)
-      html << %(</svg>)
-      html << %(<span class="govuk-pagination__link-title">Previous</span></a>)
-      html << %(</div>)
+      html << (link_to "Prev", pagy_url_for(pagy, p_prev), class: "pager__prev govuk-link", rel: "prev")
     end
-    html << %(<ul class="govuk-pagination__list">)
+    html << %(<ul class="pager__items">)
     pagy.series.each do |item|  # series example: [1, :gap, 7, 8, "9", 10, 11, :gap, 36]
       html << case item
-              when Integer then %(<li class="govuk-pagination__item"><a>#{link.call item}</a></li>) # page link
-              when String  then %(<li class="govuk-pagination__item govuk-pagination__item--current"><a>#{item}</a></li>) # current page
+              when Integer then %(<li>#{link.call item}</li>) # page link
+              when String  then %(<li>#{item}</li>) # current page
+              when :gap    then %(<li">#{pagy_t('pagy.nav.gap')}</li>)   # page gap
               end
     end
     html << %(</ul>)
     if p_next
-      html << %(<div class="govuk-pagination__next">)
-      html << %(<a class="govuk-link govuk-pagination__link" href="#{pagy_url_for(pagy, p_next)}" rel="next">)
-      html << %(<span class="govuk-pagination__link-title">Next</span>)
-      html << %(<svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">)
-      html << %(<path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path></svg></a>)
-      html << %(</div>)
+      html << (link_to "Next", pagy_url_for(pagy, p_next), class: "pager__next govuk-link", rel: "next")
     end
-    html << %(</nav>)
     html << %(</div>)
     html << %(</nav>)
   end

--- a/spec/features/super_admin/locations/locations_spec.rb
+++ b/spec/features/super_admin/locations/locations_spec.rb
@@ -32,18 +32,18 @@ describe "View and search locations", type: :feature do
       FactoryBot.create_list(:location, 40, organisation:)
       click_on organisation.name
     end
-    it "shows 5 pages, a 'Next' link but not a 'Previous' link" do
-      expect(page).to_not have_content "Previous"
+    it "shows 5 pages, a 'Next' link but not a 'Prev' link" do
+      expect(page).to_not have_content "Prev"
       expect(page).to have_content(/1\s*2\s*3\s*4\s*5\s*Next/).twice
     end
-    it "shows 5 pages, a 'Next' link and a 'Previous' link" do
+    it "shows 5 pages, a 'Next' link and a 'Prev' link" do
       within(".pager__controls", match: :first) { click_on "3" }
-      expect(page).to have_content(/Previous\s*1\s*2\s*3\s*4\s*5\s*Next/).twice
+      expect(page).to have_content(/Prev\s*1\s*2\s*3\s*4\s*5\s*Next/).twice
     end
-    it "shows 5 pages, a 'Previous' link but not a 'Next' link" do
+    it "shows 5 pages, a 'Prev' link but not a 'Next' link" do
       within(".pager__controls", match: :first) { click_on "5" }
       expect(page).to_not have_content "Next"
-      expect(page).to have_content(/Previous\s*1\s*2\s*3\s*4\s*5/).twice
+      expect(page).to have_content(/Prev\s*1\s*2\s*3\s*4\s*5/).twice
     end
   end
 


### PR DESCRIPTION
### What

This reverts commit b6d60a8b81ab53573755b62c52de0f8152cb4156.

Reverts changes in the above commit which brought pagination in the admin site into line with the design system. See: https://technologyprogramme.atlassian.net/browse/GW-279

### Why

This is to test whether the above commit is related to errors displaying the landing page for large organisations in the prod admin site. Unfortunately whatever the issue is, it wasn't caught by running the admin site locally or in the tests. 

We may need a development db which, like the admin site, contains some large orgs wit many locations/IPs.

