### PR TITLE
Remove condition on validate_in_register? in organisation model

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -10,7 +10,7 @@ class Organisation < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :service_email, format: { with: Devise.email_regexp }
-  validate :validate_in_register?, unless: proc { |org| org.name.blank? }
+  validate :validate_in_register?
 
   validates :cba_enabled, inclusion: { in: [true, false] }, allow_nil: true
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -82,8 +82,8 @@ describe Organisation do
 
     it "explains why it is invalid" do
       organisation.valid?
-      expect(organisation.errors.full_messages).to eq([
-        "Name can't be blank",
+      expect(organisation.errors.full_messages).to match_array([
+        "Name can't be blank", "Name isn't in the organisations allow list"
       ])
     end
   end

--- a/spec/models/user_membership_form_spec.rb
+++ b/spec/models/user_membership_form_spec.rb
@@ -63,7 +63,8 @@ describe UserMembershipForm do
       it "copies the validations" do
         form.write_to(user)
         expect(form.errors.map(&:full_message)).to match_array(["Name can't be blank",
-                                                                "Service email must be in the correct format, like name@example.com"])
+                                                                "Service email must be in the correct format, like name@example.com",
+                                                                "Name isn't in the organisations allow list"])
       end
     end
   end


### PR DESCRIPTION
Since we use the DFE form builder, only one error per attribute is ever shown and so this condition can be removed.

