### PR TITLE
only show when user signed in

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,8 +39,8 @@
     <%= render "shared/header" %>
 
     <div class="govuk-width-container">
-      <%= render "shared/mou_notification" %>
       <% if show_navigation_bars %>
+        <%= render "shared/mou_notification" %>
         <%= render "shared/subnav/#{subnav}" %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-one-quarter">

--- a/spec/features/mou/mou_notification_spec.rb
+++ b/spec/features/mou/mou_notification_spec.rb
@@ -2,29 +2,38 @@ describe "MOU notification banner", type: :feature do
   let(:user) { create(:user, :with_organisation) }
   let(:organisation) { user.organisations.first }
 
-  before do
-    sign_in_user user
-  end
-
-  context "when organisation needs to sign the MOU" do
-    it "shows the notification banner with sign the MOU link" do
-      visit settings_path
-
-      expect(page).to have_css(".govuk-notification-banner")
-      expect(page).to have_content("Your organisation hasn’t signed the MOU yet.")
-      expect(page).to have_link("Sign the memorandum of understanding", href: show_options_mous_path)
-    end
-  end
-
-  context "when organisation does not need to sign the MOU" do
-    before do
-      organisation.mous.destroy_all
-      create(:mou, organisation: organisation, version: Mou.latest_known_version)
-      visit settings_path
-    end
-    it "does not show the notification banner" do
-      expect(page).not_to have_css(".govuk-notification-banner")
+  context "when the user is not signed in" do
+    before { visit root_path }
+    it "does not show the MOU notification banner" do
       expect(page).not_to have_content("Your organisation hasn’t signed the MOU yet.")
+    end
+  end
+
+  context "when the user is signed in" do
+    before do
+      sign_in_user user
+    end
+
+    context "when organisation needs to sign the MOU" do
+      it "shows the notification banner with sign the MOU link" do
+        visit settings_path
+
+        expect(page).to have_css(".govuk-notification-banner")
+        expect(page).to have_content("Your organisation hasn’t signed the MOU yet.")
+        expect(page).to have_link("Sign the memorandum of understanding", href: show_options_mous_path)
+      end
+    end
+
+    context "when organisation does not need to sign the MOU" do
+      before do
+        organisation.mous.destroy_all
+        create(:mou, organisation: organisation, version: Mou.latest_known_version)
+        visit settings_path
+      end
+      it "does not show the notification banner" do
+        expect(page).not_to have_css(".govuk-notification-banner")
+        expect(page).not_to have_content("Your organisation hasn’t signed the MOU yet.")
+      end
     end
   end
 end


### PR DESCRIPTION
### What

MOU banner should only show when the user has signed in

### Why

Describe why the change was necessary

Link to JIRA card (if applicable):
[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)
https://technologyprogramme.atlassian.net/browse/GW-2449
