### PR TITLE
Join Lint and Test

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,16 +8,11 @@ on:
       - master
 
 jobs:
-  lint:
+  lint-and-test:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Run lint
         run: make lint
-
-  test:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
       - name: Run tests
         run: make test

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Run lint
         run: make lint
       - name: Run tests
-        run: make test
+        run: make prebuilt-test

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,9 @@ autocorrect: autocorrect-erb
 autocorrect-erb: build
 	$(DOCKER_COMPOSE) run --rm --no-deps app bundle exec erblint --lint-all --autocorrect
 
-test: stop build
+test: stop build prebuilt-test
+
+prebuilt-test:
 	$(DOCKER_COMPOSE) run -e RACK_ENV=test --rm app ./bin/rails db:create db:schema:load db:migrate
 	$(DOCKER_COMPOSE) run --rm app bundle exec rspec
 


### PR DESCRIPTION
### What
Instead of building the GitHub runner container twice, just build once and run separate steps for lint and test rather than separate jobs.

### Why
Speed up the dev-PR-merge cycle, save the environment ;)

Link to JIRA / Trello card (if applicable): 
