### PR TITLE
Fix unconfirmed memberships

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,6 +40,8 @@ class ApplicationController < ActionController::Base
     elsif user_signed_in?
       current_user.confirmed_organisations.first
     end
+  rescue ActiveRecord::RecordNotFound
+    current_user.confirmed_organisations.first
   end
 
   def super_admin?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,10 +4,10 @@ class ApplicationController < ActionController::Base
 
   include Pagy::Backend
 
-  before_action :redirect_user_with_no_organisation, unless: :devise_controller?
   before_action :update_active_sidebar_path
   before_action :authenticate_user!, except: :error
   before_action :confirm_two_factor_setup, unless: :signing_out?
+  before_action :redirect_user_with_no_organisation, unless: :devise_controller?
   before_action :configure_devise_permitted_parameters, if: :devise_controller?
   helper_method :current_organisation, :super_admin?
   helper_method :sidebar
@@ -35,10 +35,10 @@ class ApplicationController < ActionController::Base
   end
 
   def current_organisation
-    if session[:organisation_id] && (current_user.member_of?(session[:organisation_id].to_i) || super_admin?)
+    if session[:organisation_id] && (current_user.confirmed_member_of?(session[:organisation_id].to_i) || super_admin?)
       Organisation.find(session[:organisation_id])
     elsif user_signed_in?
-      current_user.organisations.first
+      current_user.confirmed_organisations.first
     end
   end
 
@@ -47,11 +47,11 @@ class ApplicationController < ActionController::Base
   end
 
   def redirect_user_with_no_organisation
-    return if current_user&.is_super_admin? && current_organisation.present?
+    return if current_user.is_super_admin? && current_organisation.present?
 
-    if current_user&.is_super_admin? && current_organisation.nil?
+    if current_user.is_super_admin? && current_organisation.nil?
       redirect_to super_admin_organisations_path, notice: "You have not assumed a membership."
-    elsif current_user&.organisations&.empty?
+    elsif current_user.memberships.confirmed.empty?
       redirect_to signed_in_new_help_path, notice: "You do not belong to an organisation. Please mention this in your support request."
     end
   end

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,7 +1,6 @@
 class HelpController < ApplicationController
-  skip_before_action :authenticate_user!
+  skip_before_action :authenticate_user!, :redirect_user_with_no_organisation
   before_action :redirect_signed_in_user, only: :new
-  skip_before_action :redirect_user_with_no_organisation, only: %i[signed_in create]
 
   def new
     case params[:choice]

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -1,7 +1,7 @@
 class MembershipsController < ApplicationController
   before_action :set_membership, only: %i[edit update destroy]
   before_action :validate_can_manage_team, only: %i[edit update destroy]
-  before_action :validate_preserve_admin_permissions, only: %i[update destroy]
+  before_action :validate_preserve_admin_permissions, only: %i[update destroy], unless: :super_admin?
   skip_before_action :redirect_user_with_no_organisation, only: %i[destroy edit update]
 
   def edit

--- a/app/controllers/monitoring_controller.rb
+++ b/app/controllers/monitoring_controller.rb
@@ -1,5 +1,5 @@
 class MonitoringController < ApplicationController
-  skip_before_action :authenticate_user!
+  skip_before_action :authenticate_user!, :redirect_user_with_no_organisation
 
   def healthcheck
     render body: "Healthy"

--- a/app/controllers/nominated_mous_controller.rb
+++ b/app/controllers/nominated_mous_controller.rb
@@ -1,5 +1,5 @@
 class NominatedMousController < ApplicationController
-  skip_before_action :authenticate_user!
+  skip_before_action :authenticate_user!, :redirect_user_with_no_organisation
   before_action :set_nomination, only: %i[new create]
   before_action :check_token, only: %i[new create]
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -4,6 +4,7 @@ class Membership < ApplicationRecord
   before_create :set_invitation_token
 
   scope :pending, -> { where(confirmed_at: nil) }
+  scope :confirmed, -> { where.not(confirmed_at: nil) }
   delegate :meets_admin_user_minimum?, to: :organisation
 
   def preserve_admin_permissions?

--- a/app/models/search_form.rb
+++ b/app/models/search_form.rb
@@ -6,6 +6,6 @@ class SearchForm
   validates :search_term, presence: true
 
   def search_term
-    @search_term&.delete(" ")
+    @search_term&.strip
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,4 +119,12 @@ class User < ApplicationRecord
   def member_of?(organisation_id)
     Membership.exists?(organisation_id:, user: self)
   end
+
+  def confirmed_member_of?(organisation_id)
+    Membership.where.not(confirmed_at: nil).where(organisation_id:, user: self).exists?
+  end
+
+  def confirmed_organisations
+    Organisation.joins(:memberships).joins(memberships: :user).where.not(memberships: { confirmed_at: nil }).where(user: { id: self })
+  end
 end

--- a/app/views/current_organisation/edit.html.erb
+++ b/app/views/current_organisation/edit.html.erb
@@ -3,7 +3,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Switch organisation</h1>
     <ul class="govuk-list">
-      <% current_user.organisations.each do | organisation | %>
+      <% current_user.confirmed_organisations.each do | organisation | %>
         <li>
           <%= button_to organisation.name, change_organisation_path(organisation_id: organisation.id),
                         method: :patch, class: "govuk-heading-m button-as-link govuk-!-margin-bottom-4", aria: { label: "Switch to #{organisation.name}" } %>

--- a/db/migrate/20241113112311_confirm_existing_memberships.rb
+++ b/db/migrate/20241113112311_confirm_existing_memberships.rb
@@ -1,0 +1,15 @@
+class ConfirmExistingMemberships < ActiveRecord::Migration[7.0]
+  sql = <<~SQL
+    Select m.id as membership_id
+      from memberships m, users u
+      where u.id=m.user_id and
+        m.confirmed_at IS NULL and
+        u.last_sign_in_at IS NOT NULL
+  SQL
+
+  result_list = ActiveRecord::Base.connection.exec_query(sql)
+  result_list.each do |result|
+    sql = "update memberships set confirmed_at = \"#{Time.zone.now.strftime('%Y-%m-%d %H:%M:%S')}\" where id=#{result['membership_id']}"
+    ActiveRecord::Base.connection.exec_query(sql)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_13_104514) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_13_112311) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,25 +5,6 @@ require "factory_bot"
 
 FactoryBot.find_definitions
 
-def create_user_for_organisations(
-  organisations,
-  email: nil,
-  confirmed_at: nil,
-  is_super_admin: false
-)
-  first_name = Faker::Name.first_name
-  last_name = Faker::Name.last_name
-  email ||= "#{first_name}.#{last_name}@example.gov.uk"
-  User.create!(
-    email:,
-    password: "password",
-    name: "#{first_name} #{last_name}",
-    confirmed_at:,
-    organisations:,
-    is_super_admin:,
-  )
-end
-
 organisation = Organisation.create!(
   name: "UKTI Education", service_email: "it@parks.com",
 )
@@ -31,25 +12,16 @@ empty_organisation = Organisation.create!(
   name: "Academy for Social Justice Commissioning", service_email: "empty@example.net",
 )
 
-create_user_for_organisations(
-  [],
-  email: "admin@gov.uk",
-  confirmed_at: Time.zone.now,
-  is_super_admin: true,
-)
-
-create_user_for_organisations(
-  [organisation, empty_organisation],
-  email: "test@gov.uk",
-  confirmed_at: Time.zone.now,
-)
+FactoryBot.create(:user, :super_admin, email: "admin@gov.uk", password: "password")
+FactoryBot.create(:user, :confirm_all_memberships, :super_admin,
+                  email: "test@gov.uk", password: "password", organisations: [organisation, empty_organisation])
 
 3.times do
-  create_user_for_organisations([organisation], confirmed_at: Time.zone.now)
+  FactoryBot.create(:user, :confirm_all_memberships, organisations: [organisation])
 end
 
 2.times do
-  create_user_for_organisations([organisation])
+  FactoryBot.create(:user, :unconfirmed, organisations: [organisation])
 end
 
 # Location with no IP addresses

--- a/spec/controllers/locations_controller_spec.rb
+++ b/spec/controllers/locations_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe LocationsController, type: :controller do
   describe "GET /add_ips" do
     context "when the user does not belong to the organisation" do
       it "redirects to the root path" do
-        response = get :add_ips, params: { location_id: other_location.id }
+        get :add_ips, params: { location_id: other_location.id }
 
         expect(response).to redirect_to(root_path)
       end
@@ -32,11 +32,11 @@ RSpec.describe LocationsController, type: :controller do
 
     context "when the update goes well" do
       before do
-        @response = post :update_ips, params:
+        post :update_ips, params:
       end
 
       it "redirects to the created ips path" do
-        expect(@response).to redirect_to(ips_path)
+        expect(response).to redirect_to(ips_path)
       end
     end
 
@@ -48,11 +48,11 @@ RSpec.describe LocationsController, type: :controller do
       end
 
       before do
-        @response = post :update_ips, params: other_params
+        post :update_ips, params: other_params
       end
 
       it "redirects them to the root path" do
-        expect(@response).to redirect_to root_path
+        expect(response).to redirect_to root_path
       end
 
       it "does not update the location" do
@@ -64,17 +64,17 @@ RSpec.describe LocationsController, type: :controller do
   describe "POST /update" do
     context "when the user does not belong to the requested location" do
       it "redirects to the root path" do
-        @response = put :update, params: { id: other_location.id }
+        put :update, params: { id: other_location.id }
 
-        expect(@response).to redirect_to(root_path)
+        expect(response).to redirect_to(root_path)
       end
     end
 
     context "when the user belongs to the requested location" do
       it "redirects to the ips path" do
-        @response = put :update, params: { id: location.id }
+        put :update, params: { id: location.id }
 
-        expect(@response).to redirect_to(ips_path)
+        expect(response).to redirect_to(ips_path)
       end
     end
   end

--- a/spec/factories/memberships.rb
+++ b/spec/factories/memberships.rb
@@ -1,3 +1,11 @@
 FactoryBot.define do
   factory :membership
+
+  trait :confirmed do
+    confirmed_at { Time.zone.now }
+  end
+
+  trait :unconfirmed do
+    confirmed_at { nil }
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,10 +1,12 @@
 FactoryBot.define do
   factory :user do
-    sequence :email do |n|
-      "test#{n}@gov.uk"
+    transient do
+      first_name { Faker::Name.first_name }
+      last_name { Faker::Name.last_name }
     end
+    email { "#{first_name}.#{last_name}@example.gov.uk" }
     password { "strong lemonade 1475 p4o6d09" }
-    name { "bob" }
+    name { "#{first_name} #{last_name}" }
     confirmed_at { Time.zone.now }
     sent_first_ip_survey { true }
 
@@ -12,15 +14,32 @@ FactoryBot.define do
       is_super_admin { true }
     end
 
+    trait :with_unconfirmed_membership do
+      after(:create) do |user|
+        create(:membership, :unconfirmed, user:, organisation: create(:organisation))
+        user.reload
+      end
+    end
+
+    trait :confirm_all_memberships do
+      after(:create) do |user|
+        user.memberships.each do |membership|
+          membership.confirm! unless membership.confirmed?
+        end
+      end
+    end
+
     trait :with_organisation do
       after(:create) do |user|
-        create(:organisation, users: [user])
+        create(:membership, :confirmed, user:, organisation: create(:organisation))
+        user.reload
       end
     end
 
     trait :with_organisation_and_locations do
       after(:create) do |user|
-        create(:organisation, :with_locations, users: [user])
+        create(:membership, :confirmed, user:, organisation: create(:organisation, :with_locations))
+        user.reload
       end
     end
 

--- a/spec/features/certificates/delete_certificate_spec.rb
+++ b/spec/features/certificates/delete_certificate_spec.rb
@@ -2,7 +2,7 @@ describe "Delete Certificate", type: :feature do
   let(:root_subject) { "/CN=rootca" }
   let(:root_key) { OpenSSL::PKey::RSA.new(512) }
   let(:organisation) { create(:organisation, :with_cba_enabled) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
   let(:root_name) { "root_cert" }
   let(:intermediate_name) { "intermediate_cert" }
 

--- a/spec/features/certificates/rename_certificate_spec.rb
+++ b/spec/features/certificates/rename_certificate_spec.rb
@@ -1,6 +1,6 @@
 describe "Rename Certificate", type: :feature do
   let(:organisation) { create(:organisation, :with_cba_enabled) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
   let(:name) { "root_cert" }
   let!(:certificate) { create(:certificate, name:, organisation:) }
 

--- a/spec/features/certificates/upload_certificate_spec.rb
+++ b/spec/features/certificates/upload_certificate_spec.rb
@@ -28,7 +28,7 @@ describe "Upload Certificate", type: :feature do
   end
 
   let(:organisation) { create(:organisation, :with_cba_enabled) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
 
   let(:root_certificate_file) do
     Tempfile.new("root_certificate_file").tap do |file|

--- a/spec/features/edit_organisation_details_spec.rb
+++ b/spec/features/edit_organisation_details_spec.rb
@@ -1,6 +1,6 @@
 describe "Editing an organisations details", type: :feature do
   let(:organisation) { create(:organisation, name: "Gov Org 2", service_email: "testme@gov.uk") }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
 
   context "when editing an organisation you belong to" do
     before do

--- a/spec/features/invites/invite_user_to_their_first_organisation_spec.rb
+++ b/spec/features/invites/invite_user_to_their_first_organisation_spec.rb
@@ -2,7 +2,7 @@ describe "Inviting a user to their first organisation", type: :feature do
   include EmailHelpers
 
   let(:organisation) { create(:organisation) }
-  let(:invitor) { create(:user, organisations: [organisation]) }
+  let(:invitor) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
   context "when the user does not exist yet" do
     let(:invitee_email) { "newuser@gov.uk" }
     before do
@@ -30,6 +30,10 @@ describe "Inviting a user to their first organisation", type: :feature do
 
       it "confirms the user" do
         expect(User.find_by(email: invitee_email)).to be_confirmed
+      end
+
+      it "confirms the membership" do
+        expect(User.find_by(email: invitee_email).membership_for(organisation)).to be_confirmed
       end
 
       it "allows the user to sign in successfully" do

--- a/spec/features/ips/permissions_spec.rb
+++ b/spec/features/ips/permissions_spec.rb
@@ -1,6 +1,6 @@
 describe "Add an IP", type: :feature do
   let(:organisation) { create(:organisation) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
 
   before do
     sign_in_user user

--- a/spec/features/ips/remove_an_ip_spec.rb
+++ b/spec/features/ips/remove_an_ip_spec.rb
@@ -1,13 +1,10 @@
 describe "Removing an IP", type: :feature do
-  let(:user) { create(:user) }
-  let(:organisation) { create(:organisation) }
-  let(:location) { create(:location) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
+  let(:organisation) { create(:organisation, locations: [location]) }
+  let(:location) { create(:location, ips: [ip]) }
   let(:ip) { create(:ip) }
 
   before do
-    user.organisations << organisation
-    organisation.locations << location
-    location.ips << ip
     sign_in_user user
   end
 

--- a/spec/features/locations/remove_a_location_spec.rb
+++ b/spec/features/locations/remove_a_location_spec.rb
@@ -1,11 +1,9 @@
 describe "Remove a location", type: :feature do
-  let(:organisation) { create(:organisation) }
-  let(:user) { create(:user) }
-  let(:location) { create(:location, organisation:) }
+  let(:location) { create(:location) }
+  let(:organisation) { create(:organisation, locations: [location]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
 
   before do
-    user.organisations << organisation
-    organisation.locations << location
     sign_in_user user
   end
 

--- a/spec/features/locations/rotate_radius_secret_key_spec.rb
+++ b/spec/features/locations/rotate_radius_secret_key_spec.rb
@@ -23,7 +23,7 @@ describe "Rotate RADIUS secret key", type: :feature do
 
   context "when it is a company that I do not belong to" do
     let(:organisation) { create(:organisation) }
-    let(:user_2) { create(:user, organisations: [organisation]) }
+    let(:user_2) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
     let(:location_2) { create(:location, organisation: user_2.organisations.first) }
 
     before do

--- a/spec/features/locations/update_location_spec.rb
+++ b/spec/features/locations/update_location_spec.rb
@@ -1,11 +1,9 @@
 describe "Update location", type: :feature do
-  let(:organisation) { create(:organisation) }
-  let(:user) { create(:user) }
-  let(:location) { create(:location, organisation:) }
+  let(:organisation) { create(:organisation, locations: [location]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
+  let(:location) { create(:location) }
 
   before do
-    user.organisations << organisation
-    organisation.locations << location
     sign_in_user user
     visit ips_path
     click_on "Update this location"

--- a/spec/features/logging/filter_logs_spec.rb
+++ b/spec/features/logging/filter_logs_spec.rb
@@ -30,7 +30,7 @@ describe "Filter CBA requests for an IP", type: :feature do
   context "as a super admin" do
     before do
       organisation = create(:organisation, cba_enabled: true)
-      super_admin_user = create(:user, :super_admin, organisations: [organisation])
+      super_admin_user = create(:user, :confirm_all_memberships, :super_admin, organisations: [organisation])
       sign_in_user super_admin_user
       visit logs_path(log_search_form: { ip: ip.address, filter_option: LogSearchForm::IP_FILTER_OPTION })
     end

--- a/spec/features/logging/view_auth_requests_for_a_location_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_a_location_spec.rb
@@ -1,5 +1,5 @@
 describe "View authentication requests for a location", type: :feature do
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
 
   before do
     sign_in_user user

--- a/spec/features/logging/view_auth_requests_for_a_username_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_a_username_spec.rb
@@ -1,7 +1,7 @@
 describe "View authentication requests for a username", type: :feature do
-  let!(:admin_user) { create(:user) }
-  let!(:organisation_one) { create(:organisation, :with_location_and_ip, users: [admin_user]) }
-  let!(:organisation_two) { create(:organisation, :with_location_and_ip, users: [admin_user]) }
+  let(:admin_user) { create(:user, :confirm_all_memberships, organisations: [organisation_one, organisation_two]) }
+  let(:organisation_one) { create(:organisation, :with_location_and_ip) }
+  let(:organisation_two) { create(:organisation, :with_location_and_ip) }
   let(:ip_organisation_one) { organisation_one.ip_addresses.first }
   let(:ip_organisation_two) { organisation_two.ip_addresses.first }
   let(:other_ip) { "6.6.6.6" }
@@ -40,7 +40,7 @@ describe "View authentication requests for a username", type: :feature do
 
   describe "With results" do
     context "Super admin" do
-      let!(:admin_user) { create(:user, :super_admin) }
+      let!(:admin_user) { create(:user, :super_admin, :with_organisation) }
       describe "Searching a username that does not belong to the current organisation" do
         let(:search_string) { "BBBBBB" }
 

--- a/spec/features/memberships/confirm_invite_to_second_organisation_spec.rb
+++ b/spec/features/memberships/confirm_invite_to_second_organisation_spec.rb
@@ -16,7 +16,7 @@ describe "Confirming an invite to a second or subsequent organisation", type: :f
     end
 
     it "Confirms the invitation" do
-      expect(invited_user.organisations).to include(organisation)
+      expect(invited_user.membership_for(organisation)).to be_confirmed
     end
 
     it "prints a success message" do

--- a/spec/features/pending_user_spec.rb
+++ b/spec/features/pending_user_spec.rb
@@ -1,9 +1,9 @@
 describe "Inviting an existing user which belongs to an organisation", type: :feature do
   let!(:organisation) { create(:organisation) }
-  let!(:user) { create(:user, organisations: [organisation]) }
+  let!(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
 
   let!(:organisation_2) { create(:organisation) }
-  let!(:user_2) { create(:user, email: "inviteme@gov.uk", organisations: [organisation_2]) }
+  let!(:user_2) { create(:user, :confirm_all_memberships, email: "inviteme@gov.uk", organisations: [organisation_2]) }
 
   context "with a user that already belongs to an organisation" do
     before do

--- a/spec/features/register_an_additional_organisation_spec.rb
+++ b/spec/features/register_an_additional_organisation_spec.rb
@@ -1,6 +1,6 @@
 describe "Register an additional organisation", type: :feature do
   let(:organisation_1) { create(:organisation) }
-  let(:user) { create(:user, organisations: [organisation_1]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation_1]) }
 
   before do
     sign_in_user user

--- a/spec/features/side_nav_spec.rb
+++ b/spec/features/side_nav_spec.rb
@@ -29,7 +29,7 @@ describe "Side nav logic", type: :feature do
           expect(@section).to have_link("Settings", href: new_organisation_settings_path)
         end
         context "the current organisation contains a location with an ip" do
-          let(:user) { create(:user, :super_admin, organisations: [create(:organisation, :with_location_and_ip)]) }
+          let(:user) { create(:user, :confirm_all_memberships, :super_admin, organisations: [create(:organisation, :with_location_and_ip)]) }
           it "displays a settings link referring to the  settings path" do
             expect(@section).to have_link("Settings", href: settings_path)
           end

--- a/spec/features/super_admin/lookup_wifi_user_contact_details_spec.rb
+++ b/spec/features/super_admin/lookup_wifi_user_contact_details_spec.rb
@@ -45,7 +45,7 @@ describe "Lookup wifi user contact details", type: :feature do
   end
 
   context "with a phone number search term" do
-    let(:search_term) { "+44 7891 234567" }
+    let(:search_term) { "+447891234567" }
     let(:contact) { "+447891234567" }
 
     it "presents the end user username" do

--- a/spec/features/super_admin/sign_in_as_super_admin_spec.rb
+++ b/spec/features/super_admin/sign_in_as_super_admin_spec.rb
@@ -22,7 +22,7 @@ describe "Signing in as a super admin", type: :feature do
 
     context "when visiting a normal organisation" do
       before do
-        user.organisations << organisation
+        create(:membership, :confirmed, organisation:, user:)
 
         visit root_path
 

--- a/spec/features/switch_organisation_spec.rb
+++ b/spec/features/switch_organisation_spec.rb
@@ -1,63 +1,85 @@
 require "rack_session_access/capybara"
 
-describe "Multiple organisations", type: :feature do
-  let(:organisation_1) { create(:organisation) }
-  let(:organisation_2) { create(:organisation) }
-  let(:user) { create(:user) }
-
+describe "Switching organisations", type: :feature do
   before do
-    user.organisations << organisation_1
     sign_in_user user
   end
 
-  context "when switching organisations" do
-    before do
-      user.organisations << organisation_2
+  describe "Unconfirmed memberships" do
+    let(:confirmed_org) { create(:organisation) }
+    let(:unconfirmed_org) { create(:organisation) }
+    let(:user) { create(:user) }
+    before :each do
+      create(:membership, :confirmed, organisation: confirmed_org, user:)
+      create(:membership, :unconfirmed, organisation: unconfirmed_org, user:)
+      create(:organisation)
       visit root_path
       click_on "Switch organisation"
     end
-
-    it "does not display the sidenav" do
-      expect(page).not_to have_selector ".leftnav"
+    it "displays a button for the confirmed organisation membership" do
+      expect(page).to have_button(confirmed_org.name)
     end
-
-    it "displays a button for organisation one" do
-      expect(page).to have_button(organisation_1.name)
-    end
-
-    it "displays a button for organisation two" do
-      expect(page).to have_button(organisation_2.name)
-    end
-
-    it "changes the organisation the user is viewing" do
-      click_on organisation_2.name
-      within ".subnav" do
-        expect(page).to have_content(organisation_2.name)
-      end
+    it "does not display a button for the unconfirmed organisation membership" do
+      expect(page).to_not have_button(unconfirmed_org.name)
     end
   end
 
-  context "when the session is updated manually" do
-    context "when the user doesn't belong to the organisation in the session" do
+  context "with two confirmed organisations" do
+    let(:user) { create(:user) }
+    let(:organisation_1) { create(:organisation) }
+    let(:organisation_2) { create(:organisation) }
+    before do
+      create(:membership, :confirmed, organisation: organisation_1, user:)
+      create(:membership, :confirmed, organisation: organisation_2, user:)
+    end
+    context "when switching organisations" do
       before do
-        page.set_rack_session(organisation_id: organisation_2.id)
         visit root_path
+        click_on "Switch organisation"
       end
 
-      it "dissallows switching to that organisation" do
-        expect(page).not_to have_content(organisation_2.name)
+      it "does not display the sidenav" do
+        expect(page).not_to have_selector ".leftnav"
+      end
+
+      it "displays a button for organisation one" do
+        expect(page).to have_button(organisation_1.name)
+      end
+
+      it "displays a button for organisation two" do
+        expect(page).to have_button(organisation_2.name)
+      end
+
+      it "changes the organisation the user is viewing" do
+        click_on organisation_2.name
+        within ".subnav" do
+          expect(page).to have_content(organisation_2.name)
+        end
       end
     end
 
-    context "when the user belongs to the organisation in the session" do
-      before do
-        user.organisations << organisation_2
-        page.set_rack_session(organisation_id: organisation_2.id)
-        visit root_path
+    context "when the session is updated manually" do
+      context "when the user doesn't belong to the organisation in the session" do
+        let(:non_member_organisation) { create(:organisation) }
+        before do
+          page.set_rack_session(organisation_id: non_member_organisation.id)
+          visit root_path
+        end
+
+        it "dissallows switching to that organisation" do
+          expect(page).not_to have_content(non_member_organisation.name)
+        end
       end
 
-      it "allows switching to that organisation" do
-        expect(page).to have_content(organisation_2.name)
+      context "when the user belongs to the organisation in the session" do
+        before do
+          page.set_rack_session(organisation_id: organisation_2.id)
+          visit root_path
+        end
+
+        it "allows switching to that organisation" do
+          expect(page).to have_content(organisation_2.name)
+        end
       end
     end
   end

--- a/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
+++ b/spec/features/team/accept_an_invitation_and_sign_up_spec.rb
@@ -1,7 +1,7 @@
 describe "Sign up from invitation", type: :feature do
   let(:invited_user_email) { "invited@gov.uk" }
   let(:organisation) { create(:organisation) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
 
   before do
     sign_in_user user

--- a/spec/features/team/edit_permissions_spec.rb
+++ b/spec/features/team/edit_permissions_spec.rb
@@ -1,6 +1,6 @@
 describe "Edit user permissions", type: :feature do
   let(:organisation) { create(:organisation) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
   let(:invited_user_other_org) { User.find_by(email: "invited_other_org@gov.uk") }
   let(:invited_user_same_org) { User.find_by(email: "invited_same_org@gov.uk") }
 

--- a/spec/features/team/invite_with_permissions_spec.rb
+++ b/spec/features/team/invite_with_permissions_spec.rb
@@ -1,6 +1,6 @@
 describe "Set user permissions on invite", type: :feature do
   let(:organisation) { create(:organisation) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
   let(:invited_email) { "invited@gov.uk" }
   let(:invited_user) { User.find_by(email: invited_email) }
 

--- a/spec/features/team/permissions_spec.rb
+++ b/spec/features/team/permissions_spec.rb
@@ -1,6 +1,6 @@
 describe "Invite a team member", type: :feature do
   let(:organisation) { create(:organisation) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
 
   before { sign_in_user user }
 

--- a/spec/features/team/resend_invitation_spec.rb
+++ b/spec/features/team/resend_invitation_spec.rb
@@ -43,6 +43,7 @@ describe "Resending an invitation to a team member", type: :feature do
 
       it "confirms the user" do
         expect(invited_user.confirmed?).to eq(true)
+        expect(invited_user.membership_for(user.organisations.first)).to be_confirmed
       end
     end
   end

--- a/spec/features/team/view_team_members_spec.rb
+++ b/spec/features/team/view_team_members_spec.rb
@@ -7,7 +7,7 @@ describe "View team members of my organisation", type: :feature do
 
   context "when logged in" do
     let(:organisation) { create(:organisation) }
-    let(:user) { create(:user, email: "me@example.gov.uk", name: "bob", organisations: [organisation]) }
+    let(:user) { create(:user, :confirm_all_memberships, email: "me@example.gov.uk", name: "bob", organisations: [organisation]) }
 
     before do
       ENV["LONDON_RADIUS_IPS"] = "1.1.1.1,2.2.2.2"

--- a/spec/features/user_with_no_organisation_memberships_spec.rb
+++ b/spec/features/user_with_no_organisation_memberships_spec.rb
@@ -1,5 +1,18 @@
 describe "A confirmed user with no organisation memberships logs in", type: :feature do
-  context "a regular user" do
+  context "a regular user with an unconfirmed membership" do
+    let(:user) { create(:user, organisations: [create(:organisation)]) }
+    before do
+      sign_in_user user
+      visit root_path
+    end
+    it "redirects to the help path" do
+      expect(page).to have_current_path(signed_in_new_help_path)
+    end
+    it "prints an instruction" do
+      expect(page).to have_content("You do not belong to an organisation")
+    end
+  end
+  context "a regular user without a membership" do
     let(:user) { create(:user, organisations: []) }
 
     context "with an existing confirmed user" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -205,4 +205,18 @@ describe User do
         .to include("#{email},#{name},#{current_sign_in_at},#{last_sign_in_at},#{sign_in_count},#{organisation_name}\n")
     end
   end
+
+  describe "#confirmed_member_of?" do
+    let(:user) { create(:user) }
+    let(:organisation) { create(:organisation) }
+
+    it "is a confirmed member" do
+      create(:membership, :confirmed, user:, organisation:)
+      expect(user.reload.confirmed_member_of?(organisation)).to be true
+    end
+    it "is not confirmed member" do
+      create(:membership, :unconfirmed, user:, organisation:)
+      expect(user.reload.confirmed_member_of?(organisation)).to be false
+    end
+  end
 end

--- a/spec/requests/certificates/create_spec.rb
+++ b/spec/requests/certificates/create_spec.rb
@@ -4,7 +4,7 @@ describe "POST /certificates", type: :request do
   let(:certificate) { Certificate.find_by_name("test") }
 
   let(:organisation) { create(:organisation, :with_cba_enabled) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
   let(:perform) do
     post certificates_path, params: { certificate_form: { file: certificate_file, name: "mycert" } }
   end

--- a/spec/requests/certificates/delete_spec.rb
+++ b/spec/requests/certificates/delete_spec.rb
@@ -1,6 +1,6 @@
 describe "GET /certificates/edit/:id", type: :request do
   let(:organisation) { create(:organisation, :with_cba_enabled) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
   let(:root_key) { OpenSSL::PKey::RSA.new(512) }
   let(:certificate) { create(:certificate, organisation:, key: root_key) }
   let(:perform) { delete certificate_path(certificate) }

--- a/spec/requests/certificates/edit_spec.rb
+++ b/spec/requests/certificates/edit_spec.rb
@@ -1,7 +1,7 @@
 describe "GET /certificates/new", type: :request do
   let(:organisation) { create(:organisation, :with_cba_enabled) }
   let(:certificate) { create(:certificate, organisation:) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
   subject(:perform) { get edit_certificate_path(certificate) }
   before :each do
     https!

--- a/spec/requests/certificates/index_spec.rb
+++ b/spec/requests/certificates/index_spec.rb
@@ -1,6 +1,6 @@
 describe "GET /certificates", type: :request do
   let(:organisation) { create(:organisation, :with_cba_enabled) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
   subject(:perform) { get certificates_path }
 
   before :each do

--- a/spec/requests/certificates/new_spec.rb
+++ b/spec/requests/certificates/new_spec.rb
@@ -1,6 +1,6 @@
 describe "GET /certificates/new", type: :request do
   let(:organisation) { create(:organisation, :with_cba_enabled) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
   subject(:perform) { get new_certificate_path }
   before :each do
     https!

--- a/spec/requests/certificates/patch_spec.rb
+++ b/spec/requests/certificates/patch_spec.rb
@@ -1,6 +1,6 @@
 describe "GET /certificates/edit/:id", type: :request do
   let(:organisation) { create(:organisation, :with_cba_enabled) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
   let(:certificate) { create(:certificate, name: "OldName", organisation:) }
   let(:new_name) { "NewName" }
   let(:perform) { patch certificate_path(certificate), params: { certificate: { name: new_name } } }

--- a/spec/requests/certificates/show_spec.rb
+++ b/spec/requests/certificates/show_spec.rb
@@ -1,7 +1,7 @@
 describe "GET /certificate/:id", type: :request do
   let(:certificate) { create(:certificate, organisation:) }
   let(:organisation) { create(:organisation, :with_cba_enabled) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
   subject(:perform) { get certificate_path(certificate) }
   before :each do
     https!

--- a/spec/requests/home/get_spec.rb
+++ b/spec/requests/home/get_spec.rb
@@ -4,7 +4,7 @@ describe "GET /home", type: :request do
     create(:ip, location: org.locations.first)
     org
   end
-  let(:user) { create(:user, :with_2fa, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, :with_2fa, organisations: [organisation]) }
   let(:super_admin) { create(:user, :super_admin) }
 
   before do

--- a/spec/requests/users/invitations/create_spec.rb
+++ b/spec/requests/users/invitations/create_spec.rb
@@ -1,5 +1,5 @@
 describe "POST /users/invitation", type: :request do
-  let(:user) { create(:user, :with_2fa, organisations: [organisation]) }
+  let(:user) { create(:user, :confirm_all_memberships, :with_2fa, organisations: [organisation]) }
   let(:organisation) { create(:organisation) }
   let(:notify_gateway) { Services.notify_gateway }
 


### PR DESCRIPTION
### What
Ensure only confirmed organisation memberships can be used


### Why
Unconfirmed organisations should not be shown in the UI and
should not be able to be modified
