### PR TITLE
set up sms gateway for notify

### DIFF
--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -92,6 +92,6 @@ class AuthenticationMailer < ::Devise::Mailer
       template_id: GOV_NOTIFY_CONFIG["notify_user_account_removed_sms"]["template_id"],
       reference: "notify_user_account_removed",
     }
-    Services.email_gateway.send_email(opts)
+    Services.sms_gateway.send_sms(opts)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ require "action_view/railtie"
 require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 require_relative "../lib/gateways/email_gateway"
+require_relative "../lib/gateways/sms_gateway"
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
@@ -48,5 +49,6 @@ module GovwifiAdmin
     config.active_model.i18n_customize_full_message = true
 
     config.email_gateway = Gateways::EmailGateway
+    config.sms_gateway = Gateways::SmsGateway
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,8 +1,10 @@
 require "action_mailer/railtie"
 require_relative "../../lib/gateways/email_gateway"
+require_relative "../../lib/gateways/sms_gateway"
 
 Rails.application.configure do
   config.email_gateway = Gateways::EmailGatewayStub
+  config.sms_gateway = Gateways::SmsGatewayStub
   config.hosts.clear
   Bullet.enable = true
   Bullet.unused_eager_loading_enable = true

--- a/lib/gateways/sms_gateway.rb
+++ b/lib/gateways/sms_gateway.rb
@@ -1,0 +1,22 @@
+require "notifications/client"
+
+module Gateways
+  class SmsGateway
+    def send_sms(opts)
+      client = Notifications::Client.new(ENV.fetch("NOTIFY_API_KEY"))
+      client.send_sms(
+        phone_number: opts[:contact],
+        template_id: opts[:template_id],
+        personalisation: opts[:locals],
+      )
+    end
+  end
+
+  class SmsGatewayStub
+    def send_sms(opts)
+      puts "Stub sms to: #{opts[:sms]}"
+      puts "...Notifiy TemplateId: #{opts[:template_id]}"
+      puts "...Personalisation: #{opts[:locals]}"
+    end
+  end
+end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -3,6 +3,10 @@ module Services
     @email_gateway ||= Rails.application.config.email_gateway.new
   end
 
+  def self.sms_gateway
+    @sms_gateway ||= Rails.application.config.sms_gateway.new
+  end
+
   def self.elasticsearch_client
     @elasticsearch_client ||= Elasticsearch::Client.new host: ENV["ELASTICSEARCH_ENDPOINT"]
   end

--- a/spec/features/super_admin/wifi_user_searches_spec.rb
+++ b/spec/features/super_admin/wifi_user_searches_spec.rb
@@ -1,7 +1,9 @@
 describe "Wifi User Searches", type: :feature do
   include EmailHelpers
+  include SmsHelpers
   let(:user) { create(:user, :super_admin, name: "super_admin") }
   let(:email_gateway) { spy }
+  let(:sms_gateway) { spy }
   let(:search_term) { username }
 
   before do
@@ -65,7 +67,7 @@ describe "Wifi User Searches", type: :feature do
       before do
         fill_in "Username, email address or phone number", with: search_term
         click_on "Find user details"
-        allow(Services).to receive(:email_gateway).and_return(email_gateway)
+        allow(Services).to receive(:sms_gateway).and_return(sms_gateway)
         click_on "Remove user"
       end
 

--- a/spec/features/support/email_helpers.rb
+++ b/spec/features/support/email_helpers.rb
@@ -72,9 +72,4 @@ module EmailHelpers
     expect(Services.email_gateway).to have_received(:send_email)
       .with(include(template_id: GOV_NOTIFY_CONFIG["notify_user_account_removed"]["template_id"])).once
   end
-
-  def it_sent_a_notify_user_sms_once
-    expect(Services.email_gateway).to have_received(:send_email)
-      .with(include(template_id: GOV_NOTIFY_CONFIG["notify_user_account_removed_sms"]["template_id"])).once
-  end
 end

--- a/spec/features/support/sms_helpers.rb
+++ b/spec/features/support/sms_helpers.rb
@@ -1,0 +1,6 @@
+module SmsHelpers
+  def it_sent_a_notify_user_sms_once
+    expect(Services.sms_gateway).to have_received(:send_sms)
+      .with(include(template_id: GOV_NOTIFY_CONFIG["notify_user_account_removed_sms"]["template_id"])).once
+  end
+end

--- a/spec/gateways/sms_gateway_spec.rb
+++ b/spec/gateways/sms_gateway_spec.rb
@@ -1,0 +1,38 @@
+require_relative "../../lib/gateways/sms_gateway"
+require "support/notifications_service"
+
+describe Gateways::SmsGateway do
+  subject(:sms_gateway) { described_class.new }
+
+  let(:notification) { instance_spy(Notifications::Client, send_sms: nil) }
+
+  before do
+    ENV["NOTIFY_API_KEY"] = "dummy_key-00000000-0000-0000-0000-000000000000"
+    allow(Notifications::Client).to receive(:new).and_return(notification)
+  end
+
+  context "when sending a sms" do
+    let(:phone_number) { "+7800000005" }
+    let(:url) { "http://example.com/confirm?token=123" }
+    let(:template_id) { 1 }
+    let(:notifications_payload) do
+      {
+        phone_number:,
+        template_id:,
+        personalisation: { url: },
+      }
+    end
+
+    before do
+      sms_gateway.send_sms(
+        contact: phone_number,
+        template_id:,
+        locals: { url: },
+      )
+    end
+
+    it "calls the Notify client" do
+      expect(notification).to have_received(:send_sms).with(notifications_payload)
+    end
+  end
+end

--- a/spec/support/notifications_service.rb
+++ b/spec/support/notifications_service.rb
@@ -9,5 +9,6 @@ shared_context "when using the notifications service" do
 
     allow(Notifications::Client).to receive(:new).and_return(notification_instance)
     allow(notification_instance).to receive(:send_email).and_return({})
+    allow(notification_instance).to receive(:send_sms).and_return({})
   end
 end


### PR DESCRIPTION
### What

Set up a notify sms gateway so that we are able to send sms messages to users

### Why

We need to notify wifi users when their account has been removed, currently we only have and email gateway set up.

Link to JIRA card (if applicable):
[[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)](https://technologyprogramme.atlassian.net/browse/GW-1776)
