### PR TITLE
add mou banner

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,7 @@
     <%= render "shared/header" %>
 
     <div class="govuk-width-container">
+      <%= render "shared/mou_notification" %>
       <% if show_navigation_bars %>
         <%= render "shared/subnav/#{subnav}" %>
         <div class="govuk-grid-row">

--- a/app/views/shared/_mou_notification.html.erb
+++ b/app/views/shared/_mou_notification.html.erb
@@ -1,0 +1,17 @@
+<% if current_organisation&.resign_mou? %>
+  <div class="govuk-!-margin-top-6">
+    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+      <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+          Important
+        </h2>
+      </div>
+      <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">
+          Your organisation hasn’t signed the MOU yet.
+          <a class="govuk-notification-banner__link" href="<%= show_options_mous_path %>">Sign the memorandum of understanding</a> to continue using GovWifi.
+        </p>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/spec/features/mou/mou_notification_spec.rb
+++ b/spec/features/mou/mou_notification_spec.rb
@@ -1,0 +1,30 @@
+describe "MOU notification banner", type: :feature do
+  let(:user) { create(:user, :with_organisation) }
+  let(:organisation) { user.organisations.first }
+
+  before do
+    sign_in_user user
+  end
+
+  context "when organisation needs to sign the MOU" do
+    it "shows the notification banner with sign the MOU link" do
+      visit settings_path
+
+      expect(page).to have_css(".govuk-notification-banner")
+      expect(page).to have_content("Your organisation hasn’t signed the MOU yet.")
+      expect(page).to have_link("Sign the memorandum of understanding", href: show_options_mous_path)
+    end
+  end
+
+  context "when organisation does not need to sign the MOU" do
+    before do
+      organisation.mous.destroy_all
+      create(:mou, organisation: organisation, version: Mou.latest_known_version)
+      visit settings_path
+    end
+    it "does not show the notification banner" do
+      expect(page).not_to have_css(".govuk-notification-banner")
+      expect(page).not_to have_content("Your organisation hasn’t signed the MOU yet.")
+    end
+  end
+end


### PR DESCRIPTION
### What
Add a notification banner to organisation accounts that haven’t signed the Memorandum of Understanding (MoU)

### Why

To remind organisations to sign the MoU and ensure they are aware of the terms and conditions for using GovWifi.

Link to JIRA card (if applicable):
[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)
https://technologyprogramme.atlassian.net/browse/GW-2375
