### PR TITLE
Fix an error in the pagination code

### DIFF
--- a/app/helpers/pagy_helper.rb
+++ b/app/helpers/pagy_helper.rb
@@ -26,6 +26,7 @@ module PagyHelper
       html << case item
               when Integer then %(<li class="govuk-pagination__item"><a>#{link.call item}</a></li>) # page link
               when String  then %(<li class="govuk-pagination__item govuk-pagination__item--current"><a>#{item}</a></li>) # current page
+              when :gap    then %(<li class="govuk-pagination__item">#{pagy_t('pagy.nav.gap')}</li>)   # page gap
               end
     end
     html << %(</ul>)

--- a/spec/features/super_admin/organisations/view_organisation_page_spec.rb
+++ b/spec/features/super_admin/organisations/view_organisation_page_spec.rb
@@ -1,6 +1,15 @@
 describe "View details of an organisation", type: :feature do
   let(:organisation) { create(:organisation) }
 
+  context "when there are lots of pages so that pagy renders a 'gap'" do
+    it "renders a gap" do
+      100.times { organisation.locations << create(:location, organisation:) }
+      sign_in_user create(:user, :super_admin)
+      visit super_admin_organisation_path(organisation)
+      expect(page.body).to include(Pagy::I18n.translate(nil, "pagy.nav.gap"))
+    end
+  end
+
   context "when logged in as a super-admin" do
     let!(:location_1) { create(:location, organisation:, address: "Aarry Street") }
     let!(:location_2) { create(:location, organisation:, address: "Carry Street") }
@@ -14,6 +23,10 @@ describe "View details of an organisation", type: :feature do
       create(:user, organisations: [organisation])
       sign_in_user create(:user, :super_admin)
       visit super_admin_organisation_path(organisation)
+    end
+
+    it "does not render a gap" do
+      expect(page.body).to_not include(Pagy::I18n.translate(nil, "pagy.nav.gap"))
     end
 
     it "shows details page for the organisations" do


### PR DESCRIPTION
### What
When a large number of elements are present, the paginator will display a 'gap', usually 3 dots in the pagination index.

In a previous commit the code that handles this was accidentally removed and this commit reinstates this.

### Why
The removal of the code caused the website to display an error when too many pages are displayed