### PR TITLE
Gw 290 blank error location uploads

### DIFF
--- a/app/models/upload_form.rb
+++ b/app/models/upload_form.rb
@@ -60,8 +60,8 @@ private
 
   def first_row_empty?
     return false if @data.nil?
-    return true if @data[1].nil?
+    return true if @data[0].nil?
 
-    @data[1].all?(&:blank?)
+    @data[0].all?(&:blank?)
   end
 end

--- a/app/views/locations/bulk_upload.html.erb
+++ b/app/views/locations/bulk_upload.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-quarters">
     <%= form_with url: upload_locations_csv_path, model: @upload_form, multipart: true  do |form| %>
       <%= form.govuk_error_summary %>
-      <h1 class="govuk-heading-l">Upload multiple locations and</h1>
+      <h1 class="govuk-heading-l">Upload multiple locations and IPs</h1>
       <p class="govuk-body">Follow these steps to upload multiple addresses and IPs:</p>
 
       <ol class="govuk-list govuk-list--number">

--- a/spec/features/locations/bulk_upload_spec.rb
+++ b/spec/features/locations/bulk_upload_spec.rb
@@ -67,6 +67,19 @@ describe "Bulk upload locations and IPs", type: :feature do
       end
     end
 
+    context "when a CSV has only one row of data" do
+      before do
+        attach_file("Upload completed template", Rails.root.join("spec/fixtures/csv/locations_upload_only_one_row_of_data.csv"))
+        click_on "Upload"
+      end
+
+      it "allows one row of data to pass validation" do
+        summary = "You have submitted 1 addresses and 2 IPs. You can review your uploaded locations before saving."
+
+        expect(page).to have_content(summary)
+      end
+    end
+
     context "when a CSV has no header AND no data" do
       before do
         attach_file("Upload completed template", Rails.root.join("spec/fixtures/csv/locations_upload_blank.csv"))

--- a/spec/fixtures/csv/locations_upload_only_one_row_of_data.csv
+++ b/spec/fixtures/csv/locations_upload_only_one_row_of_data.csv
@@ -1,0 +1,2 @@
+Address line 1,Address line 2,Address line 3,City,County,Postcode,IP address,IP address,IP address,IP address,IP address
+122,London road,,London,Greater London,LE2 0EN,192.1.2.3,192.1.2.4


### PR DESCRIPTION
### What
Describe the change

Fix for Locations Upload error.
Currently system does not allow CSV with only one Location Address to be uploaded.

### Why
Describe why the change was necessary
I changed the validations in upload_form.rb to allow CSV with one row of data.
It will only throw error when no data exist.

Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-290