### PR TITLE
Rename remove user templates

### DIFF
--- a/app/controllers/super_admin/wifi_user_searches_controller.rb
+++ b/app/controllers/super_admin/wifi_user_searches_controller.rb
@@ -37,11 +37,11 @@ private
 
   def notify_user
     if @wifi_user.mobile?
-      GovWifiMailer.notify_user_account_removed_sms(
+      GovWifiMailer.user_account_removed_sms(
         @wifi_user.contact,
       ).deliver_now
     else
-      GovWifiMailer.notify_user_account_removed(
+      GovWifiMailer.user_account_removed_email(
         @wifi_user.contact,
       ).deliver_now
     end

--- a/app/mailers/gov_wifi_mailer.rb
+++ b/app/mailers/gov_wifi_mailer.rb
@@ -75,22 +75,22 @@ class GovWifiMailer < ::Devise::Mailer
     Services.notify_gateway.send_email(opts)
   end
 
-  def notify_user_account_removed(email_address)
+  def user_account_removed_email(email_address)
     opts = {
       email_address:,
       personalisation: {},
-      template_id: NotifyTemplates.template("notify_user_account_removed"),
-      reference: "notify_user_account_removed",
+      template_id: NotifyTemplates.template("user_account_removed_email"),
+      reference: "user_account_removed_email",
     }
     Services.notify_gateway.send_email(opts)
   end
 
-  def notify_user_account_removed_sms(phone_number)
+  def user_account_removed_sms(phone_number)
     opts = {
       phone_number:,
       personalisation: {},
-      template_id: NotifyTemplates.template("notify_user_account_removed_sms"),
-      reference: "notify_user_account_removed",
+      template_id: NotifyTemplates.template("user_account_removed_sms"),
+      reference: "user_account_removed_email",
     }
     Services.notify_gateway.send_sms(opts)
   end

--- a/lib/notify_templates.rb
+++ b/lib/notify_templates.rb
@@ -8,8 +8,8 @@ class NotifyTemplates
     nominate_user_to_sign_mou
     thank_you_for_signing_the_mou
     first_ip_survey
-    notify_user_account_removed
-    notify_user_account_removed_sms
+    user_account_removed_email
+    user_account_removed_sms
   ].freeze
 
   def self.template_hash

--- a/spec/features/support/email_helpers.rb
+++ b/spec/features/support/email_helpers.rb
@@ -40,7 +40,7 @@ module EmailHelpers
   end
 
   def it_sent_a_notify_user_email_once
-    expect(email_count("notify_user_account_removed_template")).to eq(1)
+    expect(email_count("user_account_removed_email_template")).to eq(1)
   end
 
   def email_count(template_name)

--- a/spec/features/support/sms_helpers.rb
+++ b/spec/features/support/sms_helpers.rb
@@ -1,5 +1,5 @@
 module SmsHelpers
   def it_sent_a_notify_user_sms_once
-    expect(Services.notify_gateway.count_sms_with_template("notify_user_account_removed_sms_template")).to eq(1)
+    expect(Services.notify_gateway.count_sms_with_template("user_account_removed_sms_template")).to eq(1)
   end
 end


### PR DESCRIPTION
The templates we use to tell users their credentials have been removed are the same in the admin portal and the user signup api.

However they were named differently in both. This change ensures they are the same in both repositories
