### PR TITLE
Upgrade Sessions DB Version To MYSQL 8.4

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,3 +1,3 @@
-FROM mysql:8.0
+FROM mysql:8.4
 
 ADD rr_schema.sql /docker-entrypoint-initdb.d


### PR DESCRIPTION
### What
Upgrade Sessions DB Version To MYSQL 8.4

### Why
This is to match the version we are now running in production. It relates to: GovWifi/govwifi-terraform/pull/1020

Link to JIRA card (if applicable):
https://technologyprogramme.atlassian.net/browse/GW-2813
