### PR TITLE
Dependabot/bundler/pagy 7.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "net-imap", require: false
 gem "net-pop", require: false
 gem "net-smtp", require: false
 gem "notifications-ruby-client", "~> 5.4.0"
-gem "pagy", "~> 6.0.4"
+gem "pagy", "~> 7.0.2"
 gem "puma", "~> 6.3"
 gem "rails", "~> 7.0.7"
 gem "rqrcode"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,7 @@ GEM
       jwt (>= 1.5, < 3)
     orm_adapter (0.5.0)
     os (1.1.4)
-    pagy (6.0.4)
+    pagy (7.0.2)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -531,7 +531,7 @@ DEPENDENCIES
   net-smtp
   nokogiri
   notifications-ruby-client (~> 5.4.0)
-  pagy (~> 6.0.4)
+  pagy (~> 7.0.2)
   pry
   puma (~> 6.3)
   rack-mini-profiler

--- a/app/helpers/pagy_helper.rb
+++ b/app/helpers/pagy_helper.rb
@@ -26,7 +26,7 @@ module PagyHelper
       html << case item
               when Integer then %(<li class="govuk-pagination__item"><a>#{link.call item}</a></li>) # page link
               when String then %(<li class="govuk-pagination__item govuk-pagination__item--current"><a>#{item}</a></li>) # current page
-              when :gap then %(<li class="govuk-pagination__item">#{pagy_t('pagy.nav.gap')}</li>) # page gap
+              when :gap then %(<li class="govuk-pagination__item">#{pagy_t('pagy.gap')}</li>) # page gap
               end
     end
     html << %(</ul>)

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -13,6 +13,8 @@
 # See https://ddnexus.github.io/pagy/api/pagy#instance-variables
 # Pagy::DEFAULT[:page]   = 1                                  # default
 Pagy::DEFAULT[:items] = 10 # default
+Pagy::DEFAULT[:size]  = [1, 4, 4, 1] # nav bar links
+
 # Pagy::DEFAULT[:outset] = 0                                  # default
 
 # Other Variables

--- a/spec/features/super_admin/organisations/view_organisation_page_spec.rb
+++ b/spec/features/super_admin/organisations/view_organisation_page_spec.rb
@@ -6,7 +6,7 @@ describe "View details of an organisation", type: :feature do
       100.times { organisation.locations << create(:location, organisation:) }
       sign_in_user create(:user, :super_admin)
       visit super_admin_organisation_path(organisation)
-      expect(page.body).to include(Pagy::I18n.translate(nil, "pagy.nav.gap"))
+      expect(page.body).to include(Pagy::I18n.translate(nil, "pagy.gap"))
     end
   end
 


### PR DESCRIPTION
Bump pagy to 7.0.2

This has some breaking changes:

With the new version of Pagy, we now have to explicitly set how each
pager is to be rendered and the 'gap' has now a different i18n reference.
