### PR TITLE
GW-1125 notify templates dev

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -7,19 +7,23 @@ mysql: &mysql
   password: <%= ENV.fetch('DB_PASS') %>
 
 test:
-  <<: *mysql
+  !!merge <<: *mysql
   database: govwifi_admin_test
 
 development:
-  <<: *mysql
+  !!merge <<: *mysql
   database: development
 
+alpaca:
+  !!merge <<: *mysql
+  database: govwifi_admin_alpaca
+
 staging:
-  <<: *mysql
+  !!merge <<: *mysql
   database: govwifi_admin_staging
 
 production:
-  <<: *mysql
+  !!merge <<: *mysql
   database: govwifi_admin_production
 
 read_replica:

--- a/config/environments/alpaca.rb
+++ b/config/environments/alpaca.rb
@@ -1,0 +1,24 @@
+Rails.application.configure do
+  config.active_storage.service = :amazon
+  config.cache_classes = true
+  config.eager_load = true
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+  config.read_encrypted_secrets = true
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  config.assets.compile = false
+  config.log_level = :debug
+  config.log_tags = [:request_id]
+  config.i18n.fallbacks = true
+  config.active_support.deprecation = :notify
+  config.log_formatter = ::Logger::Formatter.new
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new($stdout)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
+  config.active_record.dump_schema_after_migration = false
+  config.action_mailer.default_url_options = { host: "admin.alpaca.wifi.service.gov.uk" }
+  config.s3_aws_config = {}
+  config.route53_aws_config = {}
+end

--- a/config/gov_notify.yml
+++ b/config/gov_notify.yml
@@ -17,24 +17,24 @@ staging:
   first_ip_survey:
     template_id: "da84efee-97db-4925-87c4-8981fa1fa3ca"
 
-development:
+alpaca:
   support_email: "dev@localhost.com"
   otp_email:
-    template_id: "776fff48-3e94-4417-83b0-bff027c16247"
+    template_id: "04feab1a-3289-4dc0-af7d-7f5d431eb729"
   confirmation_email:
-    template_id: "1af17502-9797-4e61-904e-999f6cf259a5"
+    template_id: "ab038b62-e42a-40ed-b370-5f4ad647cd68"
   reset_password_email:
-    template_id: "1672af2e-2acb-463a-95ee-2adad2aaceee"
+    template_id: "6dbb02a0-a1b4-495a-b1d3-2adb49cb62c3"
   invite_email:
-    template_id: "e3b5ca96-9164-462f-a0b0-65d2103c1ab8"
+    template_id: "5d920a70-f043-416c-8bd6-416da2123b6e"
   help_email:
-    template_id: "152cf3ff-e0e2-4f41-9ba0-28091db3f37f"
+    template_id: "618a05ef-e9de-471d-ab48-1041d90d32ba"
   unlock_account:
-    template_id: "41f8744a-ebe0-417e-98c7-09002ff17a95"
+    template_id: "413eb61e-228e-4b49-92ae-279a91495d6d"
   cross_organisation_invitation:
-    template_id: "d360ba95-1e7d-41e4-920c-1255b65f6f65"
+    template_id: "dd901532-8ff4-4aaf-9e60-e7b5210d1d77"
   first_ip_survey:
-    template_id: "da84efee-97db-4925-87c4-8981fa1fa3ca"
+    template_id: "f56053f5-3279-452d-a593-04ecec9cc119"
 
 test:
   support_email: "test@localhost"

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -28,6 +28,9 @@ test:
 # Or, use `bin/rails secrets:setup` to configure encrypted secrets
 # and move the `production:` environment over there.
 
+alpaca:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+
 staging:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
 

--- a/config/site.yml
+++ b/config/site.yml
@@ -11,16 +11,19 @@ default: &default
   default_meta_description: "GovWifi - Administration Platform"
 
 development:
-  <<: *default
+  !!merge <<: *default
 
 test:
-  <<: *default
+  !!merge <<: *default
+
+alpaca:
+  !!merge <<: *default
 
 staging:
   google_analytics_script_id: "UA-127779891-2"
 
-  <<: *default
+  !!merge <<: *default
 
 production:
   google_analytics_script_id: "UA-127779891-1"
-  <<: *default
+  !!merge <<: *default


### PR DESCRIPTION
### What

Create an Alpaca config and Add notify templates to them.

### Why

So the Admin app can run in Alpaca with no links to the Staging environment. 

Link to JIRA / Trello card (if applicable):
GW-1125