### PR TITLE
Bump version for govwifi-shared-frontend to 0.6.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "accessible-autocomplete": "^3.0.1",
     "govuk-frontend": "^5.14.0",
-    "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.21/govwifi-shared-frontend-0.6.21.tgz",
+    "govwifi-shared-frontend": "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.26/govwifi-shared-frontend-0.6.26.tgz",
     "hmrc-frontend": "6.113.0",
     "html5shiv": "^3.7.3",
     "postcss": "^8.5.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -389,11 +389,11 @@ govuk-frontend@^5.14.0:
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.14.0.tgz#d93f1ffa88b0696114509cab86e4ea474006f8e0"
   integrity sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==
 
-"govwifi-shared-frontend@https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.21/govwifi-shared-frontend-0.6.21.tgz":
-  version "0.6.21"
-  resolved "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.21/govwifi-shared-frontend-0.6.21.tgz#c9c4f2e4b2b7e2dfdaa87422a36a72080cfd2ef4"
+"govwifi-shared-frontend@https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.26/govwifi-shared-frontend-0.6.26.tgz":
+  version "0.6.26"
+  resolved "https://github.com/GovWifi/govwifi-shared-frontend/releases/download/v0.6.26/govwifi-shared-frontend-0.6.26.tgz#c7c130f32d9a211f0ffb8be04b755a449be63605"
   dependencies:
-    js-cookie "^3.0.7"
+    js-cookie "^3.0.8"
 
 hard-rejection@^2.1.0:
   version "2.1.0"
@@ -532,10 +532,10 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-js-cookie@^3.0.7:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.7.tgz#0a53abfc459c8e89c85d7a38eb6cb68714965b8c"
-  integrity sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==
+js-cookie@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.8.tgz#444e6f4b27a5d844594fef61c9d6bca5f0787688"
+  integrity sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
### What

Bump govwifi-shared-frontend to 0.6.26

### Why

Bump govwifi-shared-frontend to 0.6.26

Link to JIRA card (if applicable):
[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)
