### PR TITLE
refactor filter to search for organisations

### DIFF
--- a/app/views/shared/_filter_search.html.erb
+++ b/app/views/shared/_filter_search.html.erb
@@ -5,12 +5,13 @@
 
   function filterResults() {
     var filterValue = filterInput.value.toUpperCase();
-    var rows = document.querySelectorAll('.result-row');
+    var rows = document.querySelectorAll('tbody tr');
 
-    for(var i = 0; i < rows.length; i++) {
-      var text = rows[i].querySelectorAll('.filter-by')[0].innerHTML.toUpperCase();
-      rows[i].style.display = text.indexOf(filterValue) > -1 ? '' : 'none';
-    }
+    rows.forEach(function(row) {
+      var cell = row.querySelector('th, td');
+      var text = cell ? cell.textContent.toUpperCase() : '';
+      row.style.display = text.includes(filterValue) ? '' : 'none';
+    });
 
     displayResultsMessage(rows);
   }


### PR DESCRIPTION
### What

Updated the JavaScript used for filtering the organisations table to work with the GOV.UK Design System table component. Replaced class based filtering logic with generic table row and cell checks.

### Why

The previous filter stopped working after switching to the GOV.UK table component, which doesn't use the .result-row or .filter-by classes the old script depended on.

Link to JIRA card (if applicable):
[[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)](https://technologyprogramme.atlassian.net/browse/GW-2277)
