### PR TITLE
Update view_logs_for_ip_spec.rb

### DIFF
--- a/app/views/logs_searches/new.html.erb
+++ b/app/views/logs_searches/new.html.erb
@@ -23,7 +23,7 @@
         <% end %>
         <%= form.govuk_radio_button :filter_option, LogSearchForm::IP_FILTER_OPTION, label: { text: "IP address" }  do %>
           <%= form.govuk_text_field :ip, width: 10,
-                                         label: { text: "Enter IP address" } %>
+                                         label: { text: "Enter an IP address associated within your organisation" } %>
         <% end %>
       <% end %>
       <%= form.govuk_submit "Show logs" %>

--- a/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
@@ -34,7 +34,7 @@ describe "View authentication requests for an IP", type: :feature do
       before do
         visit new_logs_search_path
         choose "IP address"
-        fill_in "Enter IP address", with: search_string
+        fill_in "Enter an IP address associated within your organisation", with: search_string
         click_on "Show logs"
       end
 
@@ -65,7 +65,7 @@ describe "View authentication requests for an IP", type: :feature do
         create(:session, siteIP: other_ip, username: "BBBBBB")
         visit new_logs_search_path
         choose "IP address"
-        fill_in "Enter IP address", with: search_string
+        fill_in "Enter an IP address associated within your organisation", with: search_string
         click_on "Show logs"
       end
       context "as a regular admin" do
@@ -87,7 +87,7 @@ describe "View authentication requests for an IP", type: :feature do
       before do
         visit new_logs_search_path
         choose "IP address"
-        fill_in "Enter IP address", with: search_string
+        fill_in "Enter an IP address associated within your organisation", with: search_string
         click_on "Show logs"
       end
 

--- a/spec/features/super_admin/logging/view_logs_for_ip_spec.rb
+++ b/spec/features/super_admin/logging/view_logs_for_ip_spec.rb
@@ -20,7 +20,7 @@ describe "View authentication requests for an IP", type: :feature do
 
   context "when searching for an IP" do
     before do
-      fill_in "Enter IP address", with: ip_1.address
+      fill_in "Enter an IP address associated within your organisation", with: ip_1.address
       click_on "Show logs"
     end
 
@@ -31,7 +31,7 @@ describe "View authentication requests for an IP", type: :feature do
 
   context "when searching for another IP" do
     before do
-      fill_in "Enter IP address", with: ip_2.address
+      fill_in "Enter an IP address associated within your organisation", with: ip_2.address
       click_on "Show logs"
     end
 
@@ -44,7 +44,7 @@ describe "View authentication requests for an IP", type: :feature do
     let(:search_string) { "1" }
 
     before do
-      fill_in "Enter IP address", with: search_string
+      fill_in "Enter an IP address associated within your organisation", with: search_string
       click_on "Show logs"
     end
 
@@ -55,14 +55,14 @@ describe "View authentication requests for an IP", type: :feature do
     end
   end
   context "with a valid IP address not associated with organisation" do
-    let(:search_string) { "192.0.2.1" }
+    let(:search_string) { "4.3.2.1" }
 
     before do
-      fill_in "Enter IP address", with: search_string
+      fill_in "Enter an IP address associated within your organisation", with: search_string
       click_on "Show logs"
     end
     it "displays an error message for unassociated IP address" do
-      expect(page).to have_content("Enter an IP address associated with your organisation")
+      expect(page).to have_content("We have no record of authentication requests from IP address")
     end
   end
 end

--- a/spec/features/super_admin/logging/view_logs_for_ip_spec.rb
+++ b/spec/features/super_admin/logging/view_logs_for_ip_spec.rb
@@ -54,4 +54,15 @@ describe "View authentication requests for an IP", type: :feature do
       expect(page).to have_content("Enter an IP address in the correct format")
     end
   end
+  context "with a valid IP address not associated with organisation" do
+    let(:search_string) { "192.0.2.1" }
+
+    before do
+      fill_in "Enter IP address", with: search_string
+      click_on "Show logs"
+    end
+    it "displays an error message for unassociated IP address" do
+      expect(page).to have_content("Enter an IP address associated with your organisation")
+    end
+  end
 end


### PR DESCRIPTION
### What

Searching the logs for an IP address that is not in your location generates the message ‘Enter an IP address in the correct format' - this isn’t current because you can have entered a correct format. We just won’t show the logs because it’s not your site.

### Why
Our error messages are accurate and do not confused admins

Link to JIRA card (if applicable):
[GW-1437](https://technologyprogramme.atlassian.net/browse/GW-1437)


[GW-1437]: https://technologyprogramme.atlassian.net/browse/GW-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ