### PR TITLE
last login bug fix

### DIFF
--- a/app/views/super_admin/organisations/_team.html.erb
+++ b/app/views/super_admin/organisations/_team.html.erb
@@ -13,8 +13,8 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" scope="row"><%= user.name %></td>
           <td class="govuk-table__cell" scope="row">
-            <% if user.last_sign_in_at.present? %>
-                <%= user.last_sign_in_at.strftime("%-d %b %Y") %>
+            <% if user.current_sign_in_at.present? %>
+                <%= user.current_sign_in_at.strftime("%-d %b %Y") %>
             <% end %>
             </td>
           <td class="govuk-table__cell text-right" scope="row"><%= user.sign_in_count %></td>


### PR DESCRIPTION
### What

The date shown to SuperAdmins for a user’s last sign in seems to be reporting incorrectly and showing a date older than the known last sign in. 

### Why

Within the 'devise' package we use the last_sign_in_at value, which is apparently the previous date they signed in, so is probably misleading.
last_sign_in_at is the date and time the user signed in before their current session, which is current_sign_in_at. It will be nil if they haven't signed in or this is their first session.

Link to JIRA card (if applicable):
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=62c2bb48159944bf7687d333&selectedIssue=GW-1438
