### PR TITLE
Add filters to the team section

### DIFF
--- a/app/controllers/super_admin/organisations_controller.rb
+++ b/app/controllers/super_admin/organisations_controller.rb
@@ -20,7 +20,7 @@ class SuperAdmin::OrganisationsController < SuperAdminController
 
   def show
     @organisation = Organisation.find(params[:id])
-    @team = @organisation.users.order_by_name_and_email
+    @team = @organisation.users.order("#{sort_column} #{sort_direction}")
     @pagy, @locations = pagy(@organisation.locations.order("address asc"))
   end
 
@@ -34,7 +34,7 @@ class SuperAdmin::OrganisationsController < SuperAdminController
 private
 
   def sortable_columns
-    %w[name created_at locations_count ips_count active_storage_attachments.created_at]
+    %w[name created_at locations_count ips_count active_storage_attachments.created_at last_sign_in_at email sign_in_count]
   end
 
   def sort_column

--- a/app/views/super_admin/organisations/_team.html.erb
+++ b/app/views/super_admin/organisations/_team.html.erb
@@ -1,11 +1,23 @@
 <% if team.any? %>
   <table class="govuk-table">
     <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header"><%= sort_link "name", "Username" %></th>
+      <th scope="col" class="govuk-table__header"><%= sort_link "last_sign_in_at", "Last login" %></th>
+      <th scope="col" class="govuk-table__header"><%= sort_link "sign_in_count", "Logins" %></th>
+      <th scope="col" class="govuk-table__header"><%= sort_link "email", "Email" %></th>
+    </tr>
     </thead>
     <tbody class="govuk-table__body">
       <% team.each do |user| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" scope="row"><%= user.name %></td>
+          <td class="govuk-table__cell" scope="row">
+            <% if user.last_sign_in_at.present? %>
+                <%= user.last_sign_in_at.strftime("%-d %b %Y") %>
+            <% end %>
+            </td>
+          <td class="govuk-table__cell text-right" scope="row"><%= user.sign_in_count %></td>
           <td class="govuk-table__cell text-right" scope="row"><%= user.email %></td>
           <td class="govuk-table__cell text-right" scope="row">
             <%= link_to edit_membership_path(user.membership_for(@organisation), remove_team_member: true),

--- a/spec/features/super_admin/locations/locations_spec.rb
+++ b/spec/features/super_admin/locations/locations_spec.rb
@@ -48,9 +48,63 @@ describe "View and search locations", type: :feature do
   end
 
   context "selecting a location" do
-    it "takes the user to the organisation page" do
+    before do
+      create(:user, name: "Team member 1", organisations: [organisation], last_sign_in_at: "10 Dec 2023", email: "adam@gov.uk")
+      create(:user, name: "Team member 2", organisations: [organisation], last_sign_in_at: "10 Feb 2011", email: "brian@gov.uk")
+      create(:user, name: "Team member 3", organisations: [organisation], last_sign_in_at: "10 Dec 2013", email: "Toni@gov.uk")
+
       click_on "69 Garry Street, London, HA7 2BL"
+    end
+
+    it "takes the user to the organisation page" do
       expect(page).to have_content(organisation.name)
+    end
+
+    it "shows the team section" do
+      expect(page).to have_content("Team")
+    end
+
+    it "shows the last login for the team" do
+      expect(page).to have_content("Last login")
+    end
+
+    it "shows the login count for the team members" do
+      expect(page).to have_content("Logins")
+    end
+
+    it "the list is sorted from newest to oldest, after Last login is clicked the first time" do
+      click_link "Last login"
+      expect(page.body).to match(/Team member 1.*Team member 3.*Team member 2/m)
+    end
+
+    it "the list is sorted from oldest to newest, after Last login is clicked again" do
+      2.times { click_link "Last login" }
+
+      expect(page.body).to match(/Team member 2.*Team member 3.*Team member 1/m)
+    end
+
+    it "the list is sorted after Email is clicked the first time" do
+      click_link "Email"
+
+      expect(page.body).to match(/Team member 3.*Team member 2.*Team member 1/m)
+    end
+
+    it "the list is sorted in reverse order after Email is clicked again" do
+      2.times { click_link "Email" }
+
+      expect(page.body).to match(/Team member 1.*Team member 2.*Team member 3/m)
+    end
+
+    it "the list is sorted after Username is clicked the first time" do
+      click_link "Username"
+
+      expect(page.body).to match(/Team member 3.*Team member 2.*Team member 1/m)
+    end
+
+    it "the list is sorted in reverse order after Username is clicked again" do
+      2.times { click_link "Username" }
+
+      expect(page.body).to match(/Team member 1.*Team member 2.*Team member 3/m)
     end
   end
 end


### PR DESCRIPTION
### What

Add filters to the team section to show admin logs as we already collect this information however we don’t show it to super admins

### Why

It’d be useful to use when finding and contacting the most active admins for an organisation in certain instances - i.e. issues with that org, research, engagement, etc.

Link to JIRA / Trello card (if applicable):
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=62c2bb48159944bf7687d333&selectedIssue=GW-791