### PR TITLE
Add GUI to add, remove and list certificates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ prebuild:
 	$(DOCKER_COMPOSE) up --no-start
 
 serve: stop build
-	$(DOCKER_COMPOSE) run --rm app ./bin/rails db:create db:schema:load db:seed
+	$(DOCKER_COMPOSE) run --rm app ./bin/rails db:create db:schema:load db:migrate db:seed
 	$(DOCKER_COMPOSE) up -d app
 
 lint: lint-ruby lint-erb lint-scss lint-prettier

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,6 +45,7 @@ protected
   def update_active_sidebar_path
     sidebar_paths =
       [ips_path,
+       certificates_path,
        memberships_path,
        new_organisation_settings_path,
        settings_path,

--- a/app/controllers/certificates_controller.rb
+++ b/app/controllers/certificates_controller.rb
@@ -1,0 +1,56 @@
+class CertificatesController < ApplicationController
+  before_action :authorise_manage_certificates
+  before_action :authorise_manage_current_certificate, only: %i[show edit destroy]
+  before_action :cba_flag_check
+
+  def index
+    @certificates = Certificate.where(organisation: current_organisation)
+  end
+
+  def show
+    @certificate = Certificate.find(params[:id])
+  end
+
+  def edit
+    @certificate = Certificate.find(params[:id])
+  end
+
+  def destroy
+    @certificate = Certificate.find(params[:id])
+    @certificate.destroy!
+    redirect_to(certificates_path, notice: "Successfully removed Certificate: #{@certificate.name}")
+  end
+
+  def new
+    @certificate_form = CertificateForm.new(organisation: current_organisation)
+  end
+
+  def create
+    cert_params = params.require(:certificate_form).permit(:file, :name)
+    file = cert_params[:file]
+    name = cert_params[:name]
+
+    @certificate_form = CertificateForm.new(name:, file:, organisation: current_organisation)
+    if @certificate_form.save
+      redirect_to(certificates_path, notice: "New Certificate Added: #{@certificate_form.name}")
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+private
+
+  def authorise_manage_current_certificate
+    unless can? :manage, Certificate.find(params[:id])
+      redirect_to root_path, flash: { error: "You are not allowed to perform this operation" }
+    end
+  end
+
+  def authorise_manage_certificates
+    redirect_to root_path, flash: { error: "You are not allowed to perform this operation" } unless current_user.can_manage_certificates?(current_organisation)
+  end
+
+  def cba_flag_check
+    redirect_to root_path, flash: { error: "You are not allowed to perform this operation" } unless current_organisation.cba_enabled?
+  end
+end

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -12,7 +12,8 @@ class MembershipsController < ApplicationController
         hint: <<~HINT.html_safe,
           View locations and IPs, team members, and logs<br>
           Manage locations and IPs<br>
-          Add or remove team members
+          Add or remove team members<br>
+          View, add and remove certificates
         HINT
       ),
       OpenStruct.new(
@@ -21,7 +22,8 @@ class MembershipsController < ApplicationController
         hint: <<~HINT.html_safe,
           View locations and IPs, team members, and logs<br>
           Manage locations and IPs<br>
-          Cannot add or remove team members
+          Cannot add or remove team members<br>
+          View, add and remove certificates
         HINT
       ),
       OpenStruct.new(

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,6 +14,10 @@ class Ability
         user.membership_for(loc.organisation)
       end
 
+      can :manage, Certificate do |cert|
+        user.membership_for(cert.organisation)
+      end
+
       # :manage is a reserved can-can word to represent ALL actions
       if user.is_super_admin?
         can :manage, :all

--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -1,0 +1,24 @@
+class Certificate < ApplicationRecord
+  belongs_to :organisation
+
+  validates :name, presence: true, uniqueness: { scope: :organisation_id }
+  validates :fingerprint, presence: true, uniqueness: { scope: :organisation_id }
+
+  validates :content, :subject, :issuer, :not_before, :not_after, :serial, presence: true
+  def root_cert?
+    subject == issuer
+  end
+
+  def expired?
+    Time.zone.now.after?(not_after)
+  end
+
+  def nearly_expired?(days)
+    warning_start_date = not_after.days_ago(days)
+    Time.zone.now.after?(warning_start_date)
+  end
+
+  def not_yet_valid?
+    not_before.after?(Time.zone.now)
+  end
+end

--- a/app/models/certificate_form.rb
+++ b/app/models/certificate_form.rb
@@ -1,0 +1,57 @@
+require "openssl"
+class CertificateForm
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  include ActiveModel::Validations::Callbacks
+
+  attr_accessor :file, :name, :organisation
+
+  before_validation :parse_certificate
+
+  validate :name_uniqueness, :fingerprint_uniqueness
+  validates :name, presence: true
+  validates :file, presence: true
+
+  validate :validate_x509
+
+  def save
+    return false unless valid?
+
+    !!@certificate&.save
+  end
+
+private
+
+  def name_uniqueness
+    errors.add(:name, :taken) if Certificate.exists?(organisation:, name:)
+  end
+
+  def fingerprint_uniqueness
+    return if @certificate.nil?
+
+    errors.add(:file, :taken) if Certificate.exists?(organisation:, fingerprint: @certificate.fingerprint)
+  end
+
+  def validate_x509
+    return if @x509_parsing_error.nil?
+
+    errors.add(:file, :invalid_certificate)
+  end
+
+  def parse_certificate
+    content = file&.read
+    return if content.nil?
+
+    @certificate = Certificate.new(name:, organisation:)
+    @certificate.content = content
+    x509_certificate = OpenSSL::X509::Certificate.new(content)
+    @certificate.fingerprint = OpenSSL::Digest::SHA1.new(x509_certificate.to_der).to_s
+    @certificate.subject = x509_certificate.subject.to_s
+    @certificate.issuer = x509_certificate.issuer.to_s
+    @certificate.not_before = x509_certificate.not_before
+    @certificate.not_after = x509_certificate.not_after
+    @certificate.serial = x509_certificate.serial.to_s
+  rescue OpenSSL::X509::CertificateError => e
+    @x509_parsing_error = e.message
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -5,6 +5,7 @@ class Organisation < ApplicationRecord
   has_many :users, through: :memberships, inverse_of: :organisations
   has_many :locations, dependent: :destroy
   has_many :ips, through: :locations
+  has_many :certificates, dependent: :destroy
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :service_email, format: { with: Devise.email_regexp }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,10 @@ class User < ApplicationRecord
     is_super_admin? || membership_for(organisation).can_manage_locations?
   end
 
+  def can_manage_certificates?(organisation)
+    can_manage_locations?(organisation)
+  end
+
   def membership_for(organisation)
     memberships.find_by(organisation:)
   end

--- a/app/views/certificates/_confirm_remove_certificate.html.erb
+++ b/app/views/certificates/_confirm_remove_certificate.html.erb
@@ -1,0 +1,17 @@
+<% content_for :page_title, "Remove Certificate", flush: true %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-padding-0">
+    <h1 class="govuk-heading-l">Certificate - <%= @certificate.name %></h1>
+  </div>
+</div>
+<div class="govuk-error-summary" role="alert">
+  <h2 class="govuk-error-summary__title">Remove this Certificate?</h2>
+  <div class="govuk-error-summary__body">
+    <p class="govuk-body">
+      Any devices using a related certificate will stop connecting to GovWifi
+    </p>
+    <%= button_to "Remove", certificate_path(@certificate), method: :delete, class: "govuk-button red-button" %>
+    <%= link_to "Cancel", certificates_path, class: "govuk-link--no-visited-state govuk-body" %>
+  </div>
+</div>
+<%= render "show_certificate" %>

--- a/app/views/certificates/_show_certificate.erb
+++ b/app/views/certificates/_show_certificate.erb
@@ -1,0 +1,93 @@
+<div id="wrapper">
+  <div class="govuk-grid-row">
+      <div aria-live="polite">
+        <table class="govuk-table govuk-!-margin-bottom-9">
+          <caption class="govuk-visually-hidden">Settings</caption>
+          <thead class="govuk-table__head govuk-visually-hidden">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header govuk-!-width-one-third">Setting</th>
+              <th scope="col" class="govuk-table__header">Value</th>
+              <th scope="col" class="govuk-table__header">Action</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__cell govuk-!-width-one-third">
+                Name
+              </th>
+              <td class="govuk-table__cell">
+                <%= @certificate.name %>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                 <% if current_user.can_manage_locations?(current_organisation) && params[:confirm_remove].nil? %>
+                  <%= link_to edit_certificate_path(@certificate, confirm_remove: true), class: "govuk-link red-link govuk-link--no-visited-state" do %>
+                    Remove <span class='govuk-visually-hidden'><%= @certificate.serial %> from <%= @certificate.name %></span>
+                  <% end %>
+                <% end %>
+              </td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__cell govuk-!-width-one-third">
+                Fingerprint
+              </th>
+              <td class="govuk-table__cell">
+                <%= @certificate.fingerprint %>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+              </td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__cell govuk-!-width-one-third">
+                Serial
+              </th>
+              <td class="govuk-table__cell">
+                <%= @certificate.serial %>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+              </td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__cell govuk-!-width-one-third">
+                Valid From
+              </th>
+              <td class="govuk-table__cell">
+                  <%= @certificate.not_before %>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+              </td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__cell govuk-!-width-one-third">
+                Expires
+              </th>
+              <td class="govuk-table__cell">
+                  <%= @certificate.not_after %>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+              </td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__cell govuk-!-width-one-third">
+                Issuer
+              </th>
+              <td class="govuk-table__cell">
+                <%= @certificate.issuer %>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+              </td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__cell govuk-!-width-one-third">
+                Subject
+              </th>
+              <td class="govuk-table__cell">
+                <%= @certificate.subject %>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+  </div>
+</div>

--- a/app/views/certificates/edit.html.erb
+++ b/app/views/certificates/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :page_title, "Manage team member" %>
+
+<%= render "confirm_remove_certificate" %>

--- a/app/views/certificates/index.html.erb
+++ b/app/views/certificates/index.html.erb
@@ -1,0 +1,65 @@
+<% content_for :page_title, "Certificates" %>
+<div id='wrapper'>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-!-padding-0">
+      <h1 class="govuk-heading-l">Certificates</h1>
+    </div>
+      <div class="govuk-inset-text govuk-!-margin-top-0 govuk-!-margin-bottom-9">
+        You need to upload at least one Certificate to enable GovWifi Certificate Based Authentication. This will allow devices you issue (with a corresponding client certificate) to seamlessly authenticate with GovWifi.
+      </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-button-group govuk-!-padding-0">
+      <% if current_user.can_manage_locations?(current_organisation) %>
+        <%= link_to "Add Certificate", new_certificate_path, class: "govuk-button govuk-!-margin-bottom-5", role: "button", draggable: "false", "data-module" => "govuk-button" %>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible" />
+    <div aria-live="polite">
+      <table class="govuk-table govuk-!-margin-bottom-9">
+        <thead>
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Name</th>
+            <th scope="col" class="govuk-table__header govuk-!-text-align-left">Type</th>
+            <th scope="col" class="govuk-table__header govuk-!-text-align-left">Expires</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @certificates.each do |certificate| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell govuk-!-width-one-quarter">
+                <%= link_to certificate.name, certificate_path(certificate), class: "govuk-link govuk-link--no-visited-state" %>
+              </td>
+              <td class="govuk-table__cell govuk-!-width-one-quarter govuk-!-text-align-left">
+                <ul class="govuk-list">
+                  <% if certificate.root_cert? %>
+                    <li>Root</li>
+                  <% else %>
+                    <li>Intermediate</li>
+                  <% end %>
+                  <% if certificate.created_at.today? %>
+                    <li>Available from 6am tomorrow</li>
+                  <% end %>
+                </ul>
+              </td>
+              <td class="govuk-table__cell govuk-!-width-one-quarter govuk-!-text-align-left">
+                <%= certificate.not_after.strftime("%d %b %y") %>
+                <% if certificate.expired? %>
+                  <strong class="govuk-tag govuk-tag--red">Expired</strong>
+                <% elsif certificate.nearly_expired?(14) %>
+                  <strong class="govuk-tag govuk-tag--orange">Expiring soon</strong>
+                <% elsif certificate.not_yet_valid? %>
+                  <strong class="govuk-tag govuk-tag--yellow">Not yet valid</strong>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/app/views/certificates/new.html.erb
+++ b/app/views/certificates/new.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title, "Add Certificate" %>
+<%= form_with model: @certificate_form, url: { action: "create" }  do |f| %>
+  <%= f.govuk_error_summary %>
+  <div class='govuk-grid-row'>
+    <div class='govuk-grid-column-full'>
+      <h1 class='govuk-heading-l'>Add Certificate</h1>
+    </div>
+     <div class="govuk-inset-text govuk-!-margin-top-0 govuk-!-margin-bottom-9">
+        You need to upload at least one <strong>Intermediate</strong> Certificate to enable GovWifi Certificate Based Authentication. This will allow devices you issue (with a corresponding client certificate) to seamlessly authenticate with GovWifi.
+     </div>
+
+    <div class='govuk-grid-column-full'>
+      <%= f.govuk_text_field :name, hint: { text: "e.g. IntermediateCA 1" } %>
+      <%= f.govuk_file_field :file %>
+      <%= f.govuk_submit "Upload Certificate" %>
+      <p><%= link_to "Cancel", certificates_path, class: "govuk-link--no-visited-state govuk-body" %></p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/certificates/show.html.erb
+++ b/app/views/certificates/show.html.erb
@@ -1,0 +1,7 @@
+<% content_for :page_title, "Certificate" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-!-padding-0">
+    <h1 class="govuk-heading-l">Certificate - <%= @certificate.name %></h1>
+  </div>
+</div>
+<%= render "show_certificate" %>

--- a/app/views/ips/_confirm_remove_ip.html.erb
+++ b/app/views/ips/_confirm_remove_ip.html.erb
@@ -3,6 +3,9 @@
 <div class="govuk-error-summary" role="alert">
   <h2 class="govuk-error-summary__title">
     Remove this IP address?
+    <p class="govuk-body">
+      Any device trying to connect to GovWifi at this IP address will no longer be authenticated
+    </p>
   </h2>
 
   <div class="govuk-error-summary__body">

--- a/app/views/shared/sidebar/_default.html.erb
+++ b/app/views/shared/sidebar/_default.html.erb
@@ -5,6 +5,11 @@
         <li>
           <%= link_to "Locations", ips_path, id: "nav-ips", class: active_tab(ips_path) %>
         </li>
+        <% if current_organisation.cba_enabled? %>
+        <li>
+          <%= link_to "Certificates", certificates_path, class: active_tab(certificates_path) %>
+        </li>
+        <% end %>
         <li>
           <%= link_to "Team members", memberships_path, class: active_tab(memberships_path) %>
         </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,17 @@ en:
             details:
               format: "%{message}"
               blank: "Details can't be blank"
+        certificate_form:
+          attributes:
+            name:
+              format: "%{message}"
+              blank: "Certificate Name can't be blank"
+              taken: "Certificate Name already taken"
+            file:
+              format: "%{message}"
+              taken: "This certificate has already been uploaded"
+              blank: "No Certificate file selected. Please choose a file to try again."
+              invalid_certificate: "Certificates must be in a .PEM format"
   activerecord:
     errors:
       models:
@@ -98,6 +109,15 @@ en:
               private: "Address '%{ip_address}' is a private IP address. Only public IPv4 addresses can be added."
               malformed: "Address '%{ip_address}' is not a valid IP address"
               unpersisted_duplicate: "Ip address %{address} is a duplicate"
+        certificate:
+          attributes:
+            name:
+              format: "%{message}"
+              blank: "Certificate Name can't be blank"
+              taken: "Certificate Name already taken"
+            fingerprint:
+              format: "%{message}"
+              taken: "Identical Certificate already exists"
 
   users:
     two_factor_authentication:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
 
   resources :status, only: %i[index]
   resources :ips, only: %i[index new create destroy]
-
+  resources :certificates
   resources :help, only: %i[create new] do
     get "/", on: :collection, to: "help#new"
     get "signed_in", on: :new

--- a/db/migrate/20240215142005_create_certificates_table.rb
+++ b/db/migrate/20240215142005_create_certificates_table.rb
@@ -1,0 +1,19 @@
+class CreateCertificatesTable < ActiveRecord::Migration[6.1]
+  def change
+    create_table :certificates do |t|
+      t.string :fingerprint, unique: true
+      t.string :name
+      t.string :issuer
+      t.string :subject
+      t.datetime :not_before
+      t.datetime :not_after
+      t.string :serial
+      t.text :content
+      t.bigint :organisation_id
+
+      t.index %i[fingerprint organisation_id], unique: true
+      t.index %i[name organisation_id], unique: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_28_135538) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_15_142005) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -44,6 +44,22 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_28_135538) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["name"], name: "index_authorised_email_domains_on_name", unique: true
+  end
+
+  create_table "certificates", charset: "utf8mb3", force: :cascade do |t|
+    t.string "fingerprint"
+    t.string "name"
+    t.string "issuer"
+    t.string "subject"
+    t.datetime "not_before", precision: nil
+    t.datetime "not_after", precision: nil
+    t.string "serial"
+    t.text "content"
+    t.bigint "organisation_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["fingerprint", "organisation_id"], name: "index_certificates_on_fingerprint_and_organisation_id", unique: true
+    t.index ["name", "organisation_id"], name: "index_certificates_on_name_and_organisation_id", unique: true
   end
 
   create_table "custom_organisation_names", charset: "utf8mb3", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -121,6 +121,6 @@ end
 
 MouTemplate.create!
 
-Organisation.all.each do |org|
+Organisation.all.find_each do |org|
   org.update(cba_enabled: false)
 end

--- a/lib/tasks/repair_migrated_data.rake
+++ b/lib/tasks/repair_migrated_data.rake
@@ -12,7 +12,7 @@ namespace :repair_migrated_data do
 
   desc "Confirms and creates passwords for users"
   task confirm_and_create_passwords_for_users: :environment do
-    User.all.each do |user|
+    User.all.find_each do |user|
       random_password = Devise.friendly_token.first(16)
       user.update!(
         password: random_password,

--- a/spec/factories/certificates.rb
+++ b/spec/factories/certificates.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  factory :certificate do
+    sequence :name do |n|
+      "my_certificate_#{n}"
+    end
+    fingerprint { "ABCDEF123" }
+    content { "A Certificate" }
+    subject { "/CN=root" }
+    issuer { "/CN=root" }
+    not_before { Time.zone.now }
+    not_after { Time.zone.now + 7 * 4 }
+    serial { "1234567890" }
+
+    trait :with_organisation do
+      after :build do |cert|
+        cert.organisation = create(:organisation, :with_cba_enabled)
+      end
+    end
+  end
+end

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -19,5 +19,12 @@ FactoryBot.define do
         org.reload
       end
     end
+
+    trait :with_cba_enabled do
+      after :create do |org|
+        org.enable_cba_feature!
+        org.reload
+      end
+    end
   end
 end

--- a/spec/features/certificates/upload_certificate_spec.rb
+++ b/spec/features/certificates/upload_certificate_spec.rb
@@ -1,0 +1,244 @@
+describe "Upload Certificate", type: :feature do
+  let(:organisation) { create(:organisation, :with_cba_enabled) }
+  let(:user) { create(:user, organisations: [organisation]) }
+  let(:not_after) { Time.zone.now.days_since(365) }
+  let(:not_before) { Time.zone.now.days_ago(1) }
+
+  let(:root_ca) { CertificateHelper.new.root_ca(not_after:, not_before:) }
+  let(:intermediate_ca) { CertificateHelper.new.intermediate_ca(signed_by: root_ca) }
+  let(:root_certificate_path) do
+    file = Tempfile.new("certificate_file")
+    file.write(root_ca.to_pem)
+    file.close
+    file.path
+  end
+
+  let(:intermediate_certificate_path) do
+    file = Tempfile.new("certificate_file")
+    file.write(intermediate_ca.to_pem)
+    file.close
+    file.path
+  end
+
+  before do
+    sign_in_user user
+  end
+
+  context "when organisation is not enabled for cba" do
+    let(:organisation) { create(:organisation) }
+    before do
+      visit root_path
+    end
+
+    it "does not display the Certificates link on the left nav" do
+      expect(page.find(".leftnav")).to_not have_content("Certificates")
+    end
+  end
+
+  context "when organisation is enabled for cba" do
+    before do
+      visit root_path
+    end
+
+    it "displays the Certificates link on the left nav" do
+      expect(page.find(".leftnav")).to have_content("Certificates")
+    end
+
+    it "takes you to the form to upload a certificate" do
+      click_on "Certificates"
+      expect(page).to have_link("Add Certificate")
+
+      click_on "Add Certificate"
+      expect(page).to have_content "Add Certificate"
+    end
+  end
+
+  describe "when uploading a certificate without choosing a file" do
+    before do
+      visit new_certificate_path
+    end
+
+    it "reports an error" do
+      fill_in "Name", with: "MyCert1"
+      click_button "Upload Certificate"
+
+      expect(page).to have_content "No Certificate file selected. Please choose a file to try again."
+    end
+  end
+
+  describe "when uploading a certificate without setting a name" do
+    before do
+      visit new_certificate_path
+    end
+
+    it "reports an error" do
+      attach_file("File", root_certificate_path)
+      click_button "Upload Certificate"
+
+      expect(page).to have_content "Certificate Name can't be blank"
+    end
+  end
+
+  describe "when uploading a malformed certificate" do
+    before do
+      visit new_certificate_path
+    end
+
+    it "reports an error" do
+      file = Tempfile.new("bad_cert")
+      file.write("this is not a certificate")
+      file.close
+
+      fill_in "Name", with: "MyCert1"
+      attach_file("File", Rails.root.join(file.path))
+      click_button "Upload Certificate"
+
+      file.unlink
+
+      expect(page).to have_content "Certificates must be in a .PEM format"
+    end
+  end
+
+  describe "when uploading a valid certificate" do
+    let(:certificate_path) { root_certificate_path }
+    before do
+      visit new_certificate_path
+    end
+    before :each do
+      fill_in "Name", with: "MyCert1"
+      attach_file("File", certificate_path)
+      click_button "Upload Certificate"
+    end
+    it "succeeds" do
+      expect(page).to have_current_path(certificates_path)
+      expect(page).to have_content("New Certificate Added")
+    end
+    it "lists the new certificate" do
+      expect(page.find_link("MyCert1")).to_not be nil
+    end
+    it "indicates the certificate has not expired" do
+      expect(page).to_not have_content("Expired")
+    end
+    it "indicates the certificate does not expire soon" do
+      expect(page).to_not have_content("Expiring soon")
+    end
+    it "indicates the certificate is a root certificate" do
+      expect(page).to have_content("Root")
+      expect(page).to_not have_content("Intermediate")
+    end
+    context "upload an intermediate certificate" do
+      let(:certificate_path) { intermediate_certificate_path }
+
+      it "indicates the certificate is an intermediate certificate" do
+        expect(page).to_not have_content("Root")
+        expect(page).to have_content("Intermediate")
+      end
+    end
+    context "the certificate has expired" do
+      let(:not_after) { Time.zone.now.days_ago(1) }
+      it "indicates the certificate has expired" do
+        expect(page).to have_content("Expired")
+      end
+    end
+    context "the certificate has nearly expired" do
+      let(:not_after) { Time.zone.now.days_since(5) }
+      it "indicates the certificate has nearly expired" do
+        expect(page).to have_content("Expiring soon")
+      end
+    end
+    context "the certificate is not yet valid" do
+      let(:not_before) { Time.zone.now.days_since(5) }
+      it "is not yet valid" do
+        expect(page).to have_content("Not yet valid")
+      end
+    end
+    it "is already valid" do
+      expect(page).to_not have_content("Not yet valid")
+    end
+    context "the certificate was created today" do
+      it "will be activated tomorrow" do
+        visit(certificates_path)
+        expect(page).to have_content("Available from 6am tomorrow")
+      end
+    end
+    context "the certificate was created yesterday" do
+      it "has already been activated" do
+        Timecop.travel(Time.zone.now.days_since(1)) do
+          visit(certificates_path)
+          expect(page).to_not have_content("Available the following day")
+        end
+      end
+    end
+    context "show the certificate" do
+      before :each do
+        click_link "MyCert1"
+      end
+      it "shows the properties of the certificate" do
+        expect(page).to have_content("Name MyCert1")
+        expect(page).to have_content("Fingerprint #{OpenSSL::Digest::SHA1.new(root_ca.to_der)}")
+        expect(page).to have_content("Serial #{root_ca.serial}")
+        expect(page).to have_content("Valid From #{root_ca.not_before}")
+        expect(page).to have_content("Expires #{root_ca.not_after}")
+        expect(page).to have_content("Issuer #{root_ca.issuer}")
+        expect(page).to have_content("Subject #{root_ca.subject}")
+      end
+      context "remove the certificate" do
+        before :each do
+          click_link("Remove #{root_ca.serial} from MyCert1")
+        end
+        it "Asks for confirmation" do
+          expect(page).to have_content("Remove this Certificate?")
+        end
+        context "confirm" do
+          before :each do
+            click_button("Remove")
+          end
+          it "shows an empty table" do
+            expect(page).not_to have_css("tbody tr")
+          end
+          it "confirms the certificate has been removed" do
+            expect(page).to have_content("Successfully removed Certificate: MyCert1")
+          end
+        end
+      end
+    end
+  end
+
+  describe "when uploading a certificate with a name already in use" do
+    before do
+      visit new_certificate_path
+    end
+
+    it "reports an error" do
+      fill_in "Name", with: "MyCert1"
+      attach_file("File", root_certificate_path)
+      click_button "Upload Certificate"
+
+      visit new_certificate_path
+      fill_in "Name", with: "MyCert1"
+      attach_file("File", intermediate_certificate_path)
+      click_button "Upload Certificate"
+
+      expect(page).to have_content "Certificate Name already taken"
+    end
+  end
+
+  describe "when uploading the same certificate twice" do
+    before do
+      visit new_certificate_path
+    end
+
+    it "reports an error" do
+      fill_in "Name", with: "MyCert1"
+      attach_file("File", root_certificate_path)
+      click_button "Upload Certificate"
+
+      visit new_certificate_path
+      fill_in "Name", with: "MyCert2"
+      attach_file("File", root_certificate_path)
+      click_button "Upload Certificate"
+
+      expect(page).to have_content "This certificate has already been uploaded"
+    end
+  end
+end

--- a/spec/features/ips/view_ip_address_readiness_spec.rb
+++ b/spec/features/ips/view_ip_address_readiness_spec.rb
@@ -23,7 +23,7 @@ describe "View whether IPs are ready", type: :feature do
 
     context "when viewing the IP after a day" do
       before do
-        Ip.all.each do |ip|
+        Ip.all.find_each do |ip|
           ip.update(created_at: Date.yesterday)
         end
         sign_in_user user

--- a/spec/features/super_admin/organisations/view_organisation_list_spec.rb
+++ b/spec/features/super_admin/organisations/view_organisation_list_spec.rb
@@ -94,7 +94,7 @@ describe "View a list of signed up organisations", type: :feature do
       end
 
       it "shows all three organisations" do
-        Organisation.all.each do |org|
+        Organisation.all.find_each do |org|
           expect(page).to have_content(org.name)
         end
       end

--- a/spec/features/support/certificate_helper.rb
+++ b/spec/features/support/certificate_helper.rb
@@ -1,0 +1,46 @@
+require "openssl"
+
+class CertificateHelper
+  def initialize
+    @root_key = OpenSSL::PKey::RSA.new 512
+    @intermediate_key = OpenSSL::PKey::RSA.new 512
+  end
+
+  def root_ca(subject: "/CN=RootCA",
+              not_after: Time.zone.now.days_since(365),
+              not_before: Time.zone.now.days_ago(1),
+              serial: 123)
+    certificate = OpenSSL::X509::Certificate.new
+
+    certificate.public_key = @root_key.public_key
+    certificate.serial = serial
+    certificate.subject = certificate.issuer = OpenSSL::X509::Name.parse(subject)
+    certificate.not_before = not_before
+    certificate.not_after = not_after
+    certificate.extensions = [
+      OpenSSL::X509::ExtensionFactory.new.create_extension("basicConstraints", "CA:TRUE", true),
+    ]
+    certificate.sign @root_key, OpenSSL::Digest.new("SHA1")
+    certificate
+  end
+
+  def intermediate_ca(signed_by:,
+                      subject: "/CN=IntermediateCA",
+                      not_after: Time.zone.now + 365 * 24 * 60 * 60,
+                      serial: 234)
+    certificate = OpenSSL::X509::Certificate.new
+
+    certificate.public_key = @intermediate_key.public_key
+    certificate.serial = serial
+    certificate.subject = OpenSSL::X509::Name.parse subject
+    certificate.issuer = signed_by.subject
+    certificate.not_before = Time.zone.now
+    certificate.not_after = not_after
+
+    certificate.extensions = [
+      OpenSSL::X509::ExtensionFactory.new.create_extension("basicConstraints", "CA:TRUE", true),
+    ]
+    certificate.sign(@root_key, OpenSSL::Digest.new("SHA256"))
+    certificate
+  end
+end

--- a/spec/features/support/mock_zendesk_client.rb
+++ b/spec/features/support/mock_zendesk_client.rb
@@ -1,5 +1,5 @@
 shared_context "with a mocked support tickets client" do
-  class ZendeskClientMock       # rubocop:disable Lint/ConstantDefinitionInBlock
+  class ZendeskClientMock # rubocop:disable Lint/ConstantDefinitionInBlock
     class << self
       attr_accessor :config, :support_tickets, :exception_to_raise
     end

--- a/spec/models/certificate_form_spec.rb
+++ b/spec/models/certificate_form_spec.rb
@@ -1,0 +1,82 @@
+describe CertificateForm do
+  let(:root_ca) { CertificateHelper.new.root_ca }
+  let(:intermediate_ca) { CertificateHelper.new.intermediate_ca(signed_by: root_ca) }
+  let(:organisation) { create(:organisation) }
+  let(:name) { "myCert" }
+
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:file) }
+
+  describe "unique name" do
+    it "is valid because there is no Certificate with the same name in the organisation" do
+      certificate = CertificateForm.new(name:, organisation:, file: StringIO.new(root_ca.to_pem))
+      expect(certificate).to be_valid
+    end
+    it "is valid because there is a Certificate with the same name but in a different organisation" do
+      create(:certificate, :with_organisation, name:)
+
+      certificate = CertificateForm.new(name:, organisation:, file: StringIO.new(root_ca.to_pem))
+      expect(certificate).to be_valid
+    end
+    it "is invalid because there is a Certificate with the same name in the organisation" do
+      create(:certificate, name:, organisation:)
+      certificate = CertificateForm.new(name:, organisation:, file: StringIO.new(root_ca.to_pem))
+      expect(certificate).to_not be_valid
+      expect(certificate.errors.of_kind?(:name, :taken)).to be true
+    end
+  end
+
+  describe "unique fingerprint" do
+    it "is valid because there is no Certificate with the same fingerprint in the organisation" do
+      certificate = CertificateForm.new(name:, organisation:, file: StringIO.new(root_ca.to_pem))
+      expect(certificate).to be_valid
+    end
+    it "is valid because there is a Certificate with the same name but in a different organisation" do
+      create(:certificate, :with_organisation, fingerprint: OpenSSL::Digest::SHA1.new(root_ca.to_der).to_s)
+
+      certificate = CertificateForm.new(name:, organisation:, file: StringIO.new(root_ca.to_pem))
+      expect(certificate).to be_valid
+    end
+    it "is invalid because there is a Certificate with the same name in the organisation" do
+      create(:certificate, organisation:, fingerprint: OpenSSL::Digest::SHA1.new(root_ca.to_der).to_s)
+      certificate = CertificateForm.new(name:, organisation:, file: StringIO.new(root_ca.to_pem))
+      expect(certificate).to_not be_valid
+    end
+  end
+
+  describe "create a new certificate" do
+    context "a valid certificate" do
+      it "creates a new certificate" do
+        expect {
+          CertificateForm.new(name:, organisation:, file: StringIO.new(root_ca.to_pem)).save
+        }.to change(Certificate, :count).by(1)
+      end
+      it "The new certificate has the correct attributes" do
+        expect(CertificateForm.new(name:, organisation:, file: StringIO.new(root_ca.to_pem)).save).to be true
+        new_certificate = Certificate.find_by_name_and_organisation_id(name, organisation.id)
+        expect(new_certificate.content).to eq(root_ca.to_pem)
+        expect(new_certificate.fingerprint).to eq(OpenSSL::Digest::SHA1.new(root_ca.to_der).to_s)
+        expect(new_certificate.subject).to eq(root_ca.subject.to_s)
+        expect(new_certificate.issuer).to eq(root_ca.issuer.to_s)
+        expect(new_certificate.not_before).to eq(root_ca.not_before)
+        expect(new_certificate.not_after).to eq(root_ca.not_after)
+        expect(new_certificate.serial).to eq(root_ca.serial.to_s)
+      end
+    end
+    context "an invalid certificate" do
+      it "does not create a new certificate" do
+        expect {
+          CertificateForm.new(name:, organisation:, file: StringIO.new("invalid")).save
+        }.to_not change(Certificate, :count)
+      end
+      it "is invalid" do
+        form = CertificateForm.new(name:, organisation:, file: StringIO.new("invalid"))
+        expect(form).to_not be_valid
+        expect(form.errors.of_kind?(:file, :invalid_certificate)).to be true
+      end
+      it "returns false" do
+        expect(CertificateForm.new(name:, organisation:, file: StringIO.new("invalid")).save).to be false
+      end
+    end
+  end
+end

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -1,0 +1,85 @@
+describe Certificate do
+  let(:name) { "mycert" }
+  let(:content) { "A certificate" }
+  let(:fingerprint) { "ABC123" }
+  let(:certificate_subject) { "/CN=RootCA" }
+  let(:issuer) { "/CN=RootCA" }
+  let(:not_before) { Time.zone.now }
+  let(:not_after) { Time.zone.now.days_since(4 * 7) }
+  let(:serial) { "12345" }
+
+  subject(:certificate) do
+    build(:certificate, :with_organisation,
+          name:,
+          content:,
+          fingerprint:,
+          subject: certificate_subject,
+          issuer:,
+          not_before:,
+          not_after:,
+          serial:)
+  end
+
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:content) }
+  it { is_expected.to validate_presence_of(:fingerprint) }
+  it { is_expected.to validate_presence_of(:subject) }
+  it { is_expected.to validate_presence_of(:issuer) }
+  it { is_expected.to validate_presence_of(:not_before) }
+  it { is_expected.to validate_presence_of(:not_after) }
+  it { is_expected.to validate_presence_of(:serial) }
+  it { is_expected.to belong_to(:organisation) }
+
+  it "is valid" do
+    expect(certificate).to be_valid
+  end
+
+  context "when loading an intermediate certificate file" do
+    let(:certificate_subject) { "/CN=intermediate" }
+    it "is not a root certificate" do
+      expect(certificate).to_not be_root_cert
+    end
+  end
+
+  context "when loading a root certificate file" do
+    it "is a root certificate" do
+      expect(certificate).to be_root_cert
+    end
+  end
+
+  describe "#has_expired" do
+    context "expired" do
+      let(:not_after) { Time.zone.now.days_ago(7) }
+      it "is expired" do
+        expect(certificate).to be_expired
+      end
+    end
+    context "not expired" do
+      it "is not expired" do
+        expect(certificate).to_not be_expired
+      end
+    end
+  end
+
+  describe "#nearly_expired?" do
+    let(:not_after) { Time.zone.now.days_since(7) }
+    it "is nearly expired" do
+      expect(certificate.nearly_expired?(14)).to be true
+    end
+    it "is not nearly expired" do
+      expect(certificate.nearly_expired?(3)).to be false
+    end
+  end
+
+  describe "#not_yet_valid?" do
+    context "not yet valid" do
+      let(:not_before) { Time.zone.now.days_since(7) }
+      it "is not yet valid" do
+        expect(certificate).to be_not_yet_valid
+      end
+    end
+    it "is already valid" do
+      expect(certificate).to_not be_not_yet_valid
+    end
+  end
+end

--- a/spec/requests/certificates/certificate_helpers.rb
+++ b/spec/requests/certificates/certificate_helpers.rb
@@ -1,0 +1,27 @@
+module CertificateHelpers
+  def user_is_not_a_member_of_the_certificates_organisation
+    certificate.organisation = create(:organisation, :with_cba_enabled)
+    certificate.save!
+  end
+
+  def remove_edit_location_permission
+    membership = user.membership_for(organisation)
+    membership.permission_level = "view_only"
+    membership.save!
+  end
+
+  def no_cba_enabled_flag
+    organisation.disable_cba_feature!
+    organisation.save!
+  end
+
+  def successfully_renders_template(template)
+    expect(response).to have_http_status(:success)
+    expect(response).to render_template(template)
+  end
+
+  def redirects_with_error_message
+    expect(response).to redirect_to root_path
+    expect(flash[:error]).to match(/not allowed/)
+  end
+end

--- a/spec/requests/certificates/create_spec.rb
+++ b/spec/requests/certificates/create_spec.rb
@@ -1,0 +1,57 @@
+require_relative "./certificate_helpers"
+
+describe "POST /certificates", type: :request do
+  include CertificateHelpers
+
+  let(:certificate_content) { StringIO.new(CertificateHelper.new.root_ca.to_pem) }
+  let(:certificate_file) { Rack::Test::UploadedFile.new(certificate_content, original_filename: "certificate.pem") }
+  let(:certificate) { Certificate.find_by_name("test") }
+
+  let(:organisation) { create(:organisation, :with_cba_enabled) }
+  let(:user) { create(:user, organisations: [organisation]) }
+  before :each do
+    https!
+    sign_in_user(user)
+  end
+
+  def post_certificate
+    post certificates_path, params: { certificate_form: { file: certificate_file, name: "mycert" } }
+  end
+
+  context "valid certificate" do
+    it "successfully creates a certificate" do
+      expect {
+        post_certificate
+      }.to change(Certificate, :count).by(1)
+    end
+    it "redirects to the certificates index page" do
+      post_certificate
+      expect(response).to redirect_to certificates_path
+      expect(flash[:notice]).to match(/New Certificate Added/)
+    end
+    it "redirects without edit location permission" do
+      remove_edit_location_permission
+      post_certificate
+      redirects_with_error_message
+    end
+    it "redirects when the cba flag is disabled" do
+      no_cba_enabled_flag
+      get certificates_path
+      redirects_with_error_message
+    end
+  end
+  context "invalid certificate" do
+    let(:certificate_content) { StringIO.new("invalid certificate") }
+
+    it "does not create a certificate" do
+      expect {
+        post_certificate
+      }.to_not change(Certificate, :count)
+    end
+    it "re-renders the new page" do
+      post_certificate
+      expect(response).to render_template(:new)
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/spec/requests/certificates/delete_spec.rb
+++ b/spec/requests/certificates/delete_spec.rb
@@ -1,0 +1,37 @@
+require_relative "./certificate_helpers"
+
+describe "GET /certificates/edit/:id", type: :request do
+  include CertificateHelpers
+
+  let(:organisation) { create(:organisation, :with_cba_enabled) }
+  let(:user) { create(:user, organisations: [organisation]) }
+  let(:certificate) { create(:certificate, organisation:) }
+  before :each do
+    https!
+    sign_in_user(user)
+  end
+
+  it "deletes a certificate" do
+    certificate
+    expect { delete certificate_path(certificate) }.to change(Certificate, :count).from(1).to(0)
+  end
+  it "redirects to the index certificates page" do
+    delete certificate_path(certificate)
+    expect(response).to redirect_to certificates_path
+  end
+  it "redirects without edit location permission" do
+    remove_edit_location_permission
+    delete certificate_path(certificate)
+    redirects_with_error_message
+  end
+  it "redirects if the user is not a member of the certificates organisation" do
+    user_is_not_a_member_of_the_certificates_organisation
+    delete certificate_path(certificate)
+    redirects_with_error_message
+  end
+  it "redirects when the cba flag is disabled" do
+    no_cba_enabled_flag
+    get certificates_path
+    redirects_with_error_message
+  end
+end

--- a/spec/requests/certificates/edit_spec.rb
+++ b/spec/requests/certificates/edit_spec.rb
@@ -1,0 +1,35 @@
+require_relative "./certificate_helpers"
+
+describe "GET /certificates/edit/:id", type: :request do
+  include CertificateHelpers
+
+  let(:certificate) { create(:certificate, organisation:) }
+
+  let(:organisation) { create(:organisation, :with_cba_enabled) }
+  let(:user) { create(:user, organisations: [organisation]) }
+
+  before :each do
+    https!
+    sign_in_user(user)
+  end
+
+  it "successfully renders the edit certificate template" do
+    get edit_certificate_path(certificate)
+    successfully_renders_template(:edit)
+  end
+  it "redirects without edit location permission" do
+    remove_edit_location_permission
+    get edit_certificate_path(certificate)
+    redirects_with_error_message
+  end
+  it "redirects if the user is not a member of the certificates organisation" do
+    user_is_not_a_member_of_the_certificates_organisation
+    get edit_certificate_path(certificate)
+    redirects_with_error_message
+  end
+  it "redirects when the cba flag is disabled" do
+    no_cba_enabled_flag
+    get edit_certificate_path(certificate)
+    redirects_with_error_message
+  end
+end

--- a/spec/requests/certificates/index_spec.rb
+++ b/spec/requests/certificates/index_spec.rb
@@ -1,0 +1,28 @@
+require_relative "./certificate_helpers"
+
+describe "GET /certificates", type: :request do
+  include CertificateHelpers
+
+  let(:organisation) { create(:organisation, :with_cba_enabled) }
+  let(:user) { create(:user, organisations: [organisation]) }
+
+  before :each do
+    https!
+    sign_in_user(user)
+  end
+
+  it "successfully renders the index template" do
+    get certificates_path
+    successfully_renders_template(:index)
+  end
+  it "redirects without permission" do
+    remove_edit_location_permission
+    get certificates_path
+    redirects_with_error_message
+  end
+  it "redirects when the cba flag is disabled" do
+    no_cba_enabled_flag
+    get certificates_path
+    redirects_with_error_message
+  end
+end

--- a/spec/requests/certificates/new_spec.rb
+++ b/spec/requests/certificates/new_spec.rb
@@ -1,0 +1,28 @@
+require_relative "./certificate_helpers"
+
+describe "GET /certificates/new", type: :request do
+  include CertificateHelpers
+
+  let(:organisation) { create(:organisation, :with_cba_enabled) }
+  let(:user) { create(:user, organisations: [organisation]) }
+
+  before :each do
+    https!
+    sign_in_user(user)
+  end
+
+  it "successfully renders the new certificate template" do
+    get new_certificate_path
+    successfully_renders_template(:new)
+  end
+  it "redirects without edit location permission" do
+    remove_edit_location_permission
+    get new_certificate_path
+    redirects_with_error_message
+  end
+  it "redirects when the cba flag is disabled" do
+    no_cba_enabled_flag
+    get new_certificate_path
+    redirects_with_error_message
+  end
+end

--- a/spec/requests/certificates/show_spec.rb
+++ b/spec/requests/certificates/show_spec.rb
@@ -1,0 +1,32 @@
+require_relative "./certificate_helpers"
+
+describe "GET /certificate/:id", type: :request do
+  include CertificateHelpers
+  let(:certificate) { create(:certificate, organisation:) }
+  let(:organisation) { create(:organisation, :with_cba_enabled) }
+  let(:user) { create(:user, organisations: [organisation]) }
+
+  before :each do
+    https!
+    sign_in_user(user)
+  end
+  it "successfully renders the show certificate template" do
+    get certificate_path(certificate)
+    successfully_renders_template(:show)
+  end
+  it "redirects without edit location permission" do
+    remove_edit_location_permission
+    get certificate_path(certificate)
+    redirects_with_error_message
+  end
+  it "redirects if the user is not a member of the certificates organisation" do
+    user_is_not_a_member_of_the_certificates_organisation
+    get certificate_path(certificate)
+    redirects_with_error_message
+  end
+  it "redirects when the cba flag is disabled" do
+    no_cba_enabled_flag
+    get certificate_path(certificate)
+    redirects_with_error_message
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -731,14 +731,14 @@ postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
 
-postcss@^8.4.28, postcss@^8.4.37:
-  version "8.4.37"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.37.tgz#4505f992cd0c20e03d25f13b31901640b2db731a"
-  integrity sha512-7iB/v/r7Woof0glKLH8b1SPHrsX7uhdO+Geb41QpF/+mWZHU3uxxSlN+UXGVit1PawOYDToO+AbZzhBzWRDwbQ==
+postcss@^8.4.28, postcss@^8.4.35:
+  version "8.4.35"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.35.tgz#60997775689ce09011edf083a549cea44aabe2f7"
+  integrity sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==
   dependencies:
     nanoid "^3.3.7"
     picocolors "^1.0.0"
-    source-map-js "^1.2.0"
+    source-map-js "^1.0.2"
 
 prettier@^3.2.5:
   version "3.2.5"
@@ -839,10 +839,10 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-source-map-js@^1.0.1, source-map-js@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
-  integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
+source-map-js@^1.0.1, source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 spdx-correct@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
### What

Add GUI to add, remove and list certificates for use in EAP-TLS

### Why

Describe why the change was necessary

We want organisations to manage certificates for EAP-TLS. This change adds a GUI to upload and view certificates.

Link to JIRA card (if applicable):
[[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)
](https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=557058%3Add853f03-c9ea-4b86-a72e-1f14eb7f1aaf&selectedIssue=GW-1299)

<img width="1087" alt="image" src="https://github.com/alphagov/govwifi-admin/assets/6050162/04abbeb6-097b-4e63-b086-9e6057b2abd9">

<img width="1277" alt="image" src="https://github.com/alphagov/govwifi-admin/assets/6050162/4b9fd0af-dd29-415d-90aa-12d96c0fd944">

<img width="1076" alt="image" src="https://github.com/alphagov/govwifi-admin/assets/6050162/2adfb185-541c-4b7d-a442-d77aea1e9d4f">
