### PR TITLE
add cba flag

### DIFF
--- a/app/controllers/super_admin/organisations_controller.rb
+++ b/app/controllers/super_admin/organisations_controller.rb
@@ -1,6 +1,8 @@
 class SuperAdmin::OrganisationsController < SuperAdminController
   helper_method :sort_column, :sort_direction
 
+  before_action :set_organisation, only: %i[toggle_cba_feature]
+
   def index
     @organisations = Organisation.sortable_with_child_counts(sort_column, sort_direction)
 
@@ -31,7 +33,16 @@ class SuperAdmin::OrganisationsController < SuperAdminController
     redirect_to super_admin_organisations_path, notice: "Organisation has been removed"
   end
 
+  def toggle_cba_feature
+    @organisation.update!(cba_enabled: !@organisation.cba_enabled)
+    redirect_to super_admin_organisation_path, notice: "Cba feature flag toggled successfully"
+  end
+
 private
+
+  def set_organisation
+    @organisation = Organisation.find(params[:id])
+  end
 
   def sortable_columns
     %w[name created_at locations_count ips_count active_storage_attachments.created_at last_sign_in_at email sign_in_count]

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -10,6 +10,8 @@ class Organisation < ApplicationRecord
   validates :service_email, format: { with: Devise.email_regexp }
   validate :validate_in_register?, unless: proc { |org| org.name.blank? }
 
+  validates :cba_enabled, inclusion: { in: [true, false] }, allow_nil: true
+
   validates_associated :locations
 
   scope :sortable_with_child_counts, lambda { |sort_column, sort_direction|
@@ -18,6 +20,14 @@ class Organisation < ApplicationRecord
       .group("organisations.id, active_storage_attachments.created_at")
       .order(sort_column => sort_direction)
   }
+
+  def enable_cba_feature!
+    update(cba_enabled: true)
+  end
+
+  def disable_cba_feature!
+    update(cba_enabled: false)
+  end
 
   def meets_invited_admin_user_minimum?
     memberships.count(&:administrator?) >= 2

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -59,6 +59,7 @@
               <% end %>
             </td>
           <% end %>
+
           <td class="govuk-table__cell"><%= log.ap %></td>
           <td class="govuk-table__cell"><%= log.mac %></td>
           <% unless log_search_form.ip %>

--- a/app/views/super_admin/organisations/_cba_form.html.erb
+++ b/app/views/super_admin/organisations/_cba_form.html.erb
@@ -1,0 +1,21 @@
+<% cba_enabled = organisation.cba_enabled %>
+
+  <p class="govuk-body">
+    Show both EAP/TLS and MS-CHAPv2 authentication attempts in the logs. This is for organisations using Certificate Based Authentication (CBA)
+  </p>
+  <% if cba_enabled %>
+    <p class="govuk-body">
+      This organisation can see the CBA logs.
+    </p>
+  <% else %>
+    <p class="govuk-body">
+      This organisation cannot see the CBA logs.
+    </p>
+  <% end %>
+
+<div id="cba-form">
+  <%= form_with(model: @organisation, url: toggle_cba_feature_super_admin_organisation_path(@organisation), method: :patch) do |form| %>
+    <%= form.hidden_field :cba_enabled, value: !@organisation.cba_enabled %>
+    <%= form.submit(@organisation.cba_enabled ? "Turn off CBA logs" : "Turn on CBA logs", class: @organisation.cba_enabled ? "govuk-button govuk-button--secondary" : "govuk-button") %>
+  <% end %>
+</div>

--- a/app/views/super_admin/organisations/show.html.erb
+++ b/app/views/super_admin/organisations/show.html.erb
@@ -35,6 +35,10 @@
       <%= render "mou_form", organisation: @organisation %>
     <% end %>
 
+    <%= render "section", heading: "CBA" do %>
+      <%= render "cba_form", organisation: @organisation %>
+    <% end %>
+
     <%= render "section", heading: "Locations" do %>
       <%== pagy_nav_govuk(@pagy) %>
       <%= render "locations", locations: @locations %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,7 @@ Rails.application.routes.draw do
     end
     resources :mou, only: %i[index update create]
     resources :organisations, only: %i[index show destroy] do
+      patch "toggle_cba_feature", to: "organisations#toggle_cba_feature", on: :member
       collection do
         get "service_emails", to: "organisations#service_emails", constraints: { format: "csv" }
       end

--- a/db/migrate/20231228135538_add_cba_enabled_to_organisations.rb
+++ b/db/migrate/20231228135538_add_cba_enabled_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddCbaEnabledToOrganisations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organisations, :cba_enabled, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_19_161245) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_28_135538) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -96,6 +96,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_19_161245) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "service_email"
+    t.boolean "cba_enabled"
     t.index ["name"], name: "index_organisations_on_name", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -120,3 +120,7 @@ location_two.ips.each_with_index do |location_two_ip, index|
 end
 
 MouTemplate.create!
+
+Organisation.all.each do |org|
+  org.update(cba_enabled: false)
+end


### PR DESCRIPTION
### What

This pull request introduces a feature that allows admins to control the visibility of CBA information in the logs through the use of a flag. Additionally, a user interface has been implemented specifically for superadmins, enabling them to toggle the CBA feature on and off.

### Why

The motivation behind these changes is to facilitate a controlled rollout of the CBA feature to selected organisations. The key objectives are as follows:

1. **Gradual Rollout:**
   - The introduction of the flag feature empowers superadmins to selectively enable or disable the CBA display in logs. This ensures a gradual rollout, allowing us to test and validate the feature in a controlled manner.

2. **Avoid Confusion:**
   - By providing superadmins with a dedicated UI to manage the CBA feature, we prevent confusion among other admins who may not be using CBA yet.

3. **User Friendly Control:**
   - The inclusion of a UI for superadmins makes the management of the CBA feature user friendly and accessible, providing them with a centralised control point.

4. **Customisation for Organisations:**
   - Superadmins now have the flexibility to customise the CBA visibility based on the specific needs and readiness of different organisations.

This change aligns with our strategy to ensure a smooth and well managed integration of the CBA feature into our system, optimising user experience and minimising disruption.

Link to JIRA card (if applicable):
[[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)](https://technologyprogramme.atlassian.net/browse/GW-1267)
