### PR TITLE
search mac addresses regardless of seperator

### DIFF
--- a/lib/gateways/sessions.rb
+++ b/lib/gateways/sessions.rb
@@ -16,7 +16,12 @@ module Gateways
 
       results = results.where(username:) unless username.nil?
       results = results.where(siteIP: ips) unless ips.nil?
-      results = results.where(mac: mac) if mac.present?
+      if mac.present?
+        normalised = mac.gsub(/[^0-9A-Fa-f]/, "").upcase
+        results = results.where(
+          "UPPER(REPLACE(REPLACE(mac, ':', ''), '-', '')) = ?", normalised
+        )
+      end
       results = results.where(success:) if success.present?
       if authentication_method.present?
         results = if authentication_method == "true"

--- a/spec/features/logging/view_auth_requests_for_a_mac_address_spec.rb
+++ b/spec/features/logging/view_auth_requests_for_a_mac_address_spec.rb
@@ -7,7 +7,6 @@ describe "View authentication requests for a mac address", type: :feature do
   let(:other_ip) { "6.6.6.6" }
   let!(:sessions) do
     create(:session, mac: "b9:e0:ba:aa:08:7e", username: "AAAAAA", siteIP: ip_organisation_one, success: true)
-    create(:session, mac: "b9-e0-ba-aa-08-7e", username: "AAAAAA", siteIP: ip_organisation_one, success: true)
     create(:session, mac: "b9:e0:ba:aa:08:7d", username: "AAAAAA", siteIP: ip_organisation_one, success: true)
     create(:session, mac: "b9:e0:ba:aa:08:7e", username: "AAAAAA", siteIP: ip_organisation_one, success: false)
     create(:session, mac: "a9:e0:cc:bb:08:3e", username: "AAAAAA", siteIP: ip_organisation_two, success: true)
@@ -77,11 +76,18 @@ describe "View authentication requests for a mac address", type: :feature do
       end
     end
 
-    describe "Searching mac addresses separated by hyphens" do
-      let(:search_string) { "b9-e0-ba-aa-08-7e" }
+    describe "searching MAC addresses regardless of separator and case" do
+      [
+        "b9-e0-ba-aa-08-7e", # lowercase and hyphens
+        "B9:E0:BA:AA:08:7E", # uppercase and colons
+      ].each do |mac|
+        context "when searching for '#{mac}'" do
+          let(:search_string) { mac }
 
-      it "displays the search results of the mac address" do
-        expect(page).to have_content(ip_organisation_one)
+          it "displays the search results of the MAC address" do
+            expect(page).to have_content(ip_organisation_one)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
### What

Currently when admins search logs using MAC addresses that contain colons (e.g., ba:ea:71:4e:84:51), no results are returned. Logs only appear if the MAC address is searched with hyphens (e.g., ba-ea-71-4e-84-51). This creates confusion and slows down investigations.

### Why

We are updating log search functionality to accept MAC addresses in multiple formats, including both colons and hyphens.

Admins often copy and paste MAC addresses directly from devices or tools, which frequently use colons as separators. Requiring admins to reformat the address to hyphens is unintuitive and wastes time. Supporting multiple formats will make log searches more reliable and user friendly.

Reduces friction in troubleshooting and investigations. Prevents missed log results caused by inconsistent formatting.

Link to JIRA card (if applicable):
[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)
https://technologyprogramme.atlassian.net/browse/GW-2447
