### PR TITLE
add data on new cba organisations to grafana

### DIFF
--- a/lib/tasks/opensearch.rake
+++ b/lib/tasks/opensearch.rake
@@ -15,6 +15,9 @@ namespace :opensearch do
     logger.info("Fetching data on new locations being added")
     Gateways::Opensearch.new("govwifi-metrics").write("new_locations-#{Time.zone.today}", UseCases::NewLocations.fetch_stats)
 
+    logger.info("Fetching data on new cba organisations being added")
+    Gateways::Opensearch.new("govwifi-metrics").write("new_cba_organisations-#{Time.zone.today}", UseCases::NewCbaOrganisations.fetch_stats)
+
     logger.info("Done.")
   end
 end

--- a/lib/use_cases/new_cba_organisations.rb
+++ b/lib/use_cases/new_cba_organisations.rb
@@ -1,0 +1,13 @@
+class UseCases::NewCbaOrganisations
+  def self.fetch_stats
+    gateway = Gateways::NewRecords.new(Organisation.where(cba_enabled: true))
+
+    {
+      metric: "new_cba_organisations",
+      date: Time.zone.today,
+      daily_new_cba_organisations: gateway.fetch_daily_count,
+      weekly_new_cba_organisations: gateway.fetch_weekly_count,
+      monthly_new_cba_organisations: gateway.fetch_monthly_count,
+    }
+  end
+end

--- a/spec/use_cases/new_cba_organisations_spec.rb
+++ b/spec/use_cases/new_cba_organisations_spec.rb
@@ -1,0 +1,24 @@
+describe UseCases::NewCbaOrganisations do
+  before do
+    Timecop.freeze(Time.zone.local(2025, 5, 22))
+
+    create(:organisation, :with_cba_enabled, created_at: Time.zone.today)
+    create(:organisation, :with_cba_enabled, created_at: 2.days.ago)
+    create(:organisation, :with_cba_enabled, created_at: 20.days.ago)
+    create(:organisation, created_at: 10.days.ago)
+
+    @date = Time.zone.today
+  end
+
+  it "displays the correct data" do
+    expect(described_class.fetch_stats).to eq(
+      {
+        metric: "new_cba_organisations",
+        date: Time.zone.today,
+        daily_new_cba_organisations: 1,
+        weekly_new_cba_organisations: 2,
+        monthly_new_cba_organisations: 3,
+      },
+    )
+  end
+end


### PR DESCRIPTION
### What

Sending daily, weekly and monthly metrics on organisations using CBA to Grafana.

### Why

We require data on organisations using CBA for GovWifi monthly reporting.


Link to JIRA card (if applicable):
[[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)](https://technologyprogramme.atlassian.net/browse/GW-2264)
