### PR TITLE
add status page link to locations

### DIFF
--- a/app/views/ips/index.html.erb
+++ b/app/views/ips/index.html.erb
@@ -10,7 +10,7 @@
     <div class="govuk-grid-column-two-thirds govuk-!-padding-0">
       <h1 class="govuk-heading-l">Locations</h1>
       <p class="govuk-!-font-size-16">
-        <%= link_to "Check the GovWifi status page", "https://status.wifi.service.gov.uk", class: "govuk-link" %>
+        <%= govuk_link_to "Check the GovWifi status page", "https://status.wifi.service.gov.uk" %>
       </p>
     </div>
     <% unless current_organisation&.meets_invited_admin_user_minimum? %>


### PR DESCRIPTION
### What

Add GovWifi status link to the ‘home’ locations page.

### Why

Admins are looking to check status more often and we don't link clearly to status page.

It will reduce support ticket requests.

Link to JIRA card (if applicable):
[[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)](https://technologyprogramme.atlassian.net/browse/GW-181)
