### PR TITLE
Add development back into gov_notify.yml

### DIFF
--- a/config/gov_notify.yml
+++ b/config/gov_notify.yml
@@ -17,6 +17,25 @@ staging:
   first_ip_survey:
     template_id: "da84efee-97db-4925-87c4-8981fa1fa3ca"
 
+development:
+  support_email: "dev@localhost.com"
+  otp_email:
+    template_id: "776fff48-3e94-4417-83b0-bff027c16247"
+  confirmation_email:
+    template_id: "1af17502-9797-4e61-904e-999f6cf259a5"
+  reset_password_email:
+    template_id: "1672af2e-2acb-463a-95ee-2adad2aaceee"
+  invite_email:
+    template_id: "e3b5ca96-9164-462f-a0b0-65d2103c1ab8"
+  help_email:
+    template_id: "152cf3ff-e0e2-4f41-9ba0-28091db3f37f"
+  unlock_account:
+    template_id: "41f8744a-ebe0-417e-98c7-09002ff17a95"
+  cross_organisation_invitation:
+    template_id: "d360ba95-1e7d-41e4-920c-1255b65f6f65"
+  first_ip_survey:
+    template_id: "da84efee-97db-4925-87c4-8981fa1fa3ca"
+
 alpaca:
   support_email: "dev@localhost.com"
   otp_email:


### PR DESCRIPTION
This is needed when Rails runs into development mode, i.e. running locally
