### PR TITLE
Gw 2374 ensure new accounts can t go live until mou is s

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -150,6 +150,11 @@ private
   end
 
   def authorise_ip_actions
+    if current_organisation.resign_mou?
+      flash[:alert] = "Your organisation must sign the Memorandum of Understanding (MoU) before you can add IPs or multiple locations."
+      redirect_to ips_path and return
+    end
+
     unless current_organisation.meets_invited_admin_user_minimum?
       flash[:alert] = "You must add another administrator before you can add IPs or multiple locations."
       redirect_to ips_path

--- a/spec/features/ips/add_ip_to_existing_location_spec.rb
+++ b/spec/features/ips/add_ip_to_existing_location_spec.rb
@@ -2,6 +2,7 @@ describe "Adding an IP to an existing location", type: :feature do
   let(:user) { create(:user, :with_organisation) }
   let(:location) { create(:location, organisation: user.organisations.first) }
   let!(:another_administrator) { create(:user, organisations: [user.organisations.first]) }
+  let!(:mou) { create(:mou, organisation: user.organisations.first, version: Mou.latest_known_version) }
 
   context "when viewing the form" do
     before do
@@ -207,6 +208,20 @@ describe "Adding an IP to an existing location", type: :feature do
 
     it "shows error summary" do
       expect(page).to have_content("There is a problem\nYou must add another administrator before you can add IPs or multiple locations.")
+    end
+  end
+
+  context "when the organisation has not signed the MoU" do
+    before do
+      user.organisations.first.mous.destroy_all
+    end
+
+    it "redirects to IPs page with an alert" do
+      sign_in_user user
+      visit location_add_ips_path(location_id: location.id)
+
+      expect(page).to have_current_path(ips_path)
+      expect(page).to have_content("Your organisation must sign the Memorandum of Understanding (MoU) before you can add IPs or multiple locations.")
     end
   end
 end

--- a/spec/features/ips/first_ip_survey_spec.rb
+++ b/spec/features/ips/first_ip_survey_spec.rb
@@ -4,6 +4,7 @@ describe "Sending a survey when adding the first IP to an organisation", type: :
   let(:organisation) { user.organisations.first }
   let(:location) { create(:location, organisation:) }
   let!(:another_administrator) { create(:user, organisations: [user.organisations.first]) } # a minimium of two administrators are now required to add IP addresses
+  let!(:mou) { create(:mou, organisation: user.organisations.first, version: Mou.latest_known_version) } # Signed MoU required to add IP addresses
   let(:notify_gateway) { Services.notify_gateway }
   before do
     sign_in_user user

--- a/spec/features/ips/view_ip_address_readiness_spec.rb
+++ b/spec/features/ips/view_ip_address_readiness_spec.rb
@@ -3,6 +3,7 @@ describe "View whether IPs are ready", type: :feature do
     let(:user) { create(:user, :with_organisation) }
     let!(:another_administrator) { create(:user, organisations: [user.organisations.first]) }
     let!(:location) { create(:location, organisation: user.organisations.first) }
+    let!(:mou) { create(:mou, organisation: user.organisations.first, version: Mou.latest_known_version) }
 
     before do
       sign_in_user user

--- a/spec/features/locations/bulk_upload_spec.rb
+++ b/spec/features/locations/bulk_upload_spec.rb
@@ -1,6 +1,7 @@
 describe "Bulk upload locations and IPs", type: :feature do
   let(:user) { create(:user, :with_organisation) }
   let(:organisation) { user.organisations.first }
+  let!(:mou) { create(:mou, organisation: user.organisations.first, version: Mou.latest_known_version) }
 
   context "when there is only one administrator for the organisation" do
     before do

--- a/spec/features/track_new_organisations_spec.rb
+++ b/spec/features/track_new_organisations_spec.rb
@@ -1,6 +1,7 @@
 describe "Tracking new organisations", type: :feature do
   let(:user) { create(:user, :with_organisation) }
   let!(:another_administrator) { create(:user, organisations: [user.organisations.first]) }
+  let!(:mou) { create(:mou, organisation: user.organisations.first, version: Mou.latest_known_version) }
 
   before do
     sign_in_user user


### PR DESCRIPTION
### What

Restrict IP creation if MoU not signed.

### Why

We require organisations to accept terms and conditions before using GovWifi.

Link to JIRA card (if applicable):
[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)
https://technologyprogramme.atlassian.net/browse/GW-2374
