### PR TITLE
User Search View Fix

### DIFF
--- a/app/views/super_admin/wifi_user_searches/show.html.erb
+++ b/app/views/super_admin/wifi_user_searches/show.html.erb
@@ -9,7 +9,7 @@
       <% if @form_valid %>
         <div class="govuk-body">
           <% if @wifi_user.present? %>
-            <h3 class="govuk-heading-s">User details for '<%= params[:search_term] %>'</h3>
+            <h3 class="govuk-heading-s">User details for '<%= @form.search_term %>'</h3>
             <p class="govuk-body">
               Username: <%= link_to @wifi_user.username,
                                     logs_path(log_search_form: { username: @wifi_user.username,


### PR DESCRIPTION
### What
User interface fix to show 'User details for _search_term_ ' correctly and not with a blank string for _search_term_

### Why
Previous code showed an inconsistency in User interface.

JIRA: https://technologyprogramme.atlassian.net/browse/GW-873
