### PR TITLE
Upgrade Admin DB Version To MYSQL 8.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: "mysql:8.0"
+    image: "mysql:8.4"
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: root


### PR DESCRIPTION
### What
Upgrade Admin Database to 8.4

### Why
Upgrading mysql to as 8.0 will soon be unsupported. Also makes
moving toward 9.0 easier


Jira card: https://technologyprogramme.atlassian.net/browse/GW-2793