### PR TITLE
Add template check to healthcheck

### DIFF
--- a/lib/notify_templates.rb
+++ b/lib/notify_templates.rb
@@ -24,4 +24,10 @@ class NotifyTemplates
   def self.template(name)
     template_hash.fetch(name.is_a?(Symbol) ? name.to_s : name)
   end
+
+  def self.verify_templates
+    names = Services.notify_gateway.get_all_templates.collection.map(&:name)
+    differences = NotifyTemplates::TEMPLATES - names
+    raise "Some templates have not been defined in Notify: #{differences.join(', ')}" unless differences.empty?
+  end
 end

--- a/lib/tasks/verify_notify_templates.rake
+++ b/lib/tasks/verify_notify_templates.rake
@@ -1,9 +1,8 @@
 require_relative "../../lib/notify_templates"
 desc "Verify if the required templates are present in Notify. Use the notify key as an argument"
 
-task :verify_notify_templates, [:key] => :environment do |_, args|
-  client = Notifications::Client.new(args.key)
-  names = client.get_all_templates.collection.map(&:name)
-  differences = NotifyTemplates::TEMPLATES - names
-  abort "Some templates have not been defined in Notify: #{differences.join(', ')}" unless differences.empty?
+task verify_notify_templates: :environment do
+  NotifyTemplates.verify_templates
+rescue StandardError => e
+  abort e.message
 end

--- a/spec/features/ips/first_ip_survey_spec.rb
+++ b/spec/features/ips/first_ip_survey_spec.rb
@@ -4,10 +4,8 @@ describe "Sending a survey when adding the first IP to an organisation", type: :
   let(:organisation) { user.organisations.first }
   let(:location) { create(:location, organisation:) }
   let!(:another_administrator) { create(:user, organisations: [user.organisations.first]) } # a minimium of two administrators are now required to add IP addresses
-  let(:notify_gateway) { spy }
+  let(:notify_gateway) { Services.notify_gateway }
   before do
-    allow(Services).to receive(:notify_gateway).and_return(notify_gateway)
-    allow(notify_gateway).to receive(:send_email)
     sign_in_user user
     visit location_add_ips_path(location_id: location.id)
     fill_in "location_ips_form[ip_1]", with: "1.1.1.1"
@@ -16,7 +14,7 @@ describe "Sending a survey when adding the first IP to an organisation", type: :
   describe "The user has had a survey sent already" do
     it "does not send a survey" do
       click_on "Add IP addresses"
-      expect(notify_gateway).to_not have_received(:send_email)
+      expect(notify_gateway.count_all_emails).to eq(0)
     end
   end
 
@@ -24,10 +22,10 @@ describe "Sending a survey when adding the first IP to an organisation", type: :
     let(:sent_first_ip_survey) { false }
     it "sends a survey" do
       click_on "Add IP addresses"
-      expect(notify_gateway).to have_received(:send_email).with({ email_address: user.email,
-                                                                  personalisation: {},
-                                                                  template_id: "first_ip_survey_template",
-                                                                  reference: "first_ip_survey" })
+      expect(notify_gateway.last_email_parameters).to eq({ email_address: user.email,
+                                                           personalisation: {},
+                                                           template_id: "first_ip_survey_template",
+                                                           reference: "first_ip_survey" })
     end
     it "sets the sent_first_ip_survey flag" do
       expect {
@@ -42,7 +40,7 @@ describe "Sending a survey when adding the first IP to an organisation", type: :
         expect {
           click_on "Add IP addresses"
         }.to_not(change { user.reload.sent_first_ip_survey })
-        expect(notify_gateway).to_not have_received(:send_email)
+        expect(notify_gateway.count_all_emails).to eq(0)
       end
     end
   end

--- a/spec/features/super_admin/invite_user_to_organisation_spec.rb
+++ b/spec/features/super_admin/invite_user_to_organisation_spec.rb
@@ -2,10 +2,9 @@ describe "Inviting a team member as a super admin", type: :feature do
   let(:organisation) { create(:organisation, name: "Gov Org 3") }
   let(:super_admin) { create(:user, :super_admin) }
   let(:email) { "barry@gov.uk" }
-  let(:notify_gateway) { spy }
+  let(:notify_gateway) { Services.notify_gateway }
 
   before do
-    allow(Services).to receive(:notify_gateway).and_return(notify_gateway)
     sign_in_user super_admin
     visit super_admin_organisation_path(organisation)
     click_on "Add team member"
@@ -44,7 +43,7 @@ describe "Inviting a team member as a super admin", type: :feature do
     end
 
     it "does not send an invite" do
-      expect(notify_gateway).to_not have_received(:send_email)
+      expect(notify_gateway.count_all_emails).to eq 0
     end
 
     it "displays the correct error message" do
@@ -60,7 +59,7 @@ describe "Inviting a team member as a super admin", type: :feature do
       end
 
       it "sends an invite" do
-        expect(notify_gateway).to have_received(:send_email).once
+        expect(notify_gateway.count_all_emails).to eq 1
       end
 
       it "adds the invited user to the correct organisation" do

--- a/spec/features/super_admin/lookup_wifi_user_contact_details_spec.rb
+++ b/spec/features/super_admin/lookup_wifi_user_contact_details_spec.rb
@@ -1,6 +1,5 @@
 describe "Lookup wifi user contact details", type: :feature do
   include EmailHelpers
-  let(:notify_gateway) { spy }
   let(:user) { create(:user, :super_admin) }
   let(:search_term) { "" }
   let(:contact) { "wifi.user@govwifi.org" }
@@ -64,10 +63,6 @@ describe "Lookup wifi user contact details", type: :feature do
 
   context "when deleting a user" do
     let(:search_term) { "zZyYxX" }
-    before do
-      allow(Services).to receive(:notify_gateway).and_return(notify_gateway)
-    end
-
     it "successfully deletes the user" do
       click_on "Remove user"
 

--- a/spec/features/team/invite_with_permissions_spec.rb
+++ b/spec/features/team/invite_with_permissions_spec.rb
@@ -5,7 +5,6 @@ describe "Set user permissions on invite", type: :feature do
   let(:invited_user) { User.find_by(email: invited_email) }
 
   before do
-    allow(Services).to receive(:notify_gateway).and_return(spy)
     sign_in_user user
     visit new_user_invitation_path
     fill_in "Email", with: invited_email

--- a/spec/notify_templates_spec.rb
+++ b/spec/notify_templates_spec.rb
@@ -1,22 +1,40 @@
 describe NotifyTemplates do
+  let(:templates) do
+    NotifyTemplates::TEMPLATES.map do |template|
+      instance_double(Notifications::Client::Template, name: template, id: "#{template}_id")
+    end
+  end
+  before do
+    template_collection = instance_double(Notifications::Client::TemplateCollection, collection: templates)
+    notify_gateway = instance_double(Notifications::Client, get_all_templates: template_collection)
+    allow(Services).to receive(:notify_gateway).and_return(notify_gateway)
+  end
   describe "#template" do
     context "with stubbed gateway" do
-      before do
-        templates = [instance_double(Notifications::Client::Template, name: "unused", id: "unused")]
-        template_collection = instance_double(Notifications::Client::TemplateCollection, collection: templates)
-        notify_gateway = instance_double(Notifications::Client, get_all_templates: template_collection)
-        allow(Services).to receive(:notify_gateway).and_return(notify_gateway)
-      end
       it "filters out unused templates" do
+        templates << instance_double(Notifications::Client::Template, name: "unused", id: "unused_id")
         expect { NotifyTemplates.template("unused") }.to raise_error(KeyError)
       end
     end
     it "fetches a template" do
-      expect(NotifyTemplates.template("confirmation_email")).to eq("confirmation_email_template")
-      expect(NotifyTemplates.template("reset_password_email")).to eq("reset_password_email_template")
+      expect(NotifyTemplates.template("confirmation_email")).to eq("confirmation_email_id")
+      expect(NotifyTemplates.template("reset_password_email")).to eq("reset_password_email_id")
     end
     it "accepts symbols" do
-      expect(NotifyTemplates.template(:confirmation_email)).to eq("confirmation_email_template")
+      expect(NotifyTemplates.template(:confirmation_email)).to eq("confirmation_email_id")
+    end
+  end
+  describe "#verify_templates" do
+    it "verifies all templates" do
+      expect {
+        NotifyTemplates.verify_templates
+      }.to_not raise_error
+    end
+    it "has a missing template" do
+      missing_template = templates.delete_at(0)
+      expect {
+        NotifyTemplates.verify_templates
+      }.to raise_error(StandardError, /Some templates have not been defined in Notify: #{missing_template.name}/)
     end
   end
 end

--- a/spec/notify_templates_spec.rb
+++ b/spec/notify_templates_spec.rb
@@ -4,7 +4,8 @@ describe NotifyTemplates do
       before do
         templates = [instance_double(Notifications::Client::Template, name: "unused", id: "unused")]
         template_collection = instance_double(Notifications::Client::TemplateCollection, collection: templates)
-        allow(Services).to receive(:notify_gateway).and_return(template_collection)
+        notify_gateway = instance_double(Notifications::Client, get_all_templates: template_collection)
+        allow(Services).to receive(:notify_gateway).and_return(notify_gateway)
       end
       it "filters out unused templates" do
         expect { NotifyTemplates.template("unused") }.to raise_error(KeyError)

--- a/spec/requests/users/invitations/create_spec.rb
+++ b/spec/requests/users/invitations/create_spec.rb
@@ -1,10 +1,9 @@
 describe "POST /users/invitation", type: :request do
   let(:user) { create(:user, :with_2fa, organisations: [organisation]) }
   let(:organisation) { create(:organisation) }
-  let(:notify_gateway) { spy }
+  let(:notify_gateway) { Services.notify_gateway }
 
   before do
-    allow(Services).to receive(:notify_gateway).and_return(notify_gateway)
     https!
     login_as(user, scope: :user)
   end
@@ -21,8 +20,8 @@ describe "POST /users/invitation", type: :request do
     end
 
     it "invites a user" do
-      expect(notify_gateway).to have_received(:send_email)
-      .with(include(template_id: NotifyTemplates.template(:invite_email))).once
+      expect(notify_gateway.count_all_emails).to eq 1
+      expect(notify_gateway.last_email_parameters).to include(template_id: NotifyTemplates.template(:invite_email))
     end
 
     it "ignores provided organisation_id" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,8 @@ RSpec.configure do |config|
   config.around do |example|
     original_s3_aws_config = Rails.application.config.s3_aws_config
     Services.notify_gateway.reset
+    Object.send(:remove_const, :NotifyTemplates) if Object.const_defined?(:NotifyTemplates)
+    load "notify_templates.rb"
     begin
       example.run
     ensure


### PR DESCRIPTION
### What

The healthcheck now includes a call to check if all notify templates are defined.

### Why

We need to ensure all notify templates have been defined before the container starts.

Link to JIRA card (if applicable):
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251
