### PR TITLE
enforce IP location referential integrity with cascading deletes

### DIFF
--- a/db/migrate/20260529103602_add_foreign_key_to_ips.rb
+++ b/db/migrate/20260529103602_add_foreign_key_to_ips.rb
@@ -1,0 +1,6 @@
+class AddForeignKeyToIps < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :ips, :location_id, false
+    add_foreign_key :ips, :locations, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_23_164928) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_29_103602) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -72,7 +72,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_23_164928) do
     t.string "address"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.bigint "location_id"
+    t.bigint "location_id", null: false
     t.index ["address"], name: "index_ips_on_address", unique: true
     t.index ["location_id"], name: "index_ips_on_location_id"
   end
@@ -191,6 +191,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_23_164928) do
   end
 
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "ips", "locations", on_delete: :cascade
   add_foreign_key "mous", "organisations"
   add_foreign_key "mous", "users"
   add_foreign_key "nominations", "organisations"

--- a/spec/models/ip_spec.rb
+++ b/spec/models/ip_spec.rb
@@ -1,9 +1,18 @@
 describe Ip do
-  subject(:ip_address) { described_class.new }
+  subject(:ip_address) { build(:ip) }
 
   it { is_expected.to belong_to(:location) }
   it { is_expected.to validate_presence_of(:address) }
-  it { is_expected.to validate_uniqueness_of(:address) }
+
+  describe "address uniqueness" do
+    it "does not allow duplicate addresses" do
+      create(:ip, address: "141.0.0.10")
+      duplicate = build(:ip, address: "141.0.0.10")
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors.of_kind?(:address, :taken)).to be true
+    end
+  end
 
   # rubocop:disable Rails/SaveBang
 

--- a/spec/use_cases/radius/publish_radius_ip_allowlist_spec.rb
+++ b/spec/use_cases/radius/publish_radius_ip_allowlist_spec.rb
@@ -56,7 +56,7 @@ client 2-2-2-2 {
 
   context "when an invalid IP has been accidentally saved to the DB" do
     it "ignores this IP address" do
-      Ip.new(address: "1.2.3.1").save!(validate: false)
+      Ip.new(address: "1.2.3.1", location: location1).save!(validate: false)
       expect { described_class.new.execute }.to_not raise_error
     end
   end


### PR DESCRIPTION
### What

Enforce IP location referential integrity with cascading deletes

### Why

Investigation identified that the ips table does not currently enforce referential integrity with the locations table. The table only contains an index on location_id and does not have a foreign key constraint.

As a result, orphaned IP records exist within the database:

2 IP records reference a deleted/non-existent location (location_id = 580)

1 IP record has a NULL location_id

The Rails associations are already configured with:

Ip model: belongs_to :location

Location model: has_many :ips, dependent: :destroy

This indicates that application-level cleanup is already implemented correctly when records are deleted through Rails. However, database-level referential integrity is not enforced, meaning orphaned IP records can still be created when operations bypass Rails (e.g. direct SQL operations, scripts, imports, or use of delete instead of destroy).

Changes to be implemented:

Check whether these IPs are being used (done)

Remove existing orphaned/invalid IP records (staging and prod)

Add a foreign key constraint between ips.location_id and locations.id

Configure ON DELETE CASCADE to automatically remove associated IPs when a location is deleted

Consider making location_id non-nullable if every IP must belong to a location

These changes will ensure referential integrity is enforced at the database level and prevent orphaned IP records from being created in future.

Link to JIRA card (if applicable):
[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)
https://technologyprogramme.atlassian.net/browse/GW-2762
