### PR TITLE
Require CSV to fix the BackupServiceEmails class

### DIFF
--- a/lib/use_cases/backup_service_emails.rb
+++ b/lib/use_cases/backup_service_emails.rb
@@ -1,3 +1,5 @@
+require "csv"
+
 module UseCases
   class BackupServiceEmails
     def initialize(writer:)


### PR DESCRIPTION
### What

Require CSV to fix the BackupServiceEmails class
### Why

Otherwise converting an array to CSV does not work

Link to JIRA card (if applicable):
[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)
