### PR TITLE
How Organisations with no signed MOU?

### DIFF
--- a/lib/tasks/publish_orgs_with_no_signed_mou_count.rake
+++ b/lib/tasks/publish_orgs_with_no_signed_mou_count.rake
@@ -1,0 +1,11 @@
+require "logger"
+logger = Logger.new($stdout)
+
+namespace :metrics do
+  desc "Publish orgs with no signed MOU count to S3 and post to metrics API"
+  task publish_orgs_with_no_signed_mou_count: :environment do
+    logger.info("BEGIN: Publishing orgs with no signed MOU count...")
+    UseCases::Administrator::PublishOrgsWithNoSignedMouCount.new.publish
+    logger.info("END: Publishing orgs with no signed MOU count")
+  end
+end

--- a/lib/use_cases/administrator/publish_orgs_with_no_signed_mou_count.rb
+++ b/lib/use_cases/administrator/publish_orgs_with_no_signed_mou_count.rb
@@ -1,0 +1,62 @@
+require "logger"
+
+module UseCases
+  module Administrator
+    class PublishOrgsWithNoSignedMouCount
+      METRIC_NAME = "account-health-orgs-with-no-signed-mou-count".freeze
+      S3_FOLDER = "account-health-orgs-with-no-signed-mou-count".freeze
+
+      def initialize(logger: Logger.new($stdout))
+        @logger = logger
+      end
+
+      def publish
+        send_to_s3
+        send_to_api
+      end
+
+    private
+
+      def today
+        @today ||= Time.zone.today
+      end
+
+      def metric
+        @metric ||= ::Organisation.where.missing(:mous).count(:id)
+      end
+
+      def stats
+        {
+          metric_name: METRIC_NAME,
+          count: metric,
+          run_time: today,
+        }
+      end
+
+      def s3_key
+        "#{S3_FOLDER}/orgs-with-no-signed-mou-count-#{today.iso8601}"
+      end
+
+      def s3_payload
+        {
+          count: metric,
+          metric_name: METRIC_NAME,
+          period: "day",
+          date: today.iso8601,
+        }
+      end
+
+      def send_to_s3
+        @logger.info("BEGIN: Writing to S3 bucket...")
+        Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).write("#{s3_payload.to_json}\n")
+        @logger.info("END: Writing to S3 bucket - (Orgs with no signed MOU count: #{metric})")
+      end
+
+      def send_to_api
+        @logger.info("BEGIN: Posting to metrics API...")
+        UseCases::PerformancePlatform::MetricsApiPublisher.publish(stats)
+        @logger.info("END: Posting to metrics API - (Orgs with no signed MOU count: #{metric})")
+      end
+    end
+  end
+end

--- a/spec/use_cases/administrator/publish_orgs_with_no_signed_mou_count_spec.rb
+++ b/spec/use_cases/administrator/publish_orgs_with_no_signed_mou_count_spec.rb
@@ -1,0 +1,115 @@
+describe UseCases::Administrator::PublishOrgsWithNoSignedMouCount do
+  subject(:use_case) { described_class.new }
+
+  let(:today) { Time.zone.local(2026, 7, 17) }
+
+  let(:s3_key) { "account-health-orgs-with-no-signed-mou-count/orgs-with-no-signed-mou-count-2026-07-17" }
+  let(:metrics_api_endpoint) { "https://metrics.test.example.com" }
+  let(:api_endpoint) { "#{metrics_api_endpoint}/v1/record" }
+
+  before do
+    stub_request(:post, api_endpoint).to_return(status: 200, body: "", headers: {})
+  end
+
+  around do |example|
+    original_endpoint = ENV["METRICS_API_ENDPOINT"]
+    ENV["METRICS_API_ENDPOINT"] = metrics_api_endpoint
+    Timecop.freeze(today) { example.run }
+    ENV["METRICS_API_ENDPOINT"] = original_endpoint
+  end
+
+  def published_payload
+    JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)
+  end
+
+  context "when an organisation has a signed MOU" do
+    it "does not count it" do
+      organisation = create(:organisation)
+      create(:mou, organisation:)
+
+      use_case.publish
+
+      expect(published_payload["count"]).to eq(0)
+    end
+  end
+
+  context "when an organisation has no signed MOU" do
+    it "counts it" do
+      create(:organisation)
+
+      use_case.publish
+
+      expect(published_payload["count"]).to eq(1)
+    end
+  end
+
+  context "when an organisation has re-signed and has multiple MOUs" do
+    it "counts it only once, and only as signed" do
+      organisation = create(:organisation)
+      create(:mou, organisation:)
+      create(:mou, organisation:)
+
+      use_case.publish
+
+      expect(published_payload["count"]).to eq(0)
+    end
+  end
+
+  context "when there is a mix of organisations with and without a signed MOU" do
+    it "aggregates the count across organisations" do
+      create(:organisation)
+      create(:organisation)
+      signed_organisation = create(:organisation)
+      create(:mou, organisation: signed_organisation)
+
+      use_case.publish
+
+      expect(published_payload["count"]).to eq(2)
+    end
+  end
+
+  context "when there are no organisations at all" do
+    it "publishes a zero count rather than erroring" do
+      use_case.publish
+
+      expect(published_payload["count"]).to eq(0)
+    end
+  end
+
+  it "writes the full payload shape to S3" do
+    create(:organisation)
+
+    use_case.publish
+
+    expect(published_payload).to eq(
+      "count" => 1,
+      "metric_name" => "account-health-orgs-with-no-signed-mou-count",
+      "period" => "day",
+      "date" => "2026-07-17",
+    )
+  end
+
+  it "posts the count to the metrics api" do
+    create(:organisation)
+
+    use_case.publish
+
+    expect(a_request(:post, api_endpoint).with(
+             body: {
+               "name" => "account-health-orgs-with-no-signed-mou-count",
+               "value" => "1",
+               "datetime" => "2026-07-17T00:00:00Z",
+             }.to_json,
+           )).to have_been_made
+  end
+
+  context "when the metrics api request fails" do
+    it "does not raise, and still writes to S3" do
+      stub_request(:post, api_endpoint).to_timeout
+      create(:organisation)
+
+      expect { use_case.publish }.not_to raise_error
+      expect(published_payload["count"]).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## How Organisations with no signed MOU?

### What

- Adds `metrics:publish_orgs_with_no_signed_mou_count` rake task
- Counts organisations with no `mous` record, writes a daily JSON count file to the metrics S3 bucket, and posts the count to the Metrics API
- Follows the existing `metrics:publish_orgs_with_dormant_admins_count` pattern, with full spec coverage (ok/edge/API-failure cases)

### Why

- Account health reporting needs a daily data point for how many organisations have not signed an MOU
- Reuses the existing S3 + Metrics API publishing pipeline so it plugs into current dashboards with no extra infra beyond scheduling

### Link to JIRA card (if applicable):

- [GW-2737](https://technologyprogramme.atlassian.net/browse/GW-2738)
