### PR TITLE
Revert "Add Yarn To Dependabot Nightly Security Check"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,6 @@ updates:
       interval: daily
       time: "03:00"
     open-pull-requests-limit: 10
-  - package-ecosystem: yarn
-    directory: "/"
-    schedule:
-      interval: daily
-      time: "03:00"
   - package-ecosystem: npm
     directory: "/"
     schedule:


### PR DESCRIPTION
Reverts GovWifi/govwifi-admin#2443

Reverting as we now have akido and this is erroring with our dependabot installation:
https://github.com/GovWifi/govwifi-admin/runs/50573589328
The property '#/updates/1/package-ecosystem' value "yarn" did not match one of the following values: npm, bundler, composer, devcontainers, dotnet-sdk, maven, mix, cargo, gradle, nuget, gomod, docker, docker-compose, elm, gitsubmodule, github-actions, pip, terraform, pub, rust-toolchain, swift, bun, uv, vcpkg, helm, conda


