### PR TITLE
Add Yarn To Dependabot Nightly Security Check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: daily
       time: "03:00"
     open-pull-requests-limit: 10
+  - package-ecosystem: yarn
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "03:00"
   - package-ecosystem: npm
     directory: "/"
     schedule:


### PR DESCRIPTION
### What
Add Yarn To Dependabot Nightly Security Check

### Why
Dependabot was previously not checking this, and it is good practice to check everything for vulnerabilities.

