### PR TITLE
Enable EmailGatewayStub use in development env

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,6 @@ require_relative "../lib/gateways/email_gateway"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-
 module GovwifiAdmin
   class Application < Rails::Application
     config.exceptions_app = routes
@@ -50,6 +49,5 @@ module GovwifiAdmin
     config.active_model.i18n_customize_full_message = true
 
     config.email_gateway = Gateways::EmailGateway
-    
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,10 +11,11 @@ require "action_view/railtie"
 require "sprockets/railtie"
 require "active_storage/engine"
 # require "rails/test_unit/railtie"
-
+require_relative "../lib/gateways/email_gateway"
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+
 
 module GovwifiAdmin
   class Application < Rails::Application
@@ -47,5 +48,8 @@ module GovwifiAdmin
 
     # enable customising the full_message method.
     config.active_model.i18n_customize_full_message = true
+
+    config.email_gateway = Gateways::EmailGateway
+    
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,8 @@
 require "action_mailer/railtie"
+require_relative "../../lib/gateways/email_gateway"
+
 Rails.application.configure do
+  config.email_gateway = Gateways::EmailGatewayStub
   config.active_storage.service = :local
   config.hosts.clear
   Bullet.enable = true

--- a/lib/gateways/email_gateway.rb
+++ b/lib/gateways/email_gateway.rb
@@ -2,7 +2,7 @@ require "notifications/client"
 
 module Gateways
   class EmailGateway
-    def self.send_email(opts)
+    def send_email(opts)
       client = Notifications::Client.new(ENV.fetch("NOTIFY_API_KEY"))
       client.send_email(
         email_address: opts[:email],
@@ -10,6 +10,15 @@ module Gateways
         personalisation: opts[:locals],
         reference: opts[:reference],
       )
+    end
+  end
+
+  class EmailGatewayStub
+    def send_email(opts)
+      puts "Stub email to: #{opts[:email]}"
+      puts "...Notifiy TemplateId: #{opts[:template_id]}"
+      puts "...Personalisation: #{opts[:locals]}"
+      puts "...Reference: #{opts[:reference]}"
     end
   end
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,6 +1,6 @@
 module Services
   def self.email_gateway
-    Gateways::EmailGateway
+    @email_gateway ||= Rails.application.config.email_gateway.new
   end
 
   def self.elasticsearch_client

--- a/spec/gateways/email_gateway_spec.rb
+++ b/spec/gateways/email_gateway_spec.rb
@@ -1,7 +1,7 @@
 require "support/notifications_service"
 
 describe Gateways::EmailGateway do
-  subject(:email_gateway) { described_class }
+  subject(:email_gateway) { described_class.new }
 
   let(:notification) { instance_spy(Notifications::Client, send_email: nil) }
 


### PR DESCRIPTION
### What

Created a stub implementation of EmailGateway which just prints out info and does not use notify or send actual email

### Why

db migration was attempting to use notify and failing since dev notify was not fully configured. Easier to not need notify in some localdev circumstances
