### PR TITLE
Add another column to superadmin view to show which orgs use CBA

### DIFF
--- a/app/controllers/super_admin/organisations_controller.rb
+++ b/app/controllers/super_admin/organisations_controller.rb
@@ -40,7 +40,7 @@ private
   end
 
   def sortable_columns
-    %w[name created_at locations_count ips_count mous.created_at last_sign_in_at email sign_in_count]
+    %w[name created_at locations_count ips_count mous.created_at last_sign_in_at email sign_in_count certificates_count]
   end
 
   def sort_column

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -39,8 +39,12 @@ class Organisation < ApplicationRecord
   end
 
   scope :sortable_with_child_counts, lambda { |sort_column, sort_direction|
-    select("organisations.*, MAX(mous.created_at) AS latest_mou_created_at, COUNT(DISTINCT(locations.id)) AS locations_count, COUNT(DISTINCT(ips.id)) AS ips_count")
-      .left_joins(:locations).left_joins(:ips).left_joins(:mous)
+    select("organisations.*,
+       MAX(mous.created_at) AS latest_mou_created_at,
+       COUNT(DISTINCT(locations.id)) AS locations_count,
+       COUNT(DISTINCT(ips.id)) AS ips_count,
+       COUNT(DISTINCT(certificates.id)) AS certificates_count")
+      .left_joins(:locations).left_joins(:ips).left_joins(:mous).left_joins(:certificates)
       .group("organisations.id")
       .order(sort_column => sort_direction)
   }

--- a/app/views/super_admin/organisations/index.html.erb
+++ b/app/views/super_admin/organisations/index.html.erb
@@ -34,6 +34,7 @@
       <th class="govuk-table__header govuk-table__header"><%= sort_link "mous.created_at", "MOU Signed" %></th>
       <th class="govuk-table__header govuk-table__header--numeric"><%= sort_link "locations_count", "Locations" %></th>
       <th class="govuk-table__header govuk-table__header--numeric"><%= sort_link "ips_count", "IPs" %></th>
+      <th class="govuk-table__header"><%= sort_link "certificates_count", "Uses EAP-TLS" %></th>
     </tr>
   </thead>
   <tbody class="govuk-table__body" aria-live="polite">
@@ -57,6 +58,9 @@
         </td>
         <td class="govuk-table__cell govuk-table__cell--numeric" scope="row">
           <%= organisation.ips_count %>
+        </td>
+        <td class="govuk-table__cell govuk-table__cell">
+          <%= organisation.certificates.empty? ? "no" : "yes" %>
         </td>
       </tr>
     <% end %>

--- a/spec/features/super_admin/organisations/sort_organisation_list_spec.rb
+++ b/spec/features/super_admin/organisations/sort_organisation_list_spec.rb
@@ -3,9 +3,10 @@ describe "Sorting the organisations list", type: :feature do
     let!(:super_admin) { create(:user, :super_admin) }
 
     before do
-      create(:organisation, name: "Gov Org 1", created_at: "10 Dec 2015")
-      create(:organisation, name: "Gov Org 2", created_at: "10 Dec 2013")
-      create(:organisation, name: "Gov Org 3", created_at: "10 Feb 2014")
+      create(:organisation, :with_cba_enabled, name: "Gov Org 1", created_at: "10 Dec 2015")
+      create(:organisation, :with_cba_enabled, name: "Gov Org 2", created_at: "10 Dec 2013")
+      create(:organisation, :with_cba_enabled, name: "Gov Org 3", created_at: "10 Feb 2014")
+      create(:certificate, organisation: Organisation.find_by_name("Gov Org 2"))
 
       sign_in_user super_admin
       visit super_admin_organisations_path
@@ -42,6 +43,19 @@ describe "Sorting the organisations list", type: :feature do
         2.times { click_link "Name" }
 
         expect(page.body).to match(/Gov Org 1.*Gov Org 2.*Gov Org 3/m)
+      end
+
+      context "when using eap-tls" do
+        it "sorts the list from yes to no after EAP-TLS is clicked the first time" do
+          click_link "Uses EAP-TLS"
+
+          expect(page.body).to match(/Gov Org 2.*Gov Org 1.*Gov Org 3/m)
+        end
+        it "sorts the list from no to yes after EAP-TLS is clicked twice" do
+          2.times { click_link "Uses EAP-TLS" }
+
+          expect(page.body).to match(/Gov Org 1.*Gov Org 3.*Gov Org 2/m)
+        end
       end
     end
 

--- a/spec/features/super_admin/organisations/view_organisation_list_spec.rb
+++ b/spec/features/super_admin/organisations/view_organisation_list_spec.rb
@@ -27,10 +27,11 @@ describe "View a list of signed up organisations", type: :feature do
     end
 
     context "when one organisation exists" do
-      let(:org) { create(:organisation, created_at: "1 Feb 2014") }
+      let(:cba_enabled) { true }
+      let(:organisation) { create(:organisation, created_at: "1 Feb 2014", cba_enabled:) }
 
       before do
-        create_list(:location, 2, organisation: org)
+        create_list(:location, 2, organisation:)
         create_list(:ip, 3, location: Location.first)
         visit super_admin_organisations_path
       end
@@ -65,6 +66,22 @@ describe "View a list of signed up organisations", type: :feature do
 
       it "shows a link to download service emails as CSV" do
         expect(page).to have_link("Download all service emails in CSV format")
+      end
+
+      describe "no certificates" do
+        it "shows the organisation does not use EAP-TLS" do
+          within("table tbody tr td:nth-child(6)") do
+            expect(page).to have_content("no")
+          end
+        end
+      end
+      describe "a certificate is present" do
+        let(:organisation) { create(:organisation, cba_enabled:).tap { |org| create(:certificate, organisation: org) } }
+        it "shows the organisation uses EAP-TLS" do
+          within("table tbody tr td:nth-child(6)") do
+            expect(page).to have_content("yes")
+          end
+        end
       end
     end
 


### PR DESCRIPTION
### What
Add another column to superadmin view to show which orgs use CBA

### Why

So that it is easy to see which organisations actively use CBA

<img width="766" alt="image" src="https://github.com/alphagov/govwifi-admin/assets/6050162/196461b4-7d8c-42f1-a15a-91c1c33b9edb">

Link to JIRA card (if applicable):
[[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)
](https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=557058%3Add853f03-c9ea-4b86-a72e-1f14eb7f1aaf&selectedIssue=GW-1607)