### PR TITLE
GW-1924 - Headings and labels - Update confirm rotate radius key

### DIFF
--- a/app/views/ips/_confirm_rotate_radius_key.html.erb
+++ b/app/views/ips/_confirm_rotate_radius_key.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-error-summary" role="alert">
   <h2 class="govuk-error-summary__title">
-    Are you sure you want to rotate this RADIUS secret key?
+    Are you sure you want to rotate this RADIUS secret key for <%= @key_to_rotate.address %>?
   </h2>
   <div class="govuk-error-summary__body">
     <table class="govuk-table">
@@ -17,5 +17,8 @@
 
     <%= button_to "Yes, rotate this RADIUS key", location_path(@key_to_rotate),
                   method: :patch, class: "govuk-button red-button" %>
+                  <span class="govuk-visually-hidden">
+                  for <%= @key_to_rotate.address %>
+                </span>
   </div>
 </div>


### PR DESCRIPTION
### What

Button text was insufficiently descriptive of their topic or purpose, whilst browsing out of
context.

### Why

On the 'Rotate secret key' page, neither the page title, error summary nor 'Yes, rotate this
RADIUS key' button identify which location the secret key is to be rotated for.
This affects all users, but the loss of context as to which location the secret key is to be
rotated, the context from the previous step, can particularly affect cognitive and screen
reader users by relying on their memory to remember which location the pronoun 'this' is
referring to.
Link to JIRA card (if applicable):
[GW-1924
<img width="730" alt="Screenshot 2024-11-19 at 12 53 06" src="https://github.com/user-attachments/assets/a068c58a-fcc0-4052-bec2-d3dd4ab42073">
](https://technologyprogramme.atlassian.net/browse/GW-xxxx)
