### PR TITLE
How many Organisations have less than two admins?

### DIFF
--- a/lib/tasks/publish_orgs_with_less_than_two_admins_count.rake
+++ b/lib/tasks/publish_orgs_with_less_than_two_admins_count.rake
@@ -1,0 +1,11 @@
+require "logger"
+logger = Logger.new($stdout)
+
+namespace :metrics do
+  desc "Publish orgs with less than two admins count to S3 and post to metrics API"
+  task publish_orgs_with_less_than_two_admins_count: :environment do
+    logger.info("BEGIN: Publishing orgs with less than two admins count...")
+    UseCases::Administrator::PublishOrgsWithLessThanTwoAdminsCount.new.publish
+    logger.info("END: Publishing orgs with less than two admins count")
+  end
+end

--- a/lib/use_cases/administrator/publish_orgs_with_less_than_two_admins_count.rb
+++ b/lib/use_cases/administrator/publish_orgs_with_less_than_two_admins_count.rb
@@ -1,0 +1,71 @@
+require "logger"
+
+module UseCases
+  module Administrator
+    class PublishOrgsWithLessThanTwoAdminsCount
+      METRIC_NAME = "account-health-orgs-with-less-than-two-admins-count".freeze
+      S3_FOLDER = "account-health-orgs-with-less-than-two-admins-count".freeze
+
+      def initialize(logger: Logger.new($stdout))
+        @logger = logger
+      end
+
+      def publish
+        send_to_s3
+        send_to_api
+      end
+
+    private
+
+      def today
+        @today ||= Time.zone.today
+      end
+
+      # The inner join filters to admin memberships before grouping, so an org with zero
+      # admin memberships never forms a group and is excluded rather than counted as "0".
+      def metric
+        @metric ||= ::Organisation
+          .joins(memberships: :user)
+          .where(memberships: { can_manage_locations: true, can_manage_team: true })
+          .where.not(name: nil)
+          .group(:name)
+          .having("COUNT(*) < 2")
+          .count
+          .size
+      end
+
+      def stats
+        {
+          metric_name: METRIC_NAME,
+          count: metric,
+          run_time: today,
+        }
+      end
+
+      def s3_key
+        "#{S3_FOLDER}/orgs-with-less-than-two-admins-count-#{today.iso8601}"
+      end
+
+      def s3_payload
+        {
+          count: metric,
+          metric_name: METRIC_NAME,
+          period: "day",
+          date: today.iso8601,
+        }
+      end
+
+      def send_to_s3
+        @logger.info("BEGIN: Writing to S3 bucket...")
+        Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).write("#{s3_payload.to_json}\n")
+        @logger.info("END: Writing to S3 bucket - (Orgs with less than two admins count: #{metric})")
+      end
+
+      def send_to_api
+        @logger.info("BEGIN: Posting to metrics API...")
+        UseCases::PerformancePlatform::MetricsApiPublisher.publish(stats)
+        @logger.info("END: Posting to metrics API - (Orgs with less than two admins count: #{metric})")
+      end
+    end
+  end
+end

--- a/spec/use_cases/administrator/publish_orgs_with_less_than_two_admins_count_spec.rb
+++ b/spec/use_cases/administrator/publish_orgs_with_less_than_two_admins_count_spec.rb
@@ -1,0 +1,159 @@
+describe UseCases::Administrator::PublishOrgsWithLessThanTwoAdminsCount do
+  subject(:use_case) { described_class.new }
+
+  let(:today) { Time.zone.local(2026, 7, 17) }
+
+  let(:s3_key) do
+    "account-health-orgs-with-less-than-two-admins-count/" \
+      "orgs-with-less-than-two-admins-count-2026-07-17"
+  end
+  let(:metrics_api_endpoint) { "https://metrics.test.example.com" }
+  let(:api_endpoint) { "#{metrics_api_endpoint}/v1/record" }
+
+  def admin_membership(organisation:)
+    create(:membership, organisation:, user: create(:user))
+  end
+
+  def view_only_membership(organisation:)
+    create(:membership, organisation:, can_manage_team: false, can_manage_locations: false,
+                        user: create(:user))
+  end
+
+  def manage_locations_only_membership(organisation:)
+    create(:membership, organisation:, can_manage_team: false, can_manage_locations: true,
+                        user: create(:user))
+  end
+
+  before do
+    stub_request(:post, api_endpoint).to_return(status: 200, body: "", headers: {})
+  end
+
+  around do |example|
+    original_endpoint = ENV["METRICS_API_ENDPOINT"]
+    ENV["METRICS_API_ENDPOINT"] = metrics_api_endpoint
+    Timecop.freeze(today) { example.run }
+    ENV["METRICS_API_ENDPOINT"] = original_endpoint
+  end
+
+  def published_count
+    JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]
+  end
+
+  context "when an organisation has only a non-admin membership" do
+    it "is not counted, since the query inner-joins on admin memberships only" do
+      organisation = create(:organisation)
+      view_only_membership(organisation:)
+
+      use_case.publish
+
+      expect(published_count).to eq(0)
+    end
+  end
+
+  context "when an organisation has exactly one admin" do
+    it "counts it" do
+      organisation = create(:organisation)
+      admin_membership(organisation:)
+
+      use_case.publish
+
+      expect(published_count).to eq(1)
+    end
+  end
+
+  context "when an organisation has exactly two admins" do
+    it "does not count it" do
+      organisation = create(:organisation)
+      admin_membership(organisation:)
+      admin_membership(organisation:)
+
+      use_case.publish
+
+      expect(published_count).to eq(0)
+    end
+  end
+
+  context "when an organisation has three or more admins" do
+    it "does not count it" do
+      organisation = create(:organisation)
+      admin_membership(organisation:)
+      admin_membership(organisation:)
+      admin_membership(organisation:)
+
+      use_case.publish
+
+      expect(published_count).to eq(0)
+    end
+  end
+
+  context "when an org has one admin and one membership with only one of the two admin permissions" do
+    it "does not count the partial-permission membership as an admin" do
+      organisation = create(:organisation)
+      admin_membership(organisation:)
+      manage_locations_only_membership(organisation:)
+
+      use_case.publish
+
+      expect(published_count).to eq(1)
+    end
+  end
+
+  context "when multiple organisations qualify" do
+    it "aggregates the count across organisations" do
+      admin_membership(organisation: create(:organisation))
+      admin_membership(organisation: create(:organisation))
+
+      two_admin_org = create(:organisation)
+      admin_membership(organisation: two_admin_org)
+      admin_membership(organisation: two_admin_org)
+
+      use_case.publish
+
+      expect(published_count).to eq(2)
+    end
+  end
+
+  context "when no organisations exist" do
+    it "publishes a zero count rather than erroring" do
+      use_case.publish
+
+      expect(published_count).to eq(0)
+    end
+  end
+
+  it "publishes the exact expected S3 payload" do
+    admin_membership(organisation: create(:organisation))
+
+    use_case.publish
+
+    expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)).to eq(
+      "count" => 1,
+      "metric_name" => "account-health-orgs-with-less-than-two-admins-count",
+      "period" => "day",
+      "date" => "2026-07-17",
+    )
+  end
+
+  it "posts the count to the metrics api" do
+    admin_membership(organisation: create(:organisation))
+
+    use_case.publish
+
+    expect(a_request(:post, api_endpoint).with(
+             body: {
+               "name" => "account-health-orgs-with-less-than-two-admins-count",
+               "value" => "1",
+               "datetime" => "2026-07-17T00:00:00Z",
+             }.to_json,
+           )).to have_been_made
+  end
+
+  context "when the metrics api request fails" do
+    it "does not raise" do
+      stub_request(:post, api_endpoint).to_timeout
+      admin_membership(organisation: create(:organisation))
+
+      expect { use_case.publish }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
### What

- Adds `metrics:publish_orgs_with_less_than_two_admins_count`, following the same S3 + Metrics API publish pattern as `metrics:publish_orgs_with_dormant_admins_count`
- Counts organisations with fewer than two users holding admin permissions (`can_manage_locations` and `can_manage_team` both true), no sign-in-recency filtering
- Adds full spec coverage: admin-count boundaries, permission edge cases, multi-org aggregation, S3 payload shape, Metrics API POST body, and API-failure resilience

### Why

- Organisations with fewer than two admins risk losing management access entirely if their sole admin leaves
- This is an account-health signal worth tracking daily alongside the existing dormant-admins metric
- Feeds the existing Tableau/metrics dashboard pipeline via the same S3 + Metrics API path as other account-health metrics

### Link to JIRA card (if applicable):

- [GW-2738](https://technologyprogramme.atlassian.net/browse/GW-2738)