### PR TITLE
Remove old concourse deployment references in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,34 +98,7 @@ make clean
 
 ## Deploying
 
-All deployments are run by the [GDS Concourse][gds-concourse].
-
-The process amounts to:
-
-1. Test + Lint
-2. Build a deployment image
-3. Push deployment image to the GovWifi ECR
-4. Run migrations using the deployment image
-5. restart the ECS services using the new deployment image
-
-### Staging
-
-Deployments to Staging are run automatically whenever a change to the `master` branch is made.
-
-### Production
-
-Deployments to Production must be manually triggered.
-You can do this by going to the [production deployment pipeline][prod-deploy-pipeline], and starting the "Confirm Deploy to Production" task.
-
-You can start the task by clicking on it, and pressing the `+` icon in the top right of the screen.
-
-This will do a few things:
-- It ensures the tests have been run on the latest commit for master.
-- It ensures Staging has already been deployed for the latest commit for master.
-- It then allows production to deploy using the latest commit for master.
-
-You do not need to wait the Tests and Staging deploy to finish before starting a Production deploy.
-The Production deploy will wait for the Tests and Staging deploy to finish before actually running.
+You can find in depth instructions on using our deploy process [here](https://docs.google.com/document/d/1ORrF2HwrqUu3tPswSlB0Duvbi3YHzvESwOqEY9-w6IQ/) (you must be member of the GovWifi Team to access this document). 
 
 ## How to contribute
 


### PR DESCRIPTION
### What
Remove old concourse deployment references in documentation. Add link to new deploy process

### Why
Keeping documentation up to date

Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-618
