### PR TITLE
Allow signing out while setting up 2FA

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   before_action :redirect_user_with_no_organisation, unless: :devise_controller?
   before_action :update_active_sidebar_path
   before_action :authenticate_user!, except: :error
-  before_action :confirm_two_factor_setup
+  before_action :confirm_two_factor_setup, unless: :signing_out?
   before_action :configure_devise_permitted_parameters, if: :devise_controller?
   helper_method :current_organisation, :super_admin?
   helper_method :sidebar
@@ -16,6 +16,10 @@ class ApplicationController < ActionController::Base
 
   def error
     render :error, code: params[:code]
+  end
+
+  def signing_out?
+    params["controller"] == "devise/sessions" && params["action"] == "destroy"
   end
 
   def confirm_two_factor_setup

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,9 +23,9 @@ class ApplicationController < ActionController::Base
   end
 
   def confirm_two_factor_setup
-    return unless current_user &&
-      current_user.need_two_factor_authentication?(request) &&
-      !current_user.totp_enabled?
+    return if current_user.nil? ||
+      !current_user.need_two_factor_authentication?(request) ||
+      current_user.totp_enabled?
 
     redirect_to users_two_factor_authentication_setup_path
   end

--- a/spec/features/authentication/set_up_two_factor_authentication_spec.rb
+++ b/spec/features/authentication/set_up_two_factor_authentication_spec.rb
@@ -34,6 +34,11 @@ describe "Set up two factor authentication", type: :feature do
     expect(page).to have_field(:code)
   end
 
+  it "signs out" do
+    click_on "Sign out"
+    expect(page).to have_content("Sign in to your GovWifi admin account")
+  end
+
   context "when navigating to another page" do
     before { visit root_path }
 


### PR DESCRIPTION
Previously, it was impossible to sign out while setting up 2FA clicking the sign out link, would take the user back to the 2FA screen.

Now, signing out takes the user back to the sign in page while setting up 2FA

Link to JIRA card (if applicable):
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251