### PR TITLE
How many organisations have no active admins?

### DIFF
--- a/lib/tasks/publish_orgs_have_no_active_admins_count.rake
+++ b/lib/tasks/publish_orgs_have_no_active_admins_count.rake
@@ -1,0 +1,11 @@
+require "logger"
+logger = Logger.new($stdout)
+
+namespace :metrics do
+  desc "Publish orgs with no active admins count to S3 and post to metrics API"
+  task publish_orgs_have_no_active_admins_count: :environment do
+    logger.info("BEGIN: Publishing orgs with no active admins count...")
+    UseCases::Administrator::PublishOrgsHaveNoActiveAdminsCount.new.publish
+    logger.info("END: Publishing orgs with no active admins count")
+  end
+end

--- a/lib/use_cases/administrator/publish_orgs_have_no_active_admins_count.rb
+++ b/lib/use_cases/administrator/publish_orgs_have_no_active_admins_count.rb
@@ -1,0 +1,75 @@
+require "logger"
+
+module UseCases
+  module Administrator
+    class PublishOrgsHaveNoActiveAdminsCount
+      METRIC_NAME = "account-health-orgs-have-no-active-admins-count".freeze
+      S3_FOLDER = "account-health-orgs-have-no-active-admins-count".freeze
+      ACTIVE_WITHIN = 1.year
+
+      def initialize(logger: Logger.new($stdout))
+        @logger = logger
+      end
+
+      def publish
+        send_to_s3
+        send_to_api
+      end
+
+    private
+
+      def today
+        @today ||= Time.zone.today
+      end
+
+      # The inner join filters to admin memberships before grouping, so an org with zero
+      # admin memberships never forms a group and is excluded rather than counted as "0".
+      def metric
+        @metric ||= ::Organisation
+          .joins(memberships: :user)
+          .where(memberships: { can_manage_locations: true, can_manage_team: true })
+          .where.not(name: nil)
+          .group(:name)
+          .having(
+            "COUNT(*) < 2 AND SUM(CASE WHEN users.last_sign_in_at >= ? THEN 1 ELSE 0 END) = 0",
+            ACTIVE_WITHIN.ago,
+          )
+          .count
+          .size
+      end
+
+      def stats
+        {
+          metric_name: METRIC_NAME,
+          count: metric,
+          run_time: today,
+        }
+      end
+
+      def s3_key
+        "#{S3_FOLDER}/#{METRIC_NAME}-#{today.iso8601}"
+      end
+
+      def s3_payload
+        {
+          count: metric,
+          metric_name: METRIC_NAME,
+          period: "day",
+          date: today.iso8601,
+        }
+      end
+
+      def send_to_s3
+        @logger.info("BEGIN: Writing to S3 bucket...")
+        Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).write("#{s3_payload.to_json}\n")
+        @logger.info("END: Writing to S3 bucket - (Orgs with no active admins count: #{metric})")
+      end
+
+      def send_to_api
+        @logger.info("BEGIN: Posting to metrics API...")
+        UseCases::PerformancePlatform::MetricsApiPublisher.publish(stats)
+        @logger.info("END: Posting to metrics API - (Orgs with no active admins count: #{metric})")
+      end
+    end
+  end
+end

--- a/spec/use_cases/administrator/publish_orgs_have_no_active_admins_count_spec.rb
+++ b/spec/use_cases/administrator/publish_orgs_have_no_active_admins_count_spec.rb
@@ -1,0 +1,167 @@
+describe UseCases::Administrator::PublishOrgsHaveNoActiveAdminsCount do
+  subject(:use_case) { described_class.new }
+
+  let(:today) { Time.zone.local(2026, 7, 17) }
+  let(:inactive_sign_in) { 366.days.ago }
+  let(:active_sign_in) { 1.day.ago }
+
+  let(:s3_key) do
+    "account-health-orgs-have-no-active-admins-count/account-health-orgs-have-no-active-admins-count-2026-07-17"
+  end
+  let(:metrics_api_endpoint) { "https://metrics.test.example.com" }
+  let(:api_endpoint) { "#{metrics_api_endpoint}/v1/record" }
+
+  def inactive_admin_membership(organisation:)
+    create(:membership, organisation:, user: create(:user, last_sign_in_at: inactive_sign_in))
+  end
+
+  def active_admin_membership(organisation:)
+    create(:membership, organisation:, user: create(:user, last_sign_in_at: active_sign_in))
+  end
+
+  def never_signed_in_admin_membership(organisation:)
+    create(:membership, organisation:, user: create(:user, last_sign_in_at: nil))
+  end
+
+  def view_only_inactive_membership(organisation:)
+    create(:membership, organisation:, can_manage_team: false, can_manage_locations: false,
+                        user: create(:user, last_sign_in_at: inactive_sign_in))
+  end
+
+  before do
+    stub_request(:post, api_endpoint).to_return(status: 200, body: "", headers: {})
+  end
+
+  around do |example|
+    original_endpoint = ENV["METRICS_API_ENDPOINT"]
+    ENV["METRICS_API_ENDPOINT"] = metrics_api_endpoint
+    Timecop.freeze(today) { example.run }
+    ENV["METRICS_API_ENDPOINT"] = original_endpoint
+  end
+
+  context "when an organisation has exactly one admin who has never signed in" do
+    it "counts it" do
+      organisation = create(:organisation)
+      never_signed_in_admin_membership(organisation:)
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)).to eq(
+        "count" => 1,
+        "metric_name" => "account-health-orgs-have-no-active-admins-count",
+        "period" => "day",
+        "date" => "2026-07-17",
+      )
+    end
+  end
+
+  context "when an organisation has exactly one admin who signed in over a year ago" do
+    it "counts it" do
+      organisation = create(:organisation)
+      inactive_admin_membership(organisation:)
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(1)
+    end
+  end
+
+  context "when an organisation has exactly one admin who has signed in recently" do
+    it "does not count it" do
+      organisation = create(:organisation)
+      active_admin_membership(organisation:)
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(0)
+    end
+  end
+
+  context "when an organisation has two admins and both are inactive" do
+    it "does not count it, because it has two or more admins" do
+      organisation = create(:organisation)
+      inactive_admin_membership(organisation:)
+      inactive_admin_membership(organisation:)
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(0)
+    end
+  end
+
+  context "when an organisation has two admins, one active and one inactive" do
+    it "does not count it" do
+      organisation = create(:organisation)
+      active_admin_membership(organisation:)
+      inactive_admin_membership(organisation:)
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(0)
+    end
+  end
+
+  context "when the inactive member does not have admin permissions" do
+    it "does not count the organisation" do
+      organisation = create(:organisation)
+      view_only_inactive_membership(organisation:)
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(0)
+    end
+  end
+
+  context "when an organisation has no admin memberships at all" do
+    it "does not count the organisation" do
+      create(:organisation)
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(0)
+    end
+  end
+
+  context "when multiple organisations qualify" do
+    it "aggregates the count across organisations" do
+      never_signed_in_admin_membership(organisation: create(:organisation))
+      inactive_admin_membership(organisation: create(:organisation))
+      active_admin_membership(organisation: create(:organisation))
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(2)
+    end
+  end
+
+  context "when no organisations qualify" do
+    it "publishes a zero count rather than erroring" do
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(0)
+    end
+  end
+
+  it "posts the count to the metrics api" do
+    never_signed_in_admin_membership(organisation: create(:organisation))
+
+    use_case.publish
+
+    expect(a_request(:post, api_endpoint).with(
+             body: {
+               "name" => "account-health-orgs-have-no-active-admins-count",
+               "value" => "1",
+               "datetime" => "2026-07-17T00:00:00Z",
+             }.to_json,
+           )).to have_been_made
+  end
+
+  context "when the metrics api request fails" do
+    it "does not raise" do
+      stub_request(:post, api_endpoint).to_timeout
+      never_signed_in_admin_membership(organisation: create(:organisation))
+
+      expect { use_case.publish }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## How many organisations have no active admins?

### What

- Adds `metrics:publish_orgs_have_no_active_admins_count` rake task, following the same S3 + Metrics API publish pattern as `publish_orgs_with_dormant_admins_count`.
- Counts organisations with fewer than two admins where none has signed in within the last year, publishing the daily count to S3 and the Metrics API.
- Adds full spec coverage for ok/edge/error cases (zero admins, one dormant/active admin, two admins, non-admin memberships, API failure).

### Why

- Account health reporting needs visibility into organisations at risk of losing all active admin access.
- Follows the established pattern from the dormant-admins/less-than-two-admins/no-signed-mou metrics already shipped.
- Keeps the change self-contained: one use case, one rake task, one spec file.

### Link to JIRA card (if applicable):

- [GW-2740](https://technologyprogramme.atlassian.net/browse/GW-2740)