### PR TITLE
Use DEPLOY_ENV instead of APP_ENV to indicate the platform to deploy on

### DIFF
--- a/lib/deploy.rb
+++ b/lib/deploy.rb
@@ -2,14 +2,14 @@
 
 module Deploy
   def self.production?
-    ENV["APP_ENV"] == "production"
+    ENV["DEPLOY_ENV"] == "production"
   end
 
   def self.env
-    ENV["APP_ENV"] || "production"
+    ENV["DEPLOY_ENV"] || "production"
   end
 
   def self.env=(env)
-    ENV["APP_ENV"] = env
+    ENV["DEPLOY_ENV"] = env
   end
 end


### PR DESCRIPTION
APP_ENV overrides RAILS_ENV and is therefore a bad choice for this.

