### PR TITLE
Remove platform directive from app section in docker-compose

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,6 +255,14 @@ GEM
     nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.15.4-arm-linux)
+      racc (~> 1.4)
+    nokogiri (1.15.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.4-x86-linux)
+      racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-darwin)
+      racc (~> 1.4)
     notifications-ruby-client (5.4.0)
       jwt (>= 1.5, < 3)
     orm_adapter (0.5.0)
@@ -493,7 +501,10 @@ GEM
     zxcvbn (0.1.9)
 
 PLATFORMS
+  armv7-linux
   ruby
+  universal-darwin-8
+  x86-linux
 
 DEPENDENCIES
   aws-sdk-route53 (~> 1.78.0)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,6 @@ services:
       retries: 10
 
   app:
-    platform: linux/x86_64
     build:
       context: .
       args:


### PR DESCRIPTION
This is no longer required. In order for amongst others, Nokogiri to work, the arm-7, darwin and x86 platforms were added to bundler using
 bundle lock --add-platform universal-darwin-8
 bundle lock --add-platform x86-linux
 bundle lock --add-platform arm7-linux
