### PR TITLE
remove whitespace

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -14,6 +14,7 @@ class Location < ApplicationRecord
   validate :unpersisted_addresses_are_unique
   validates :radius_secret_key, length: { minimum: 10 }, on: :update
 
+  before_validation :strip_whitespace
   before_create :set_radius_secret_key
 
   def unpersisted_addresses_are_unique
@@ -36,6 +37,11 @@ class Location < ApplicationRecord
   end
 
 private
+
+  def strip_whitespace
+    self.address = address.strip if address.present?
+    self.postcode = postcode.strip if postcode.present?
+  end
 
   def validate_postcode_format
     unless UKPostcode.parse(postcode.to_s).valid? || postcode.to_s.downcase == "unknown"

--- a/spec/features/locations/add_new_location_spec.rb
+++ b/spec/features/locations/add_new_location_spec.rb
@@ -18,8 +18,8 @@ describe "Add location", type: :feature do
   context "when adding the first location" do
     context "with valid IP data" do
       before do
-        fill_in "Address", with: "30 Square"
-        fill_in "Postcode", with: "W1A 2AB"
+        fill_in "Address", with: "30 Square  "
+        fill_in "Postcode", with: "W1A 2AB  "
       end
 
       it "adds the location" do
@@ -29,6 +29,13 @@ describe "Add location", type: :feature do
       it "displays the success message to the user" do
         click_on "Add location"
         expect(page).to have_content("Added 30 Square, W1A 2AB")
+      end
+
+      it "trims the whitespace before saving" do
+        click_on "Add location"
+        location = Location.last
+        expect(location.address).to eq("30 Square")
+        expect(location.postcode).to eq("W1A 2AB")
       end
 
       it 'redirects to "After location created" path' do


### PR DESCRIPTION
### What

Remove whitespace.

### Why

Whitespace chars can end up on the end of org names, especially when copying and pasting and can cause problems with data input. This happens with org names and Post Codes.

Link to JIRA card (if applicable):
[[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)](https://technologyprogramme.atlassian.net/browse/GW-2250)
