### PR TITLE
add certificate serial number for cba

### DIFF
--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -36,6 +36,7 @@
         <% end %>
         <% if log_search_form.ip && current_organisation&.cba_enabled? %>
           <th class="govuk-table__header" scope="col">Authentication Method</th>
+          <th class="govuk-table__header" scope="col">Certificate Serial Number</th>
         <% end %>
         <th class="govuk-table__header" scope="col">Access Point</th>
         <th class="govuk-table__header" scope="col">MAC Address</th>
@@ -65,6 +66,7 @@
           <% end %>
           <% if log_search_form.ip && is_current_organisation_cba_enabled %>
             <td class="govuk-table__cell"><%= log.eap_tls? ? "EAP-TLS" : "MSCHAP" %></td>
+            <td class="govuk-table__cell"><%= log.cert_serial %></td>
           <% end %>
           <td class="govuk-table__cell"><%= log.ap %></td>
           <td class="govuk-table__cell"><%= log.mac %></td>

--- a/lib/gateways/sessions.rb
+++ b/lib/gateways/sessions.rb
@@ -1,7 +1,7 @@
 module Gateways
   class Sessions
     MAXIMUM_RESULTS_COUNT = 500
-    SESSION_SELECT_ATTRIBUTES = %i[id start username siteIP success ap mac task_id].freeze
+    SESSION_SELECT_ATTRIBUTES = %i[id start username siteIP success ap mac task_id cert_serial].freeze
 
     def self.search(username: nil, ips: nil, success: nil, authentication_method: nil)
       new.search(username:, ips:, success:, authentication_method:)

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -8,5 +8,6 @@ FactoryBot.define do
     task_id { "arn:12345" }
     success { true }
     start { (Time.zone.now - 1.day).to_s }
+    cert_serial { Faker::Number.number(digits: 10) }
   end
 end

--- a/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_an_ip_spec.rb
@@ -11,7 +11,7 @@ describe "View authentication requests for an IP", type: :feature do
     let(:user) { create(:user, :confirm_all_memberships, organisations: [organisation]) }
 
     before do
-      create(:session, siteIP: ip_address, username: "Aaaaaa", cert_name: "EAP-TLS")
+      create(:session, siteIP: ip_address, username: "Aaaaaa", cert_name: "EAP-TLS", cert_serial: "12345")
     end
     describe "when using a link" do
       before do
@@ -24,9 +24,13 @@ describe "View authentication requests for an IP", type: :feature do
         expect(page).to have_content("Found 1 result for IP: \"#{ip_address}\"")
       end
 
-      context "when the organisations is using CBA" do
+      context "when the organisation is using CBA" do
         it "displays the certificate data" do
           expect(page).to have_content("EAP-TLS")
+        end
+
+        it "displays the certificate serial number" do
+          expect(page).to have_content("12345")
         end
       end
     end


### PR DESCRIPTION
### What

Captures the certificate serial number during authentication requests.

Stores the certificate serial number in the database to be displayed in the Admin portal.

### Why

Currently Org admins cannot correlate EAP-TLS authentication entries with an identifier making troubleshooting difficult.

The plan is to display the certificate serial number.

Link to JIRA card (if applicable):
[[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)](https://technologyprogramme.atlassian.net/browse/GW-1831)
