### PR TITLE
Remove platform directives from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3.4"
 
 services:
   db:
-    platform: linux/x86_64
     image: "mysql:8.0"
     environment:
       MYSQL_ROOT_PASSWORD: root
@@ -16,7 +15,6 @@ services:
 
   rr_db:
     build: ./mysql
-    platform: linux/x86_64
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: rr_govwifi
@@ -29,7 +27,6 @@ services:
 
   wifi_user_db:
     build: ./mysql_user
-    platform: linux/x86_64
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: wifi_user_govwifi


### PR DESCRIPTION
For previous versions of mysql a specific platform had to be selected to make the admin app work on M1 macs. This has now changed with using a newer version of mysql and so these can be removed

