### PR TITLE
fix bug for the filtering of logs using the success status

### DIFF
--- a/app/views/logs/_filter_logs_select.html.erb
+++ b/app/views/logs/_filter_logs_select.html.erb
@@ -5,7 +5,7 @@
     <%= form.hidden_field :ip %>
     <%= form.hidden_field :location_id %>
     <%= form.govuk_select :success,
-                          options_for_select([["All", nil], %w[Successful true], %w[Failed false]]),
+                          options_for_select([["All", nil], %w[Successful true], %w[Failed false]], log_search_form.success),
                           label: { text: "Status type:" } %>
     <%= form.govuk_submit "Filter" %>
   <% end %>

--- a/lib/gateways/sessions.rb
+++ b/lib/gateways/sessions.rb
@@ -14,7 +14,7 @@ module Gateways
 
       results = results.where(username:) unless username.nil?
       results = results.where(siteIP: ips) unless ips.nil?
-      results = results.where(success:) unless success.nil?
+      results = results.where(success:) if success.present?
       results
     end
 

--- a/spec/features/logging/view_logs_spec.rb
+++ b/spec/features/logging/view_logs_spec.rb
@@ -47,6 +47,22 @@ describe "View authentication requests for an IP", type: :feature do
       expect(page).to have_css("td", text: task_id)
     end
 
+    context "when filtering for all requests" do
+      before do
+        select("All", from: "Status type:")
+        click_button("Filter")
+      end
+
+      it "shows all requests" do
+        expect(page).to have_css("td", text: "successful")
+        expect(page).to have_css("td", text: "failed")
+      end
+
+      it "keeps the selection on 'All'" do
+        expect(page).to have_select("Status type:", selected: "All")
+      end
+    end
+
     context "when fitering for successful requests" do
       before do
         select("Successful", from: "Status type:")
@@ -56,6 +72,10 @@ describe "View authentication requests for an IP", type: :feature do
       it "shows only successful requests" do
         expect(page).to have_css("td", text: "successful")
         expect(page).to_not have_css("td", text: "failed")
+      end
+
+      it "keeps the selection on 'Successful'" do
+        expect(page).to have_select("Status type:", selected: "Successful")
       end
     end
 
@@ -68,6 +88,10 @@ describe "View authentication requests for an IP", type: :feature do
       it "shows only failed requests" do
         expect(page).to_not have_css("td", text: "successful")
         expect(page).to have_css("td", text: "failed")
+      end
+
+      it "keeps the selection on 'Failed'" do
+        expect(page).to have_select("Status type:", selected: "Failed")
       end
     end
   end


### PR DESCRIPTION

### What
Filter for the logs partially works

### Why
We’re not able to filter logs using the three options

We’re not able to see filter status selected 


Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-777
