### PR TITLE
Updated net-imap to resolve dependabot alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,7 +294,7 @@ GEM
       bigdecimal
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.5.12)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)


### PR DESCRIPTION
### What
Updated net-imap to resolve a vulnerability with the library centered around
escalation attack potential.

### Why
net-imap needed to be upgraded to prevent escalation attacks.

Link to JIRA card (if applicable):
https://github.com/GovWifi/govwifi-admin/security/dependabot
