### PR TITLE
Gw 816 make some accessibility changes to the admin tool

### DIFF
--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -10,29 +10,29 @@ class MembershipsController < ApplicationController
         value: "administrator",
         text: "Administrator",
         hint: <<~HINT.html_safe,
-          View locations and IPs, team members, and logs<br>
-          Manage locations and IPs<br>
-          Add or remove team members<br>
-          View, add and remove certificates
+          <span>View locations and IPs, team members, and logs</span><br>
+          <span>Manage locations and IPs</span><br>
+          <span>Add or remove team members</span><br>
+          <span>View, add and remove certificates</span>
         HINT
       ),
       OpenStruct.new(
         value: "manage_locations",
         text: "Manage Locations",
         hint: <<~HINT.html_safe,
-          View locations and IPs, team members, and logs<br>
-          Manage locations and IPs<br>
-          Cannot add or remove team members<br>
-          View, add and remove certificates
+          <span>View locations and IPs, team members, and logs</span><br>
+          <span>Manage locations and IPs</span><br>
+          <span>Cannot add or remove team members</span><br>
+          <span>View, add and remove certificates</span>
         HINT
       ),
       OpenStruct.new(
         value: "view_only",
         text: "View only",
         hint: <<~HINT.html_safe,
-          View locations and IPs, team members, and logs<br>
-          Cannot manage locations and IPs<br>
-          Cannot add or remove team members
+          <span>View locations and IPs, team members, and logs</span><br>
+          <span>Cannot manage locations and IPs</span><br>
+          <span>Cannot add or remove team members</span>
         HINT
       ),
     ]

--- a/app/views/current_organisation/edit.html.erb
+++ b/app/views/current_organisation/edit.html.erb
@@ -5,7 +5,7 @@
       <% current_user.organisations.each do | organisation | %>
         <li>
           <%= button_to organisation.name, change_organisation_path(organisation_id: organisation.id),
-                        method: :patch, class: "govuk-heading-m button-as-link govuk-!-margin-bottom-4" %>
+                        method: :patch, class: "govuk-heading-m button-as-link govuk-!-margin-bottom-4", aria: { label: "Switch to #{organisation.name}" } %>
         </li>
       <% end %>
     </ul>

--- a/app/views/locations/add_ips.html.erb
+++ b/app/views/locations/add_ips.html.erb
@@ -2,26 +2,31 @@
   <div class="govuk-grid-column-three-quarters">
     <%= link_to "Back to locations", ips_path, class: "govuk-back-link" %>
     <%= form_with model: @ips_form, url: location_update_ips_path(location_id: @ips_form.location_id), method: :patch do |form| %>
-    <%= form.govuk_error_summary %>
-    <span class="govuk-caption-xl govuk-!-font-weight-bold">
-      <%= @ips_form.address %>, <%= @ips_form.postcode %>
-    </span>
-    <h1 class="govuk-heading-l">
-      Add IP addresses
-    </h1>
-
-    <p class="govuk-body">
-      Add up to 5 IPv4 addresses.
-    </p>
-
-    <div class="govuk-inset-text govuk-!-padding-top-0 govuk-!-padding-bottom-0 govuk-!-margin-top-4 govuk-!-margin-bottom-4">
+      <%= form.govuk_error_summary %>
+      <span class="govuk-caption-xl govuk-!-font-weight-bold">
+        <%= @ips_form.address %>, <%= @ips_form.postcode %>
+      </span>
+      <header>
+        <h1 class="govuk-heading-l">
+          Add IP addresses
+        </h1>
+      </header>
       <p class="govuk-body">
-        If your authenticators have dynamic IP addresses, use firewall NAT rules so your requests come from consistent IP addresses.
+        Add up to 5 IPv4 addresses.
       </p>
-    </div>
+
+      <div class="govuk-inset-text govuk-!-padding-top-0 govuk-!-padding-bottom-0 govuk-!-margin-top-4 govuk-!-margin-bottom-4">
+        <p class="govuk-body">
+          If your authenticators have dynamic IP addresses, use firewall NAT rules so your requests come from consistent IP addresses.
+        </p>
+      </div>
+
+      <p id="ip_address_hint" class="govuk-hint">
+        Enter the IPv4 address in the format xxx.xxx.xxx.xxx.
+      </p>
 
       <% LocationIpsForm::IP_FIELDS.each.with_index(1) do |field, index| %>
-          <%= form.govuk_text_field field, label: -> { "IP address #{index}" } %>
+        <%= form.govuk_text_field field, label: -> { "IP address #{index}" }, aria: { describedby: "ip_address_hint" } %>
       <% end %>
       <%= form.govuk_submit "Add IP addresses" %>
     <% end %>

--- a/app/views/locations/bulk_upload.html.erb
+++ b/app/views/locations/bulk_upload.html.erb
@@ -2,7 +2,9 @@
   <div class="govuk-grid-column-two-quarters">
     <%= form_with url: upload_locations_csv_path, model: @upload_form, multipart: true  do |form| %>
       <%= form.govuk_error_summary %>
-      <h1 class="govuk-heading-l">Upload multiple locations and IPs</h1>
+      <header>
+        <h1 class="govuk-heading-l">Upload multiple locations and IPs</h1>
+      </header>
       <p class="govuk-body">Follow these steps to upload multiple addresses and IPs:</p>
 
       <ol class="govuk-list govuk-list--number">
@@ -19,7 +21,10 @@
 
       <br>
 
-      <%= form.govuk_file_field :upload_file, label: { text: "Upload completed template" } %>
+      <div class="govuk-form-group">
+        <%= form.govuk_file_field :upload_file, label: { text: "Upload completed template" }, hint: { text: "The file should be in CSV format and follow the provided template." }, aria: { describedby: "upload_file_hint" } %>
+      </div>
+
       <%= form.govuk_submit "Upload" %>
     <% end %>
   </div>

--- a/app/views/shared/_manage_ips.html.erb
+++ b/app/views/shared/_manage_ips.html.erb
@@ -73,7 +73,9 @@
             <ul class="plain-list govuk-!-margin-0">
               <% if ip.available? && !ip.unused? && !ip.inactive? %>
                 <li>
-                  <%= link_to "View logs", logs_path(log_search_form: { ip: ip.address, filter_option: LogSearchForm::IP_FILTER_OPTION }), class: "govuk-link" %>
+                  <%= link_to logs_path(log_search_form: { ip: ip.address, filter_option: LogSearchForm::IP_FILTER_OPTION }), class: "govuk-link" do %>
+                    View logs <span class='govuk-visually-hidden'>for IP address <%= ip.address %> at <%= location.full_address %></span>
+                  <% end %>
                 </li>
               <% end %>
               <% if show_ip_controls && current_user.can_manage_locations?(current_organisation) %>

--- a/app/views/super_admin/wifi_admin_searches/show.html.erb
+++ b/app/views/super_admin/wifi_admin_searches/show.html.erb
@@ -7,9 +7,14 @@
 <%= form_with model: @form, url: super_admin_wifi_admin_search_path do |f| %>
   <%= f.govuk_error_summary %>
   <div class='govuk-grid-row'>
-    <h1 class='govuk-heading-l govuk-grid-column-full'>Search for admin details</h1>
+    <header class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l">Search for admin details</h1>
+    </header>
+
     <div class='govuk-grid-column-two-thirds'>
-      <%= f.govuk_text_field :search_term, width: 20, label: { text: "Admin name or email address" } %>
+      <div class="govuk-form-group">
+        <%= f.govuk_text_field :search_term, width: 20, label: { text: "Admin name or email address" }, hint: { text: "Enter the name or email address of the admin you want to search for." }, aria: { describedby: "search_term_hint" } %>
+      </div>
       <%= f.govuk_submit "Find admin details" %>
       <% if @form_valid %>
         <div class="govuk-body">

--- a/app/views/super_admin/wifi_user_searches/show.html.erb
+++ b/app/views/super_admin/wifi_user_searches/show.html.erb
@@ -2,9 +2,13 @@
 <%= form_with model: @form, url: super_admin_wifi_user_search_path do |f| %>
   <%= f.govuk_error_summary %>
   <div class='govuk-grid-row'>
-    <h1 class='govuk-heading-l govuk-grid-column-full'>Search for user details</h1>
+    <header class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l">Search for user details</h1>
+    </header>
     <div class='govuk-grid-column-two-thirds'>
-      <%= f.govuk_text_field :search_term, width: 20, label: { text: "Username, email address or phone number" } %>
+      <div class="govuk-form-group">
+        <%= f.govuk_text_field :search_term, width: 20, label: { text: "Username, email address or phone number" }, hint: { text: "Enter the username, email address, or phone number of the user you want to search for." }, aria: { describedby: "search_term_hint" } %>
+      </div>
       <%= f.govuk_submit "Find user details" %>
       <% if @form_valid %>
         <div class="govuk-body">

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -15,7 +15,7 @@
         <% end %>
       </h1>
 
-      <%= f.govuk_email_field :email, label: { text: "Email address" } %>
+      <%= f.govuk_email_field :email, label: { text: "Email address" }, hint: { text: "Enter the email address of the person you want to invite." } %>
 
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="sign-in-hint">
@@ -37,9 +37,9 @@
                     class: "govuk-label govuk-radios__label govuk-!-font-weight-bold",
                   ) %>
               <div id="permission_level_administrator_hint" class="govuk-hint govuk-radios__hint">
-                View locations and IPs, team members, and logs<br>
-                Manage locations and IPs<br>
-                Add or remove team members
+                <span>View locations and IPs, team members, and logs</span><br>
+                <span>Manage locations and IPs</span><br>
+                <span>Add or remove team members</span>
               </div>
             </div>
             <div class="govuk-radios__item">
@@ -56,9 +56,9 @@
                     class: "govuk-label govuk-radios__label govuk-!-font-weight-bold",
                   ) %>
               <div id="permission_level_manage_locations_hint" class="govuk-hint govuk-radios__hint">
-                View locations and IPs, team members, and logs<br>
-                Manage locations and IPs<br>
-                Cannot add or remove team members
+                <span>View locations and IPs, team members, and logs</span><br>
+                <span>Manage locations and IPs</span><br>
+                <span>Cannot add or remove team members</span>
               </div>
             </div>
             <div class="govuk-radios__item">
@@ -75,9 +75,9 @@
                     class: "govuk-label govuk-radios__label govuk-!-font-weight-bold",
                   ) %>
               <div id="permission_level_view_only_hint" class="govuk-hint govuk-radios__hint">
-                View locations and IPs, team members, and logs<br>
-                Cannot manage locations and IPs<br>
-                Cannot add or remove team members
+                <span>View locations and IPs, team members, and logs</span><br>
+                <span>Cannot manage locations and IPs</span><br>
+                <span>Cannot add or remove team members</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### What

There are some accessibility things we must improve on our website

Page titles aren’t all correct - including upload multiple locations, switch organisation, add IP address, admin details (super admin), user details (super admin)

Change admin permissions (both invite new and edit) - with a screen reader, the 3 hint text lines below each permission line get merged together. We could add <span> to break it up, add a full stop to break them into 3 sentences or maybe something else…

Give context to ‘view logs' link on /IPS page - the ‘view logs’ link doesn’t have any context as a screen reader for which logs I could look at. If you look at the ‘remove’ link it does. We just need to do similar for view logs. Otherwise as a screen reader user, I can’t tell what the view logs is for. Everything else on the page appears to do this fully.

### Why

WCAG updates from 2.1 to 2.2

Link to JIRA card (if applicable):
https://technologyprogramme.atlassian.net/browse/GW-816
