### PR TITLE
Update Support Email Address

### DIFF
--- a/app/views/users/two_factor_authentication_setup/show.html.erb
+++ b/app/views/users/two_factor_authentication_setup/show.html.erb
@@ -24,7 +24,7 @@
       <% end %>
 
       <div class="govuk-body">
-        If you cannot set up two factor authentication, contact <a href="mailto:govwifi-support@digital.cabinet-office.gov.uk" class="govuk-link">govwifi-support@digital.cabinet-office.gov.uk</a>
+        If you cannot set up two factor authentication, contact <a href="mailto:govwifi-support@cabinetoffice.gov.uk" class="govuk-link">govwifi-support@cabinetoffice.gov.uk</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### What
Update Support Email Address

### Why
The support email address has now changed, as we are updating our google groups and email address following the GDS/DSIT move

