### PR TITLE
fix: [GW-1324] update broken links.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,5 @@ Describe the change
 
 Describe why the change was necessary
 
-Link to JIRA / Trello card (if applicable):
+Link to JIRA card (if applicable):
+[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)

--- a/app/views/help/new.html.erb
+++ b/app/views/help/new.html.erb
@@ -10,7 +10,7 @@
       <%= link_to "technical documentation", SITE_CONFIG["organisation_docs_link"], class: "govuk-link" %>.
     </p>
     <p>
-      If users in your organisation are having trouble connecting devices to GovWifi, please refer them to our <%= link_to "user support guidance", "https://www.wifi.service.gov.uk/support/", class: "govuk-link" %> on common issues.
+      If users in your organisation are having trouble connecting devices to GovWifi, please refer them to our <%= link_to "user support guidance", "https://www.wifi.service.gov.uk/get-help-connecting/", class: "govuk-link" %> on common issues.
     </p>
 
       <% radio_options = [OpenStruct.new(value: :technical_support, label: "Setting up GovWifi in your organisation support"),

--- a/app/views/help/user_support.html.erb
+++ b/app/views/help/user_support.html.erb
@@ -10,7 +10,7 @@
       <div class="govuk-body">Contact us for help and support with users connecting to GovWifi in your organisation.</div>
       <div class="govuk-inset-text">
         If users in your organisation are having trouble connecting devices to GovWifi, please advise them to review our
-        <%= link_to "device support guidance", "https://www.wifi.service.gov.uk/support", class: "govuk-link" %> on common issues
+        <%= link_to "device support guidance", "https://www.wifi.service.gov.uk/get-help-connecting/", class: "govuk-link" %> on common issues
       </div>
       <%= f.govuk_text_field :name, label: { text: "Your name" } %>
       <%= f.govuk_text_field :email, label: { text: "Your email address" } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -74,7 +74,7 @@
             <h2 class="govuk-footer__heading govuk-heading-m">About</h2>
             <ul class="govuk-footer__list govuk-footer__list--columns-1">
               <li class="govuk-footer__list-item">
-                <%= link_to "Our service", "https://www.wifi.service.gov.uk/about-govwifi/", class: "govuk-footer__link" %>
+                <%= link_to "Our service", "https://docs.wifi.service.gov.uk/index.html", class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__list-item">
                 <%= link_to "Terms and conditions", "https://www.wifi.service.gov.uk/terms-and-conditions/", class: "govuk-footer__link" %>
@@ -88,13 +88,13 @@
             <h2 class="govuk-footer__heading govuk-heading-m">Connect</h2>
             <ul class="govuk-footer__list govuk-footer__list--columns-1">
               <li class="govuk-footer__list-item">
-                <%= link_to "Connect to GovWifi", "https://www.wifi.service.gov.uk/about-govwifi/connect-to-govwifi/", class: "govuk-footer__link" %>
+                <%= link_to "Connect to GovWifi", "https://www.wifi.service.gov.uk/connect-to-govwifi/", class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__list-item">
-                <%= link_to "Organisations using GovWifi", "https://www.wifi.service.gov.uk/about-govwifi/organisations-using-govwifi/", class: "govuk-footer__link" %>
+                <%= link_to "Organisations using GovWifi", "https://www.wifi.service.gov.uk/organisations-using-govwifi/", class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__list-item">
-                <%= link_to "Support", "https://www.wifi.service.gov.uk/support/", class: "govuk-footer__link" %>
+                <%= link_to "Support", "https://docs.wifi.service.gov.uk/troubleshooting.html", class: "govuk-footer__link" %>
               </li>
             </ul>
           </div>
@@ -108,7 +108,7 @@
                 <%= link_to "Network Administrator login", new_user_session_path, class: "govuk-footer__link" %>
               </li>
               <li class="govuk-footer__list-item">
-                <%= link_to "Technical Documentation", "https://docs.wifi.service.gov.uk/manage/#manage-govwifi", class: "govuk-footer__link" %>
+                <%= link_to "Technical Documentation", "https://docs.wifi.service.gov.uk/manage.html#manage-govwifi", class: "govuk-footer__link" %>
               </li>
             </ul>
           </div>

--- a/config/site.yml
+++ b/config/site.yml
@@ -1,12 +1,12 @@
 default: &default
   end_user_docs_link: "https://www.wifi.service.gov.uk/connect-to-govwifi/"
-  end_user_troubleshooting_link: "https://www.wifi.service.gov.uk/connect-to-govwifi/get-help-connecting/"
+  end_user_troubleshooting_link: "https://www.wifi.service.gov.uk/get-help-connecting/"
   service_status_link: "https://status.wifi.service.gov.uk/"
   organisation_docs_link: "https://docs.wifi.service.gov.uk"
-  support_link: "https://www.wifi.service.gov.uk/connect-to-govwifi/get-help-connecting/"
+  support_link: "https://www.wifi.service.gov.uk/get-help-connecting/"
   connect_to_govwifi_link: "https://www.wifi.service.gov.uk/connect-to-govwifi/"
-  cookies_docs_link: "https://www.wifi.service.gov.uk/cookies"
-  product_page_link: "https://wifi.service.gov.uk"
+  cookies_docs_link: "https://www.wifi.service.gov.uk/cookies/"
+  product_page_link: "https://www.wifi.service.gov.uk/"
   default_page_title: "GovWifi admin"
   default_meta_description: "GovWifi - Administration Platform"
 


### PR DESCRIPTION
### What

Describe the change
Correcting broken links.

### Why

Describe why the change was necessary
So that correct documentation can be accessed

Link to JIRA / Trello card (if applicable):
[GW-1324](https://technologyprogramme.atlassian.net/browse/GW-1324)

[GW-1324]: https://technologyprogramme.atlassian.net/browse/GW-1324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ