### PR TITLE
update name for Northamptonshire County Council to West Northamptonshire Unitary Council

### DIFF
--- a/lib/gateways/govuk_organisations_register_gateway.rb
+++ b/lib/gateways/govuk_organisations_register_gateway.rb
@@ -1266,7 +1266,7 @@ module Gateways
         "North Norfolk District Council",
         "Norwich City Council",
         "South Norfolk District Council",
-        "Northamptonshire County Council",
+        "West Northamptonshire Unitary Council",
         "Corby Borough Council",
         "Daventry District Council",
         "East Northamptonshire Council",


### PR DESCRIPTION
### What
update name for Northamptonshire County Council to West Northamptonshire Unitary Council

### Why
Northamptonshire County Council requested an updating their name to West Northamptonshire Unitary Council. Zendesk ticket attached

Link to Trello card (if applicable): 
https://govuk.zendesk.com/agent/tickets/5284993