### PR TITLE
avoid repeated queries in certificate exporter

### DIFF
--- a/lib/use_cases/certificate_exporter.rb
+++ b/lib/use_cases/certificate_exporter.rb
@@ -5,7 +5,7 @@ module UseCases
     def self.export
       zip_output = StringIO.new
       io = Zip::OutputStream.new(zip_output, true)
-      Certificate.all.reject(&:has_child?).each do |certificate|
+      Certificate.includes(:organisation).all.reject(&:has_child?).each do |certificate|
         io.put_next_entry("#{certificate.organisation.name}_#{certificate.name}.pem")
         io.write certificate.content
       end


### PR DESCRIPTION
avoid repeated queries in certificate exporter