### PR TITLE
How many Organisations have dormant administrators?

### DIFF
--- a/lib/tasks/publish_orgs_with_dormant_admins_count.rake
+++ b/lib/tasks/publish_orgs_with_dormant_admins_count.rake
@@ -1,0 +1,11 @@
+require "logger"
+logger = Logger.new($stdout)
+
+namespace :metrics do
+  desc "Publish orgs with dormant admins count to S3 and post to metrics API"
+  task publish_orgs_with_dormant_admins_count: :environment do
+    logger.info("BEGIN: Publishing orgs with dormant admins count...")
+    UseCases::Administrator::PublishOrgsWithDormantAdminsCount.new.publish
+    logger.info("END: Publishing orgs with dormant admins count")
+  end
+end

--- a/lib/use_cases/administrator/publish_orgs_with_dormant_admins_count.rb
+++ b/lib/use_cases/administrator/publish_orgs_with_dormant_admins_count.rb
@@ -1,0 +1,71 @@
+require "logger"
+
+module UseCases
+  module Administrator
+    class PublishOrgsWithDormantAdminsCount
+      METRIC_NAME = "account-health-orgs-with-dormant-admins-count".freeze
+      S3_FOLDER = "account-health-orgs-with-dormant-admins-count".freeze
+      DORMANT_AFTER = 365.days
+
+      def initialize(logger: Logger.new($stdout))
+        @logger = logger
+      end
+
+      def publish
+        send_to_s3
+        send_to_api
+      end
+
+    private
+
+      def today
+        @today ||= Time.zone.today
+      end
+
+      def metric
+        @metric ||= ::Organisation
+          .joins(memberships: :user)
+          .where(memberships: { can_manage_locations: true, can_manage_team: true })
+          .where.not(name: nil)
+          .where("users.last_sign_in_at < ? OR users.last_sign_in_at IS NULL", DORMANT_AFTER.ago)
+          .group(:name)
+          .having("COUNT(*) < 2")
+          .count
+          .size
+      end
+
+      def stats
+        {
+          metric_name: METRIC_NAME,
+          count: metric,
+          run_time: today,
+        }
+      end
+
+      def s3_key
+        "#{S3_FOLDER}/orgs-with-dormant-admins-count-#{today.iso8601}"
+      end
+
+      def s3_payload
+        {
+          count: metric,
+          metric_name: METRIC_NAME,
+          period: "day",
+          date: today.iso8601,
+        }
+      end
+
+      def send_to_s3
+        @logger.info("BEGIN: Writing to S3 bucket...")
+        Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).write("#{s3_payload.to_json}\n")
+        @logger.info("END: Writing to S3 bucket - (Orgs with dormant admins count: #{metric})")
+      end
+
+      def send_to_api
+        @logger.info("BEGIN: Posting to metrics API...")
+        UseCases::PerformancePlatform::MetricsApiPublisher.publish(stats)
+        @logger.info("END: Posting to metrics API - (Orgs with dormant admins count: #{metric})")
+      end
+    end
+  end
+end

--- a/spec/use_cases/administrator/publish_orgs_with_dormant_admins_count_spec.rb
+++ b/spec/use_cases/administrator/publish_orgs_with_dormant_admins_count_spec.rb
@@ -1,0 +1,143 @@
+describe UseCases::Administrator::PublishOrgsWithDormantAdminsCount do
+  subject(:use_case) { described_class.new }
+
+  let(:today) { Time.zone.local(2026, 7, 17) }
+  let(:dormant_sign_in) { 366.days.ago }
+  let(:active_sign_in) { 1.day.ago }
+
+  let(:s3_key) { "account-health-orgs-with-dormant-admins-count/orgs-with-dormant-admins-count-2026-07-17" }
+  let(:metrics_api_endpoint) { "https://metrics.test.example.com" }
+  let(:api_endpoint) { "#{metrics_api_endpoint}/v1/record" }
+
+  def dormant_admin_membership(organisation:)
+    create(:membership, organisation:, user: create(:user, last_sign_in_at: dormant_sign_in))
+  end
+
+  def active_admin_membership(organisation:)
+    create(:membership, organisation:, user: create(:user, last_sign_in_at: active_sign_in))
+  end
+
+  def never_signed_in_admin_membership(organisation:)
+    create(:membership, organisation:, user: create(:user, last_sign_in_at: nil))
+  end
+
+  def view_only_dormant_membership(organisation:)
+    create(:membership, organisation:, can_manage_team: false, can_manage_locations: false,
+                         user: create(:user, last_sign_in_at: dormant_sign_in))
+  end
+
+  before do
+    stub_request(:post, api_endpoint).to_return(status: 200, body: "", headers: {})
+  end
+
+  around do |example|
+    original_endpoint = ENV["METRICS_API_ENDPOINT"]
+    ENV["METRICS_API_ENDPOINT"] = metrics_api_endpoint
+    Timecop.freeze(today) { example.run }
+    ENV["METRICS_API_ENDPOINT"] = original_endpoint
+  end
+
+  context "when an organisation has exactly one dormant admin" do
+    it "counts it" do
+      organisation = create(:organisation)
+      dormant_admin_membership(organisation:)
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)).to eq(
+        "count" => 1,
+        "metric_name" => "account-health-orgs-with-dormant-admins-count",
+        "period" => "day",
+        "date" => "2026-07-17",
+      )
+    end
+  end
+
+  context "when an organisation has two or more dormant admins" do
+    it "does not count it" do
+      organisation = create(:organisation)
+      dormant_admin_membership(organisation:)
+      dormant_admin_membership(organisation:)
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(0)
+    end
+  end
+
+  context "when the dormant member does not have admin permissions" do
+    it "does not count the organisation" do
+      organisation = create(:organisation)
+      view_only_dormant_membership(organisation:)
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(0)
+    end
+  end
+
+  context "when the sole admin has signed in recently" do
+    it "does not count the organisation" do
+      organisation = create(:organisation)
+      active_admin_membership(organisation:)
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(0)
+    end
+  end
+
+  context "when the sole admin has never signed in" do
+    it "counts the organisation as dormant" do
+      organisation = create(:organisation)
+      never_signed_in_admin_membership(organisation:)
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(1)
+    end
+  end
+
+  context "when multiple organisations qualify" do
+    it "aggregates the count across organisations" do
+      dormant_admin_membership(organisation: create(:organisation))
+      dormant_admin_membership(organisation: create(:organisation))
+      active_admin_membership(organisation: create(:organisation))
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(2)
+    end
+  end
+
+  context "when no organisations qualify" do
+    it "publishes a zero count rather than erroring" do
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(0)
+    end
+  end
+
+  it "posts the count to the metrics api" do
+    dormant_admin_membership(organisation: create(:organisation))
+
+    use_case.publish
+
+    expect(a_request(:post, api_endpoint).with(
+      body: {
+        "name" => "account-health-orgs-with-dormant-admins-count",
+        "value" => "1",
+        "datetime" => "2026-07-17T00:00:00Z",
+      }.to_json,
+    )).to have_been_made
+  end
+
+  context "when the metrics api request fails" do
+    it "does not raise" do
+      stub_request(:post, api_endpoint).to_timeout
+      dormant_admin_membership(organisation: create(:organisation))
+
+      expect { use_case.publish }.not_to raise_error
+    end
+  end
+end

--- a/spec/use_cases/administrator/publish_orgs_with_dormant_admins_count_spec.rb
+++ b/spec/use_cases/administrator/publish_orgs_with_dormant_admins_count_spec.rb
@@ -23,7 +23,7 @@ describe UseCases::Administrator::PublishOrgsWithDormantAdminsCount do
 
   def view_only_dormant_membership(organisation:)
     create(:membership, organisation:, can_manage_team: false, can_manage_locations: false,
-                         user: create(:user, last_sign_in_at: dormant_sign_in))
+                        user: create(:user, last_sign_in_at: dormant_sign_in))
   end
 
   before do
@@ -124,12 +124,12 @@ describe UseCases::Administrator::PublishOrgsWithDormantAdminsCount do
     use_case.publish
 
     expect(a_request(:post, api_endpoint).with(
-      body: {
-        "name" => "account-health-orgs-with-dormant-admins-count",
-        "value" => "1",
-        "datetime" => "2026-07-17T00:00:00Z",
-      }.to_json,
-    )).to have_been_made
+             body: {
+               "name" => "account-health-orgs-with-dormant-admins-count",
+               "value" => "1",
+               "datetime" => "2026-07-17T00:00:00Z",
+             }.to_json,
+           )).to have_been_made
   end
 
   context "when the metrics api request fails" do


### PR DESCRIPTION
## How many Organisations have dormant administrators?

### What

- Adds a new rake task, `metrics:publish_orgs_with_dormant_admins_count`, that counts organisations relying on a single dormant admin
- Publishes the daily count to S3 (`account-health-orgs-with-dormant-admins-count/orgs-with-dormant-admins-count-<date>`) and posts it to the Metrics API, following the same pattern as `publish_organisation_count`
- Includes spec coverage for the counting logic, edge cases, S3 output, and Metrics API publishing

### Why

- Account health reporting needs visibility into organisations at risk of losing admin access, where the only qualifying admin hasn't signed in for over a year
- This mirrors an existing, already-scheduled metric so it slots into the current dashboard/reporting pipeline with no new infrastructure pattern

### Link to JIRA card (if applicable):

- [GW-2741](https://technologyprogramme.atlassian.net/browse/GW-2741)
