### PR TITLE
Fix bug in certificate model

### DIFF
--- a/app/models/certificate.rb
+++ b/app/models/certificate.rb
@@ -43,7 +43,7 @@ class Certificate < ApplicationRecord
   def has_child?
     children = Certificate.where(issuer: subject, organisation:).where.not(subject:)
     first_child = children.find do |child|
-      child.verify public_key
+      child.verify self
     end
     !!first_child
   end

--- a/spec/factories/x509_certificate.rb
+++ b/spec/factories/x509_certificate.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
 
     initialize_with do
       result = OpenSSL::X509::Certificate.new.tap do |certificate|
-        certificate.public_key = key.public_key
+        certificate.public_key = key
         certificate.serial = OpenSSL::BN.new(serial)
         certificate.subject = OpenSSL::X509::Name.parse(subject)
         certificate.issuer =  OpenSSL::X509::Name.parse(issuing_subject)

--- a/spec/models/certificate_spec.rb
+++ b/spec/models/certificate_spec.rb
@@ -130,4 +130,25 @@ describe Certificate do
       expect(root_ca).to have_child
     end
   end
+
+  describe "EC encryption" do
+    let(:key) { OpenSSL::PKey::EC.generate("prime256v1") }
+    let(:child_key) { OpenSSL::PKey::EC.generate("prime256v1") }
+
+    it "has a child" do
+      root_ca = create(:certificate, key:, subject: root_subject, organisation:)
+      create(:certificate,
+             key: child_key,
+             issuing_key: key,
+             issuing_subject: root_subject,
+             organisation:)
+      expect(root_ca).to have_child
+    end
+
+    it "has a parent" do
+      create(:certificate, key:, subject: root_subject, organisation:)
+      intermediate_ca = create(:certificate, key: child_key, issuing_key: key, issuing_subject: root_subject, organisation:)
+      expect(intermediate_ca).to have_parent
+    end
+  end
 end


### PR DESCRIPTION
The has_child? method should use a certificate model as a parameter of the Certificate#verify method.

This bug only shows when using an EC based key.

Link to JIRA card (if applicable):
https://technologyprogramme.atlassian.net/browse/GW-1991
