### PR TITLE
GW-1913- Accessibility audit radio buttons

### DIFF
--- a/app/views/mous/show_options.html.erb
+++ b/app/views/mous/show_options.html.erb
@@ -12,11 +12,6 @@
   <p class="govuk-body">Anyone can view or share the <%= link_to "GovWifi MOU (opens in another tab).", "https://www.wifi.service.gov.uk/memorandum-of-understanding/", target: "_blank", class: "govuk-body govuk-link govuk-link--no-visited-state", rel: "noopener" %>
   </p>
 
-  <fieldset class="govuk-fieldset" aria-describedby="sign-mou-hint">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-      Who will sign the MOU?
-    </legend>
-
   <p class="govuk-body">
     This can be a GovWifi admin or someone else from your organisation.
   </p>
@@ -25,14 +20,13 @@
   </div>
 
   <%= form_with url: choose_option_mous_path, method: :post do |f| %>
-    <%= f.govuk_radio_button :chosen_action, "sign_mou", id: "sign_mou", link_errors: true, label: { text: "I will sign the MOU" } %>
-    <%= f.govuk_radio_button :chosen_action, "nominate_user", id: "nominate_user", link_errors: true, label: { text: "I will nominate someone from my organisation to sign" } %>
-  </fieldset>
-
+      <%= f.govuk_fieldset legend: { text: "Who will sign the MOU?" } do %>
+        <%= f.govuk_radio_button :chosen_action, "sign_mou", id: "sign_mou", link_errors: true, label: { text: "I will sign the MOU" } %>
+        <%= f.govuk_radio_button :chosen_action, "nominate_user", id: "nominate_user", link_errors: true, label: { text: "I will nominate someone from my organisation to sign" } %>
     <div class="govuk-form-group">
       <%= f.govuk_submit "Continue" %>
     </div>
+    <% end %>
   <% end %>
-
   <%= link_to "Contact GovWifi support", help_index_path, class: "govuk-link" %>
 </div>

--- a/app/views/mous/show_options.html.erb
+++ b/app/views/mous/show_options.html.erb
@@ -12,9 +12,11 @@
   <p class="govuk-body">Anyone can view or share the <%= link_to "GovWifi MOU (opens in another tab).", "https://www.wifi.service.gov.uk/memorandum-of-understanding/", target: "_blank", class: "govuk-body govuk-link govuk-link--no-visited-state", rel: "noopener" %>
   </p>
 
-  <p class="govuk-body govuk-!-font-weight-bold">
-    Who will sign the MOU?
-  </p>
+  <fieldset class="govuk-fieldset" aria-describedby="sign-mou-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+      Who will sign the MOU?
+    </legend>
+
   <p class="govuk-body">
     This can be a GovWifi admin or someone else from your organisation.
   </p>
@@ -25,6 +27,7 @@
   <%= form_with url: choose_option_mous_path, method: :post do |f| %>
     <%= f.govuk_radio_button :chosen_action, "sign_mou", id: "sign_mou", link_errors: true, label: { text: "I will sign the MOU" } %>
     <%= f.govuk_radio_button :chosen_action, "nominate_user", id: "nominate_user", link_errors: true, label: { text: "I will nominate someone from my organisation to sign" } %>
+  </fieldset>
 
     <div class="govuk-form-group">
       <%= f.govuk_submit "Continue" %>


### PR DESCRIPTION
### What
Ensure that inputs have a unique and descriptive programmatically associated label.
Further, as detailed by GOV.UK Design System: Radios (How it works), related radio buttons
should be grouped within a

element and be provided with a descriptive
(which should be the first direct child of the , as defined by the HTML standard, otherwise it might not be correctly picked up by assistive technology).

### Why

On the 'Memorandum of understanding' page, there are radio buttons that, due to a lack of
programmatic association between the label and input, lack an accessible name.
This affects screen reader users, as the radio buttons are not labelled and, therefore, their
purpose is not programmatically determinable, and it also affects voice activation users, as
there is no programmatic association between the visible label and the input for the user to
select the input via its visible label ('click I will sign the MOU').

Link to JIRA card (if applicable):
[GW-1913](https://technologyprogramme.atlassian.net/browse/GW-1913)


[GW-1913]: https://technologyprogramme.atlassian.net/browse/GW-1913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ