### PR TITLE
Fix so that the portal can run in development mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER_COMPOSE = docker-compose -f docker-compose.yml
+DOCKER_COMPOSE = docker compose -f docker-compose.yml
 BUNDLE_FLAGS=
 
 ifdef DEPLOYMENT

--- a/lib/gateways/development_notify_gateway.rb
+++ b/lib/gateways/development_notify_gateway.rb
@@ -18,7 +18,8 @@ module Gateways
     end
 
     def get_all_templates
-      NotifyTemplates::TEMPLATES.map { |name| OpenStruct.new(name:, id: "#{name}_template") }
+      OpenStruct.new(collection:
+                       NotifyTemplates::TEMPLATES.map { |name| OpenStruct.new(name:, id: "#{name}_template") })
     end
   end
 end


### PR DESCRIPTION
### What
Listing all templates in Notify requires an extra call to
'collection' in order to get all templates. This adds that so
that the portal no longer breaks when running in development mode

Macs no longer support 'docker-compose' and we instead have to use 'docker compose'
