### PR TITLE
North Yorkshire County Council became North Yorkshire Council on 1st April 2023

### DIFF
--- a/lib/gateways/govuk_organisations_register_gateway.rb
+++ b/lib/gateways/govuk_organisations_register_gateway.rb
@@ -1282,7 +1282,7 @@ module Gateways
         "Mansfield District Council",
         "Newark and Sherwood District Council",
         "Rushcliffe Borough Council",
-        "North Yorkshire County Council",
+        "North Yorkshire Council",
         "Craven District Council",
         "Hambleton District Council",
         "Harrogate Borough Council",


### PR DESCRIPTION
### What

North Yorkshire County Council became North Yorkshire Council on 1st April 2023

### Why

Requested by network admin via Zendesk (6770610)

Link to JIRA card (if applicable):
Zendesk (6770610)
