### PR TITLE
Fix filtering logging by EAP-TLS and MSCHAP

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -8,6 +8,6 @@ class Session < ReadReplicaBase
   }
 
   def eap_tls?
-    [cert_serial, cert_issuer, cert_subject, cert_name].any?(&:present?)
+    username.nil?
   end
 end

--- a/lib/gateways/sessions.rb
+++ b/lib/gateways/sessions.rb
@@ -17,9 +17,9 @@ module Gateways
       results = results.where(success:) if success.present?
       if authentication_method.present?
         results = if authentication_method == "true"
-                    results.where.not(cert_name: nil, cert_serial: nil, cert_issuer: nil, cert_subject: nil)
+                    results.where(username: nil)
                   else
-                    results.where(cert_name: nil, cert_serial: nil, cert_issuer: nil, cert_subject: nil)
+                    results.where.not(username: nil)
                   end
       end
       results

--- a/spec/features/logging/filter_logs_spec.rb
+++ b/spec/features/logging/filter_logs_spec.rb
@@ -12,7 +12,7 @@ describe "Filter CBA requests for an IP", type: :feature do
            ap:,
            mac:,
            start: time,
-           username:,
+           username: nil,
            siteIP: ip.address,
            success: true,
            cert_name: "test",


### PR DESCRIPTION
The bug was caused by the cert_* attributes sometimes being an empty string instead of NULL. An easier and more reliable method to distinguish between EAP-TLS and MSCHAP is by selecting on the username being NULL.

Link to JIRA card (if applicable):
https://technologyprogramme.atlassian.net/browse/GW-1764
