### PR TITLE
Update URL of govwifi-shared-frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,6 @@
       "max-nesting-depth": 3,
       "media-feature-range-notation": null
     }
-  }
+  },
+  "version": "0.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "govuk-frontend": "^5.7.1",
-    "govwifi-shared-frontend": "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.10/govwifi-shared-frontend-0.6.10.tgz",
+    "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.10/govwifi-shared-frontend-0.6.10.tgz",
     "html5shiv": "^3.7.3",
     "postcss": "^8.4.37",
     "prettier": "^3.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,9 +355,9 @@ govuk-frontend@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.7.1.tgz#d4c561ebf8c0b76130f31df8c2e4d70d340cd63f"
 
-"govwifi-shared-frontend@https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.10/govwifi-shared-frontend-0.6.10.tgz":
+"govwifi-shared-frontend@https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.10/govwifi-shared-frontend-0.6.10.tgz":
   version "0.6.10"
-  resolved "https://github.com/alphagov/govwifi-shared-frontend/releases/download/v0.6.10/govwifi-shared-frontend-0.6.10.tgz"
+  resolved "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.10/govwifi-shared-frontend-0.6.10.tgz#b4fe700112c34d258a9fa045ad585e972fca2c70"
   dependencies:
     js-cookie "^3.0.5"
 


### PR DESCRIPTION
### What
Update URL of govwifi-shared-frontend

### Why
Update URL of govwifi-shared-frontend. We are migrating our repos from the alphagov github organisation to the govwifi organisation. We need to update the repos to the appropriate URLs.

Link to JIRA card (if applicable):
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5e45277d29e6d00c970616c6&selectedIssue=GW-1851