### PR TITLE
Rename CBA button

### DIFF
--- a/app/views/super_admin/organisations/_cba_form.html.erb
+++ b/app/views/super_admin/organisations/_cba_form.html.erb
@@ -16,6 +16,6 @@
 <div id="cba-form">
   <%= form_with(model: @organisation, url: toggle_cba_feature_super_admin_organisation_path(@organisation), method: :patch) do |form| %>
     <%= form.hidden_field :cba_enabled, value: !@organisation.cba_enabled %>
-    <%= form.submit(@organisation.cba_enabled ? "Turn off CBA logs" : "Turn on CBA logs", class: @organisation.cba_enabled ? "govuk-button govuk-button--secondary" : "govuk-button") %>
+    <%= form.submit(@organisation.cba_enabled ? "Disable CBA" : "Enable CBA", class: @organisation.cba_enabled ? "govuk-button govuk-button--secondary" : "govuk-button") %>
   <% end %>
 </div>


### PR DESCRIPTION
The button to enable/disable CBA for an organisation used to be used to enable/disable logging for CBA only, but is now used to enable all CBA functionality and so the button is renamed accordingly

<img width="755" alt="image" src="https://github.com/alphagov/govwifi-admin/assets/6050162/0ebf7092-c564-4af8-969e-d9da1dc4024c">
<img width="786" alt="image" src="https://github.com/alphagov/govwifi-admin/assets/6050162/ed3e628f-dfd7-4f41-8d9d-b448b56cfd50">
