### PR TITLE
Upgrade mysql docker containers from 5.7 to version 8.0.34

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.4"
 services:
   db:
     platform: linux/x86_64
-    image: "mysql:5.7"
+    image: "mysql:8.0"
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: root

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,3 +1,3 @@
-FROM mysql:5.7
+FROM mysql:8.0
 
 ADD rr_schema.sql /docker-entrypoint-initdb.d


### PR DESCRIPTION
### What
Upgrade mysql docker containers from 5.7 to version 8.0.34

### Why

We are upgrading our databases to mysql 8. For more information see the linked Jira card below. Version 8.0.34 is the latest stable release.

Link to JIRA / Trello card (if applicable):
 https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-1132
https://technologyprogramme.atlassian.net/browse/GW-1144

